### PR TITLE
Allow references to type variables in interface types.

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -327,7 +327,8 @@ instancetype-def  ::= <type>
                     | (export <name> <deftype>)
 functype          ::= (func <id>? (param <name>? <intertype>)* (result <intertype>))
 valuetype         ::= (value <id>? <intertype>)
-intertype         ::= unit | bool
+intertype         ::= <id>
+                    | unit | bool
                     | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64
                     | float32 | float64
                     | char | string


### PR DESCRIPTION
The explainer contains the example below. However, the current grammar doesn't allow identifiers in places where interface types are expected.

```wasm
(component $C
  (type $T (list (tuple string bool)))
  (type $U (option $T))
  (type $G (func (param (list $T)) (result $U)))
  (type $D (component
    (alias outer $C $T (type $C_T))
    (type $L (list $C_T))
    (import "f" (func (param $L) (result (list u8))))
    (import "g" $G)
    (export "g" $G)
    (export "h" (func (result $U)))
  ))
)
```