### PR TITLE
Add GitHub Actions workflow to test canonical abi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  canonical_abi:
+    name: Run Canonical ABI Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '>= 3.10.0'
+    - run: python design/mvp/canonical-abi/run_tests.py


### PR DESCRIPTION
With a [sample run here](https://github.com/alexcrichton/component-model/runs/6028366014?check_suite_focus=true)

(note that this PR is targeted at the base branch of https://github.com/WebAssembly/component-model/pull/23)