### PR TITLE
start -> invoke

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -207,11 +207,11 @@ Notes:
   in `i`'s `instancetype`.
 
 
-## Start Definitions
+## Invoke Definitions
 
-(See [Start Definitions](Explainer.md#start-definitions) in the explainer.)
+(See [Invoke Definitions](Explainer.md#invoke-definitions) in the explainer.)
 ```
-start ::= f:<funcidx> arg*:vec(<valueidx>) => (start f (value arg)*)
+invoke ::= f:<funcidx> arg*:vec(<valueidx>) => (invoke f (value arg)*)
 ```
 Notes:
 * Validation requires `f` have `functype` with `param` arity and types matching `arg*`.
@@ -222,8 +222,8 @@ In addition to the type-compatibility checks mentioned above, the validation
 rules for value definitions additionally require that each value is consumed
 exactly once. Thus, during validation, each value has an associated "consumed"
 boolean flag. When a value is first added to the value index space (via
-`import`, `instance`, `alias` or `start`), the flag is clear. When a value is
-used (via `export`, `instantiate` or `start`), the flag is set. After
+`import`, `instance`, `alias` or `invoke`), the flag is clear. When a value is
+used (via `export`, `instantiate` or `invoke`), the flag is set. After
 validating the last definition of a component, validation requires all values'
 flags are set.
 


### PR DESCRIPTION
Under the [Start Definitions](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#start-definitions) section, the explainer starts off by hinting that module start functions and component start functions are each others equivalent only at a different level:

> Like modules, components can have start functions that are called during instantiation

However, if I understand the rest of the section correctly, they are more like opposites:
- Core Wasm's `(start ...)` construct _declares_ a function to be run when instantiated, while
- ComponentModels's `(start ...)` construct _invokes_ a function during instantiation.

Additionally, ComponentModels's `(start ...)` doesn't even invoke Core Wasm's `(start ...)`, but rather arbitrary exports. Which in turn may be exported with the name "start", but that's only incidental.

If this is indeed correct, I suggest renaming ComponentModels's `(start ...)` to something else like `(invoke ...)` to avoid confusion.