### PR TITLE
Avoid potential name clash with default values.

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -162,7 +162,7 @@ intertype         ::= pit:<primintertype>                       => pit
                     | 0x69 t:<intertypeuse> u:<intertypeuse>    => (expected t u)
 field             ::= n:<name> t:<intertypeuse>                 => (field n t)
 case              ::= n:<name> t:<intertypeuse> 0x0             => (case n t)
-                    | n:<name> t:<intertypeuse> 0x1 i:<varu32>  => (case n t (subtype-of case-label[i]))
+                    | n:<name> t:<intertypeuse> 0x1 i:<varu32>  => (case n t (refines case-label[i]))
 ```
 Notes:
 * Reused Core binary rules: [`core:import`], [`core:importdesc`], [`core:functype`]

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -162,7 +162,7 @@ intertype         ::= pit:<primintertype>                       => pit
                     | 0x69 t:<intertypeuse> u:<intertypeuse>    => (expected t u)
 field             ::= n:<name> t:<intertypeuse>                 => (field n t)
 case              ::= n:<name> t:<intertypeuse> 0x0             => (case n t)
-                    | n:<name> t:<intertypeuse> 0x1 i:<varu32>  => (case n t (defaults-to case-label[i]))
+                    | n:<name> t:<intertypeuse> 0x1 i:<varu32>  => (case n t (subtype-of case-label[i]))
 ```
 Notes:
 * Reused Core binary rules: [`core:import`], [`core:importdesc`], [`core:functype`]

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -332,7 +332,7 @@ intertype         ::= unit | bool
                     | float32 | float64
                     | char | string
                     | (record (field <name> <intertype>)*)
-                    | (variant (case <name> <intertype> (subtype-of <name>)?)+)
+                    | (variant (case <name> <intertype> (refines <name>)?)+)
                     | (list <intertype>)
                     | (tuple <intertype>*)
                     | (flags <name>*)
@@ -378,9 +378,9 @@ NaN values are canonicalized to a single value so that:
 
 The subtyping between all these types is described in a separate
 [subtyping explainer](Subtyping.md). Of note here, though: the optional
-`subtype-of` field in the `case`s of `variant`s is exclusively concerned with
+`refines` field in the `case`s of `variant`s is exclusively concerned with
 subtyping. In particular, a `variant` subtype can contain a `case` not present
-in the supertype if the subtype's `case` `subtype-of` (directly or transitively)
+in the supertype if the subtype's `case` `refines` (directly or transitively)
 some `case` in the supertype.
 
 The sets of values allowed for the remaining *specialized* interface types are

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -332,7 +332,7 @@ intertype         ::= unit | bool
                     | float32 | float64
                     | char | string
                     | (record (field <name> <intertype>)*)
-                    | (variant (case <name> <intertype> (defaults-to <name>)?)+)
+                    | (variant (case <name> <intertype> (subtype-of <name>)?)+)
                     | (list <intertype>)
                     | (tuple <intertype>*)
                     | (flags <name>*)
@@ -378,9 +378,9 @@ NaN values are canonicalized to a single value so that:
 
 The subtyping between all these types is described in a separate
 [subtyping explainer](Subtyping.md). Of note here, though: the optional
-`defaults-to` field in the `case`s of `variant`s is exclusively concerned with
+`subtype-of` field in the `case`s of `variant`s is exclusively concerned with
 subtyping. In particular, a `variant` subtype can contain a `case` not present
-in the supertype if the subtype's `case` `defaults-to` (directly or transitively)
+in the supertype if the subtype's `case` `subtype-of` (directly or transitively)
 some `case` in the supertype.
 
 The sets of values allowed for the remaining *specialized* interface types are

--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -12,7 +12,7 @@ But roughly speaking:
 | `float32`, `float64`      | `float32 <: float64` |
 | `char`                    | |
 | `record`                  | fields can be reordered; covariant field payload subtyping; superfluous fields can be ignored in the subtype; `option` fields can be ignored in the supertype |
-| `variant`                 | cases can be reordered; covariant case payload subtyping; superfluous cases can be ignored in the supertype; `defaults-to` cases can be ignored in the subtype |
+| `variant`                 | cases can be reordered; covariant case payload subtyping; superfluous cases can be ignored in the supertype; `subtype-of` cases can be ignored in the subtype |
 | `list`                    | covariant element subtyping |
 | `tuple`                   | `(tuple T ...) <: T` |
 | `option`                  | `T <: (option T)` |

--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -12,7 +12,7 @@ But roughly speaking:
 | `float32`, `float64`      | `float32 <: float64` |
 | `char`                    | |
 | `record`                  | fields can be reordered; covariant field payload subtyping; superfluous fields can be ignored in the subtype; `option` fields can be ignored in the supertype |
-| `variant`                 | cases can be reordered; covariant case payload subtyping; superfluous cases can be ignored in the supertype; `subtype-of` cases can be ignored in the subtype |
+| `variant`                 | cases can be reordered; covariant case payload subtyping; superfluous cases can be ignored in the supertype; `refines` cases can be ignored in the subtype |
 | `list`                    | covariant element subtyping |
 | `tuple`                   | `(tuple T ...) <: T` |
 | `option`                  | `T <: (option T)` |

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -60,7 +60,7 @@ class Flags(InterfaceType):
 class Case:
   label: str
   t: InterfaceType
-  defaults_to: str = None
+  refines: str = None
 
 @dataclass
 class Variant(InterfaceType):
@@ -325,12 +325,12 @@ def load_variant(opts, ptr, cases):
   trap_if(disc >= len(cases))
   case = cases[disc]
   ptr = align_to(ptr, max_alignment(types_of(cases)))
-  return { case_label_with_defaults(case, cases): load(opts, ptr, case.t) }
+  return { case_label_with_refinements(case, cases): load(opts, ptr, case.t) }
 
-def case_label_with_defaults(case, cases):
+def case_label_with_refinements(case, cases):
   label = case.label
-  while case.defaults_to is not None:
-    case = cases[find_case(case.defaults_to, cases)]
+  while case.refines is not None:
+    case = cases[find_case(case.refines, cases)]
     label += '|' + case.label
   return label
 
@@ -743,7 +743,7 @@ def lift_flat_variant(opts, vi, cases):
   v = lift_flat(opts, CoerceValueIter(), case.t)
   for have in flat_types:
     _ = vi.next(have)
-  return { case_label_with_defaults(case, cases): v }
+  return { case_label_with_refinements(case, cases): v }
 
 def narrow_i64_to_i32(i):
   assert(0 <= i < (1 << 64))


### PR DESCRIPTION
While typing out [Default values](https://github.com/WebAssembly/component-model/issues/15) a couple of weeks ago, I noticed an unfortunate naming collision between the terms "default" values and the "defaults-to" property of variants.

Regardless of the outcome of that issue, I suggest renaming `defaults-to` to something else. Just as a precautionary measure.