### PR TITLE
Loosen the reentrance rules a bit for parent/child scenarios

### DIFF
--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -870,9 +870,12 @@ class Instance:
   may_enter = True
   # ...
 
-def canon_lift(callee_opts, callee_instance, callee, functype, args):
-  trap_if(not callee_instance.may_enter)
-  callee_instance.may_enter = False
+def canon_lift(callee_opts, callee_instance, callee, functype, args, called_as_export):
+  if called_as_export:
+    trap_if(not callee_instance.may_enter)
+    callee_instance.may_enter = False
+  else:
+    assert(not callee_instance.may_enter)
 
   assert(callee_instance.may_leave)
   callee_instance.may_leave = False
@@ -888,7 +891,8 @@ def canon_lift(callee_opts, callee_instance, callee, functype, args):
   def post_return():
     if callee_opts.post_return is not None:
       callee_opts.post_return(flat_results)
-    callee_instance.may_enter = True
+    if called_as_export:
+      callee_instance.may_enter = True
 
   return (result, post_return)
 

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -342,7 +342,7 @@ def test_roundtrip(t, v):
 
   callee_heap = Heap(1000)
   callee_opts = mk_opts(callee_heap.memory, 'utf8', callee_heap.realloc, lambda x: () )
-  lifted_callee = lambda args: canon_lift(callee_opts, callee_instance, callee, ft, args)
+  lifted_callee = lambda args: canon_lift(callee_opts, callee_instance, callee, ft, args, True)
 
   caller_heap = Heap(1000)
   caller_instance = Instance()


### PR DESCRIPTION
This PR loosens the reentrance rules to allow `canon lift` to be called from inside a component instance such as when a parent component is called by a child component.  For example, in this example:
```wasm
(component
  (core module $Core1 ...)
  (core instance $core1 (instantiate $Core1))
  (func $func1 (canon lift (core func $core1 "func")))
  (component $Child ...)
  (instance $child (instantiate $Child (with "func1" (func $func1))))
  (core func $child_func (canon lower (func $child "func")))
  (core module $Core2 ...)
  (core instance $core2 (instantiate $Core2 (with "child" (instance (export "func" (func $child_func))))))
  (func $func2 (canon lift (core func $core2 "func")))
  (export "func2" (func $func2))
)
```
as previously written, `$func2` would clear `may_enter` so that `$func1` would trap when called by `$child`.  With this PR, the idea is that `$func1` wouldn't check `may_enter` because `called_as_export` would be `False`.  A more realistic example of when you'd want to do this is that the parent component uses `$Core1` and `$Core2` to virtualize a filesystem for `$Child`, including passing preopens into `$Child`'s exports.

One consequence of this relaxation is that same-component-instance lift+lower would be possible and such cases would need to be compiled more pessimistically (although in a way that only impacted this (rare) case).  The PR explains more.