### PR TITLE
Switch (back) to multi-return, remove unit, s/expected/result/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Component Model design and specification
 
 This repository describes the high-level [goals], [use cases], [design choices]
-and [FAQ] of the component model as well as a more-detailed [explainer],
+and [FAQ] of the component model as well as a more-detailed [explainer], [IDL],
 [binary format] and [ABI] covering the initial Minimum Viable Product (MVP)
 release.
 
@@ -20,6 +20,7 @@ To contribute to any of these repositories, see the Community Group's
 [design choices]: design/high-level/Choices.md
 [FAQ]: design/high-level/FAQ.md
 [explainer]: design/mvp/Explainer.md
+[IDL]: design/mvp/WIT.md
 [binary format]: design/mvp/Binary.md
 [ABI]: design/mvp/CanonicalABI.md
 [formal spec]: spec/

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -180,7 +180,7 @@ defvaltype    ::= pvt:<primvaltype>                        => pvt
                 | 0x6b t:<valtype>                         => (option t)
                 | 0x6a t*:vec(<valtype>) u*:vec(<valtype>) => (result t* (error u*))
 namedtype     ::= n:<name> t:<valtype>                     => (field n t)
-case          ::= nt*:vec(<namedtype>) 0x0                 => (case nt*)
+case          ::= n:<name> t*:vec(<valtype>) 0x0           => (case n t*)
                 | n:<name> t*:vec(<valtype>) 0x1 i:<u32>   => (case n t* (refines case-label[i]))
 valtype       ::= i:<typeidx>                              => i
                 | pvt:<primvaltype>                        => pvt

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -181,7 +181,7 @@ defvaltype    ::= pvt:<primvaltype>                        => pvt
                 | 0x6a t*:vec(<valtype>) u*:vec(<valtype>) => (result t* (error u*))
 namedtype     ::= n:<name> t:<valtype>                     => (field n t)
 case          ::= nt*:vec(<namedtype>) 0x0                 => (case nt*)
-                | nt*:vec(<namedtype>) 0x1 i:<u32>         => (case nt* (refines case-label[i]))
+                | n:<name> t*:vec(<valtype>) 0x1 i:<u32>   => (case n t* (refines case-label[i]))
 valtype       ::= i:<typeidx>                              => i
                 | pvt:<primvaltype>                        => pvt
 functype      ::= 0x40 p*:<prlist> r*:<prlist>             => (func (param p)* (result r)*)

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -151,59 +151,61 @@ Notes:
   means that the maximum `ct` in an MVP `alias` declarator is `1`.
 
 ```
-type          ::= dt:<deftype>                             => (type dt)
-deftype       ::= dvt:<defvaltype>                         => dvt
-                | ft:<functype>                            => ft
-                | ct:<componenttype>                       => ct
-                | it:<instancetype>                        => it
-primvaltype   ::= 0x7f                                     => bool
-                | 0x7e                                     => s8
-                | 0x7d                                     => u8
-                | 0x7c                                     => s16
-                | 0x7b                                     => u16
-                | 0x7a                                     => s32
-                | 0x79                                     => u32
-                | 0x78                                     => s64
-                | 0x77                                     => u64
-                | 0x76                                     => float32
-                | 0x75                                     => float64
-                | 0x74                                     => char
-                | 0x73                                     => string
-defvaltype    ::= pvt:<primvaltype>                        => pvt
-                | 0x72 nt*:vec(<namedtype>)                => (record (field nt)*)
-                | 0x71 case*:vec(<case>)                   => (variant case*)
-                | 0x70 t:<valtype>                         => (list t)
-                | 0x6f t*:vec(<valtype>)                   => (tuple t*)
-                | 0x6e n*:vec(<name>)                      => (flags n*)
-                | 0x6d n*:vec(<name>)                      => (enum n*)
-                | 0x6c t*:vec(<valtype>)                   => (union t*)
-                | 0x6b t:<valtype>                         => (option t)
-                | 0x6a t*:vec(<valtype>) u*:vec(<valtype>) => (result t* (error u*))
-namedtype     ::= n:<name> t:<valtype>                     => (field n t)
-case          ::= n:<name> t*:vec(<valtype>) 0x0           => (case n t*)
-                | n:<name> t*:vec(<valtype>) 0x1 i:<u32>   => (case n t* (refines case-label[i]))
-valtype       ::= i:<typeidx>                              => i
-                | pvt:<primvaltype>                        => pvt
-functype      ::= 0x40 p*:<prlist> r*:<prlist>             => (func (param p)* (result r)*)
-prlist        ::= 0x00 t:<valtype>                         => [t]
-                | 0x01 nt*:vec(<namedtype>)                => nt*
-componenttype ::= 0x41 cd*:vec(<componentdecl>)            => (component cd*)
-instancetype  ::= 0x42 id*:vec(<instancedecl>)             => (instance id*)
-componentdecl ::= 0x03 id:<importdecl>                     => id
-                | id:<instancedecl>                        => id
-instancedecl  ::= 0x00 t:<core:type>                       => t
-                | 0x01 t:<type>                            => t
-                | 0x02 a:<alias>                           => a
-                | 0x04 ed:<exportdecl>                     => ed
-importdecl    ::= n:<name> ed:<externdesc>                 => (import n ed)
-exportdecl    ::= n:<name> ed:<externdesc>                 => (export n ed)
-externdesc    ::= 0x00 0x11 i:<core:typeidx>               => (core module (type i))
-                | 0x01 i:<typeidx>                         => (func (type i))
-                | 0x02 t:<valtype>                         => (value t)
-                | 0x03 b:<typebound>                       => (type b)
-                | 0x04 i:<typeidx>                         => (instance (type i))
-                | 0x05 i:<typeidx>                         => (component (type i))
-typebound     ::= 0x00 i:<typeidx>                         => (eq i)
+type          ::= dt:<deftype>                         => (type dt)
+deftype       ::= dvt:<defvaltype>                     => dvt
+                | ft:<functype>                        => ft
+                | ct:<componenttype>                   => ct
+                | it:<instancetype>                    => it
+primvaltype   ::= 0x7f                                 => bool
+                | 0x7e                                 => s8
+                | 0x7d                                 => u8
+                | 0x7c                                 => s16
+                | 0x7b                                 => u16
+                | 0x7a                                 => s32
+                | 0x79                                 => u32
+                | 0x78                                 => s64
+                | 0x77                                 => u64
+                | 0x76                                 => float32
+                | 0x75                                 => float64
+                | 0x74                                 => char
+                | 0x73                                 => string
+defvaltype    ::= pvt:<primvaltype>                    => pvt
+                | 0x72 nt*:vec(<namedvaltype>)         => (record (field nt)*)
+                | 0x71 case*:vec(<case>)               => (variant case*)
+                | 0x70 t:<valtype>                     => (list t)
+                | 0x6f t*:vec(<valtype>)               => (tuple t*)
+                | 0x6e n*:vec(<name>)                  => (flags n*)
+                | 0x6d n*:vec(<name>)                  => (enum n*)
+                | 0x6c t*:vec(<valtype>)               => (union t*)
+                | 0x6b t:<valtype>                     => (option t)
+                | 0x6a t?:<casetype> u?:<casetype>     => (result t? (error u)?)
+namedvaltype  ::= n:<name> t:<valtype>                 => n t
+case          ::= n:<name> t?:<casetype> 0x0           => (case n t?)
+                | n:<name> t?:<casetype> 0x1 i:<u32>   => (case n t? (refines case-label[i]))
+casetype      ::= 0x00                                 =>
+                | 0x01 t:<valtype>                     => t
+valtype       ::= i:<typeidx>                          => i
+                | pvt:<primvaltype>                    => pvt
+functype      ::= 0x40 p*:<prlist> r*:<prlist>         => (func (param p)* (result r)*)
+prlist        ::= 0x00 t:<valtype>                     => [t]
+                | 0x01 nt*:vec(<namedvaltype>)         => nt*
+componenttype ::= 0x41 cd*:vec(<componentdecl>)        => (component cd*)
+instancetype  ::= 0x42 id*:vec(<instancedecl>)         => (instance id*)
+componentdecl ::= 0x03 id:<importdecl>                 => id
+                | id:<instancedecl>                    => id
+instancedecl  ::= 0x00 t:<core:type>                   => t
+                | 0x01 t:<type>                        => t
+                | 0x02 a:<alias>                       => a
+                | 0x04 ed:<exportdecl>                 => ed
+importdecl    ::= n:<name> ed:<externdesc>             => (import n ed)
+exportdecl    ::= n:<name> ed:<externdesc>             => (export n ed)
+externdesc    ::= 0x00 0x11 i:<core:typeidx>           => (core module (type i))
+                | 0x01 i:<typeidx>                     => (func (type i))
+                | 0x02 t:<valtype>                     => (value t)
+                | 0x03 b:<typebound>                   => (type b)
+                | 0x04 i:<typeidx>                     => (instance (type i))
+                | 0x05 i:<typeidx>                     => (component (type i))
+typebound     ::= 0x00 i:<typeidx>                     => (eq i)
 ```
 Notes:
 * The type opcodes follow the same negative-SLEB128 scheme as Core WebAssembly,

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -186,8 +186,8 @@ casetype      ::= 0x00                                 =>
                 | 0x01 t:<valtype>                     => t
 valtype       ::= i:<typeidx>                          => i
                 | pvt:<primvaltype>                    => pvt
-functype      ::= 0x40 p*:<prlist> r*:<prlist>         => (func (param p)* (result r)*)
-prlist        ::= 0x00 t:<valtype>                     => [t]
+functype      ::= 0x40 p*:<funcvec> r*:<funcvec>       => (func (param p)* (result r)*)
+funcvec       ::= 0x00 t:<valtype>                     => [t]
                 | 0x01 nt*:vec(<namedvaltype>)         => nt*
 componenttype ::= 0x41 cd*:vec(<componentdecl>)        => (component cd*)
 instancetype  ::= 0x42 id*:vec(<instancedecl>)         => (instance id*)

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -151,60 +151,59 @@ Notes:
   means that the maximum `ct` in an MVP `alias` declarator is `1`.
 
 ```
-type          ::= dt:<deftype>                         => (type dt)
-deftype       ::= dvt:<defvaltype>                     => dvt
-                | ft:<functype>                        => ft
-                | ct:<componenttype>                   => ct
-                | it:<instancetype>                    => it
-primvaltype   ::= 0x7f                                 => unit
-                | 0x7e                                 => bool
-                | 0x7d                                 => s8
-                | 0x7c                                 => u8
-                | 0x7b                                 => s16
-                | 0x7a                                 => u16
-                | 0x79                                 => s32
-                | 0x78                                 => u32
-                | 0x77                                 => s64
-                | 0x76                                 => u64
-                | 0x75                                 => float32
-                | 0x74                                 => float64
-                | 0x73                                 => char
-                | 0x72                                 => string
-defvaltype    ::= pvt:<primvaltype>                    => pvt
-                | 0x71 field*:vec(<field>)             => (record field*)
-                | 0x70 case*:vec(<case>)               => (variant case*)
-                | 0x6f t:<valtype>                     => (list t)
-                | 0x6e t*:vec(<valtype>)               => (tuple t*)
-                | 0x6d n*:vec(<name>)                  => (flags n*)
-                | 0x6c n*:vec(<name>)                  => (enum n*)
-                | 0x6b t*:vec(<valtype>)               => (union t*)
-                | 0x6a t:<valtype>                     => (option t)
-                | 0x69 t:<valtype> u:<valtype>         => (expected t u)
-field         ::= n:<name> t:<valtype>                 => (field n t)
-case          ::= n:<name> t:<valtype> 0x0             => (case n t)
-                | n:<name> t:<valtype> 0x1 i:<u32>     => (case n t (refines case-label[i]))
-valtype       ::= i:<typeidx>                          => i
-                | pvt:<primvaltype>                    => pvt
-functype      ::= 0x40 param*:vec(<param>) t:<valtype> => (func param* (result t))
-param         ::= 0x00 t:<valtype>                     => (param t)
-                | 0x01 n:<name> t:<valtype>            => (param n t)
-componenttype ::= 0x41 cd*:vec(<componentdecl>)        => (component cd*)
-instancetype  ::= 0x42 id*:vec(<instancedecl>)         => (instance id*)
-componentdecl ::= 0x03 id:<importdecl>                 => id
-                | id:<instancedecl>                    => id
-instancedecl  ::= 0x00 t:<core:type>                   => t
-                | 0x01 t:<type>                        => t
-                | 0x02 a:<alias>                       => a
-                | 0x04 ed:<exportdecl>                 => ed
-importdecl    ::= n:<name> ed:<externdesc>             => (import n ed)
-exportdecl    ::= n:<name> ed:<externdesc>             => (export n ed)
-externdesc    ::= 0x00 0x11 i:<core:typeidx>           => (core module (type i))
-                | 0x01 i:<typeidx>                     => (func (type i))
-                | 0x02 t:<valtype>                     => (value t)
-                | 0x03 b:<typebound>                   => (type b)
-                | 0x04 i:<typeidx>                     => (instance (type i))
-                | 0x05 i:<typeidx>                     => (component (type i))
-typebound     ::= 0x00 i:<typeidx>                     => (eq i)
+type          ::= dt:<deftype>                             => (type dt)
+deftype       ::= dvt:<defvaltype>                         => dvt
+                | ft:<functype>                            => ft
+                | ct:<componenttype>                       => ct
+                | it:<instancetype>                        => it
+primvaltype   ::= 0x7f                                     => bool
+                | 0x7e                                     => s8
+                | 0x7d                                     => u8
+                | 0x7c                                     => s16
+                | 0x7b                                     => u16
+                | 0x7a                                     => s32
+                | 0x79                                     => u32
+                | 0x78                                     => s64
+                | 0x77                                     => u64
+                | 0x76                                     => float32
+                | 0x75                                     => float64
+                | 0x74                                     => char
+                | 0x73                                     => string
+defvaltype    ::= pvt:<primvaltype>                        => pvt
+                | 0x72 nt*:vec(<namedtype>)                => (record (field nt)*)
+                | 0x71 case*:vec(<case>)                   => (variant case*)
+                | 0x70 t:<valtype>                         => (list t)
+                | 0x6f t*:vec(<valtype>)                   => (tuple t*)
+                | 0x6e n*:vec(<name>)                      => (flags n*)
+                | 0x6d n*:vec(<name>)                      => (enum n*)
+                | 0x6c t*:vec(<valtype>)                   => (union t*)
+                | 0x6b t:<valtype>                         => (option t)
+                | 0x6a t*:vec(<valtype>) u*:vec(<valtype>) => (result t* (error u*))
+namedtype     ::= n:<name> t:<valtype>                     => (field n t)
+case          ::= nt*:vec(<namedtype>) 0x0                 => (case nt*)
+                | nt*:vec(<namedtype>) 0x1 i:<u32>         => (case nt* (refines case-label[i]))
+valtype       ::= i:<typeidx>                              => i
+                | pvt:<primvaltype>                        => pvt
+functype      ::= 0x40 p*:<prlist> r*:<prlist>             => (func (param p)* (result r)*)
+prlist        ::= 0x00 t:<valtype>                         => [t]
+                | 0x01 nt*:vec(<namedtype>)                => nt*
+componenttype ::= 0x41 cd*:vec(<componentdecl>)            => (component cd*)
+instancetype  ::= 0x42 id*:vec(<instancedecl>)             => (instance id*)
+componentdecl ::= 0x03 id:<importdecl>                     => id
+                | id:<instancedecl>                        => id
+instancedecl  ::= 0x00 t:<core:type>                       => t
+                | 0x01 t:<type>                            => t
+                | 0x02 a:<alias>                           => a
+                | 0x04 ed:<exportdecl>                     => ed
+importdecl    ::= n:<name> ed:<externdesc>                 => (import n ed)
+exportdecl    ::= n:<name> ed:<externdesc>                 => (export n ed)
+externdesc    ::= 0x00 0x11 i:<core:typeidx>               => (core module (type i))
+                | 0x01 i:<typeidx>                         => (func (type i))
+                | 0x02 t:<valtype>                         => (value t)
+                | 0x03 b:<typebound>                       => (type b)
+                | 0x04 i:<typeidx>                         => (instance (type i))
+                | 0x05 i:<typeidx>                         => (component (type i))
+typebound     ::= 0x00 i:<typeidx>                         => (eq i)
 ```
 Notes:
 * The type opcodes follow the same negative-SLEB128 scheme as Core WebAssembly,
@@ -218,9 +217,9 @@ Notes:
   in type definitions from containing components.
 * Validation of `externdesc` requires the various `typeidx` type constructors
   to match the preceding `sort`.
-* Validation of record field names, variant case names, flag names, and enum case
-  names requires that the name be unique for the record, variant, flags, or enum
-  type definition.
+* Validation of function parameter and result names, record field names,
+  variant case names, flag names, and enum case names requires that the name be
+  unique for the func, record, variant, flags, or enum type definition.
 * Validation of the optional `refines` clause of a variant case requires that
   the case index is less than the current case's index (and therefore
   cases are acyclic).

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -68,13 +68,12 @@ function to replace specialized value types with their expansion:
 ```python
 def despecialize(t):
   match t:
-    case Tuple(ts)           : return Record([ Field(str(i), t) for i,t in enumerate(ts) ])
-    case Unit()              : return Record([])
-    case Union(ts)           : return Variant([ Case(str(i), t) for i,t in enumerate(ts) ])
-    case Enum(labels)        : return Variant([ Case(l, Unit()) for l in labels ])
-    case Option(t)           : return Variant([ Case("none", Unit()), Case("some", t) ])
-    case Expected(ok, error) : return Variant([ Case("ok", ok), Case("error", error) ])
-    case _                   : return t
+    case Tuple(ts)         : return Record([ Field(str(i), t) for i,t in enumerate(ts) ])
+    case Union(ts)         : return Variant([ Case(str(i), [t]) for i,t in enumerate(ts) ])
+    case Enum(labels)      : return Variant([ Case(l, []) for l in labels ])
+    case Option(t)         : return Variant([ Case("none", []), Case("some", [t]) ])
+    case Result(ok, error) : return Variant([ Case("ok", ok), Case("error", error) ])
+    case _                 : return t
 ```
 The specialized value types `string` and `flags` are missing from this list
 because they are given specialized canonical ABI representations distinct from
@@ -98,14 +97,17 @@ def alignment(t):
     case Float64()          : return 8
     case Char()             : return 4
     case String() | List(_) : return 4
-    case Record(fields)     : return max_alignment(types_of(fields))
-    case Variant(cases)     : return max_alignment(types_of(cases) + [discriminant_type(cases)])
+    case Record(fields)     : return alignment_tuple(field_types(fields))
+    case Variant(cases)     : return alignment_variant(cases)
     case Flags(labels)      : return alignment_flags(labels)
+```
 
-def types_of(fields_or_cases):
-  return [x.t for x in fields_or_cases]
+Record alignment is tuple alignment, with the definitions split for reuse below:
+```python
+def field_types(fields):
+  return [f.t for f in fields]
 
-def max_alignment(ts):
+def alignment_tuple(ts):
   a = 1
   for t in ts:
     a = max(a, alignment(t))
@@ -117,6 +119,9 @@ covering the number of cases in the variant. Depending on the payload type,
 this can allow more compact representations of variants in memory. This smallest
 integer type is selected by the following function, used above and below:
 ```python
+def alignment_variant(cases):
+  return max(alignment(discriminant_type(cases)), max_case_alignment(cases))
+
 def discriminant_type(cases):
   n = len(cases)
   assert(0 < n < (1 << 32))
@@ -125,6 +130,12 @@ def discriminant_type(cases):
     case 1: return U8()
     case 2: return U16()
     case 3: return U32()
+
+def max_case_alignment(cases):
+  a = 1
+  for c in cases:
+    a = max(a, alignment_tuple(c.ts))
+  return a
 ```
 
 As an optimization, `flags` are represented as packed bit-vectors. Like variant
@@ -155,28 +166,28 @@ def size(t):
     case Float64()          : return 8
     case Char()             : return 4
     case String() | List(_) : return 8
-    case Record(fields)     : return size_record(fields)
+    case Record(fields)     : return size_tuple(field_types(fields))
     case Variant(cases)     : return size_variant(cases)
     case Flags(labels)      : return size_flags(labels)
 
-def size_record(fields):
+def size_tuple(ts):
   s = 0
-  for f in fields:
-    s = align_to(s, alignment(f.t))
-    s += size(f.t)
-  return align_to(s, alignment(Record(fields)))
+  for t in ts:
+    s = align_to(s, alignment(t))
+    s += size(t)
+  return align_to(s, alignment_tuple(ts))
 
 def align_to(ptr, alignment):
   return math.ceil(ptr / alignment) * alignment
 
 def size_variant(cases):
   s = size(discriminant_type(cases))
-  s = align_to(s, max_alignment(types_of(cases)))
+  s = align_to(s, max_case_alignment(cases))
   cs = 0
   for c in cases:
-    cs = max(cs, size(c.t))
+    cs = max(cs, size_tuple(c.ts))
   s += cs
-  return align_to(s, alignment(Variant(cases)))
+  return align_to(s, alignment_variant(cases))
 
 def size_flags(labels):
   n = len(labels)
@@ -360,8 +371,8 @@ def load_variant(opts, ptr, cases):
   ptr += disc_size
   trap_if(disc >= len(cases))
   case = cases[disc]
-  ptr = align_to(ptr, max_alignment(types_of(cases)))
-  return { case_label_with_refinements(case, cases): load(opts, ptr, case.t) }
+  ptr = align_to(ptr, max_case_alignment(cases))
+  return { case_label_with_refinements(case, cases): load_tuple(opts, ptr, case.ts) }
 
 def case_label_with_refinements(case, cases):
   label = case.label
@@ -376,6 +387,14 @@ def find_case(label, cases):
   if len(matches) == 1:
     return matches[0]
   return -1
+
+def load_tuple(opts, ptr, ts):
+  a = []
+  for t in ts:
+    ptr = align_to(ptr, alignment(t))
+    a.append(load(opts, ptr, t))
+    ptr += size(t)
+  return a
 ```
 
 Finally, flags are converted from a bit-vector to a dictionary whose keys are
@@ -675,8 +694,8 @@ def store_variant(opts, v, ptr, cases):
   disc_size = size(discriminant_type(cases))
   store_int(opts, case_index, ptr, disc_size)
   ptr += disc_size
-  ptr = align_to(ptr, max_alignment(types_of(cases)))
-  store(opts, case_value, cases[case_index].t, ptr)
+  ptr = align_to(ptr, max_case_alignment(cases))
+  store_tuple(opts, case_value, ptr, cases[case_index].ts)
 
 def match_case(v, cases):
   assert(len(v.keys()) == 1)
@@ -686,6 +705,12 @@ def match_case(v, cases):
     case_index = find_case(label, cases)
     if case_index != -1:
       return (case_index, value)
+
+def store_tuple(opts, v, ptr, ts):
+  for i,t in enumerate(ts):
+    ptr = align_to(ptr, alignment(t))
+    store(opts, v[i], t, ptr)
+    ptr += size(t)
 ```
 
 Finally, flags are converted from a dictionary to a bit-vector by iterating
@@ -740,11 +765,11 @@ MAX_FLAT_PARAMS = 16
 MAX_FLAT_RESULTS = 1
 
 def flatten(functype, context):
-  flat_params = flatten_types(functype.params)
+  flat_params = flatten_tuple(functype.params)
   if len(flat_params) > MAX_FLAT_PARAMS:
     flat_params = ['i32']
 
-  flat_results = flatten_type(functype.result)
+  flat_results = flatten_tuple(functype.results)
   if len(flat_results) > MAX_FLAT_RESULTS:
     match context:
       case 'lift':
@@ -755,7 +780,7 @@ def flatten(functype, context):
 
   return { 'params': flat_params, 'results': flat_results }
 
-def flatten_types(ts):
+def flatten_tuple(ts):
   return [ft for t in ts for ft in flatten_type(t)]
 ```
 
@@ -772,7 +797,7 @@ def flatten_type(t):
     case Float64()            : return ['f64']
     case Char()               : return ['i32']
     case String() | List(_)   : return ['i32', 'i32']
-    case Record(fields)       : return flatten_types(types_of(fields))
+    case Record(fields)       : return flatten_tuple(field_types(fields))
     case Variant(cases)       : return flatten_variant(cases)
     case Flags(labels)        : return ['i32'] * num_i32_flags(labels)
 ```
@@ -789,7 +814,7 @@ an `i32` into an `i64`.
 def flatten_variant(cases):
   flat = []
   for c in cases:
-    for i,ft in enumerate(flatten_type(c.t)):
+    for i,ft in enumerate(flatten_tuple(c.ts)):
       if i < len(flat):
         flat[i] = join(flat[i], ft)
       else:
@@ -915,7 +940,7 @@ def lift_flat_variant(opts, vi, cases):
         case ('i64', 'f32') : return reinterpret_i32_as_float(wrap_i64_to_i32(x))
         case ('i64', 'f64') : return reinterpret_i64_as_float(x)
         case _              : return x
-  v = lift_flat(opts, CoerceValueIter(), case.t)
+  v = lift_flat_tuple(opts, CoerceValueIter(), case.ts)
   for have in flat_types:
     _ = vi.next(have)
   return { case_label_with_refinements(case, cases): v }
@@ -923,6 +948,12 @@ def lift_flat_variant(opts, vi, cases):
 def wrap_i64_to_i32(i):
   assert(0 <= i < (1 << 64))
   return i % (1 << 32)
+
+def lift_flat_tuple(opts, vi, ts):
+  a = []
+  for t in ts:
+    a.append(lift_flat(opts, vi, t))
+  return a
 ```
 
 Finally, flags are lifted by OR-ing together all the flattened `i32` values
@@ -1007,7 +1038,7 @@ def lower_flat_variant(opts, v, cases):
   case_index, case_value = match_case(v, cases)
   flat_types = flatten_variant(cases)
   assert(flat_types.pop(0) == 'i32')
-  payload = lower_flat(opts, case_value, cases[case_index].t)
+  payload = lower_flat_tuple(opts, case_value, cases[case_index].ts)
   for i,have in enumerate(payload):
     want = flat_types.pop(0)
     match (have.t, want):
@@ -1019,6 +1050,12 @@ def lower_flat_variant(opts, v, cases):
   for want in flat_types:
     payload.append(Value(want, 0))
   return [Value('i32', case_index)] + payload
+
+def lower_flat_tuple(opts, v, ts):
+  flat = []
+  for i,t in enumerate(ts):
+    flat += lower_flat(opts, v[i], t)
+  return flat
 ```
 
 Finally, flags are lowered by slicing the bit vector into `i32` chunks:
@@ -1040,7 +1077,7 @@ parameters or results given by the `ValueIter` `vi` into a tuple of values with
 types `ts`:
 ```python
 def lift(opts, max_flat, vi, ts):
-  flat_types = flatten_types(ts)
+  flat_types = flatten_tuple(ts)
   if len(flat_types) > max_flat:
     ptr = vi.next('i32')
     tuple_type = Tuple(ts)
@@ -1057,7 +1094,7 @@ greater-than-`max_flat` case by either allocating storage with `realloc` or
 accepting a caller-allocated buffer as an out-param:
 ```python
 def lower(opts, max_flat, vs, ts, out_param = None):
-  flat_types = flatten_types(ts)
+  flat_types = flatten_tuple(ts)
   if len(flat_types) > max_flat:
     tuple_type = Tuple(functype.params)
     tuple_value = {str(i): v for i,v in enumerate(vs)}
@@ -1148,21 +1185,21 @@ def canon_lift(callee_opts, callee_instance, callee, functype, args, called_as_e
   except CoreWebAssemblyException:
     trap()
 
-  [result] = lift(callee_opts, MAX_FLAT_RESULTS, ValueIter(flat_results), [functype.result])
+  results = lift(callee_opts, MAX_FLAT_RESULTS, ValueIter(flat_results), functype.results)
   def post_return():
     if callee_opts.post_return is not None:
       callee_opts.post_return(flat_results)
     if called_as_export:
       callee_instance.may_enter = True
 
-  return (result, post_return)
+  return (results, post_return)
 ```
 There are a number of things to note about this definition:
 
 Uncaught Core WebAssembly [exceptions] result in a trap at component
 boundaries. Thus, if a component wishes to signal an error, it must use some
-sort of explicit type such as `expected` (whose `error` case particular
-language bindings may choose to map to and from exceptions).
+sort of explicit type such as `result` (whose `error` case particular language
+bindings may choose to map to and from exceptions).
 
 The `called_as_export` parameter indicates whether `canon_lift` is being called
 as part of a component export or whether this `canon_lift` is being called
@@ -1205,10 +1242,10 @@ def canon_lower(caller_opts, caller_instance, callee, functype, flat_args):
   flat_args = ValueIter(flat_args)
   args = lift(caller_opts, MAX_FLAT_PARAMS, flat_args, functype.params)
 
-  result, post_return = callee(args)
+  results, post_return = callee(args)
 
   caller_instance.may_leave = False
-  flat_results = lower(caller_opts, MAX_FLAT_RESULTS, [result], [functype.result], flat_args)
+  flat_results = lower(caller_opts, MAX_FLAT_RESULTS, results, functype.results, flat_args)
   caller_instance.may_leave = True
 
   post_return()

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -69,9 +69,9 @@ function to replace specialized value types with their expansion:
 def despecialize(t):
   match t:
     case Tuple(ts)         : return Record([ Field(str(i), t) for i,t in enumerate(ts) ])
-    case Union(ts)         : return Variant([ Case(str(i), [t]) for i,t in enumerate(ts) ])
-    case Enum(labels)      : return Variant([ Case(l, []) for l in labels ])
-    case Option(t)         : return Variant([ Case("none", []), Case("some", [t]) ])
+    case Union(ts)         : return Variant([ Case(str(i), t) for i,t in enumerate(ts) ])
+    case Enum(labels)      : return Variant([ Case(l, None) for l in labels ])
+    case Option(t)         : return Variant([ Case("none", None), Case("some", t) ])
     case Result(ok, error) : return Variant([ Case("ok", ok), Case("error", error) ])
     case _                 : return t
 ```
@@ -97,20 +97,17 @@ def alignment(t):
     case Float64()          : return 8
     case Char()             : return 4
     case String() | List(_) : return 4
-    case Record(fields)     : return alignment_tuple(field_types(fields))
+    case Record(fields)     : return alignment_record(fields)
     case Variant(cases)     : return alignment_variant(cases)
     case Flags(labels)      : return alignment_flags(labels)
 ```
 
 Record alignment is tuple alignment, with the definitions split for reuse below:
 ```python
-def field_types(fields):
-  return [f.t for f in fields]
-
-def alignment_tuple(ts):
+def alignment_record(fields):
   a = 1
-  for t in ts:
-    a = max(a, alignment(t))
+  for f in fields:
+    a = max(a, alignment(f.t))
   return a
 ```
 
@@ -134,7 +131,8 @@ def discriminant_type(cases):
 def max_case_alignment(cases):
   a = 1
   for c in cases:
-    a = max(a, alignment_tuple(c.ts))
+    if c.t is not None:
+      a = max(a, alignment(c.t))
   return a
 ```
 
@@ -166,16 +164,16 @@ def size(t):
     case Float64()          : return 8
     case Char()             : return 4
     case String() | List(_) : return 8
-    case Record(fields)     : return size_tuple(field_types(fields))
+    case Record(fields)     : return size_record(fields)
     case Variant(cases)     : return size_variant(cases)
     case Flags(labels)      : return size_flags(labels)
 
-def size_tuple(ts):
+def size_record(fields):
   s = 0
-  for t in ts:
-    s = align_to(s, alignment(t))
-    s += size(t)
-  return align_to(s, alignment_tuple(ts))
+  for f in fields:
+    s = align_to(s, alignment(f.t))
+    s += size(f.t)
+  return align_to(s, alignment_record(fields))
 
 def align_to(ptr, alignment):
   return math.ceil(ptr / alignment) * alignment
@@ -185,7 +183,8 @@ def size_variant(cases):
   s = align_to(s, max_case_alignment(cases))
   cs = 0
   for c in cases:
-    cs = max(cs, size_tuple(c.ts))
+    if c.t is not None:
+      cs = max(cs, size(c.t))
   s += cs
   return align_to(s, alignment_variant(cases))
 
@@ -367,18 +366,21 @@ string operations.
 ```python
 def load_variant(opts, ptr, cases):
   disc_size = size(discriminant_type(cases))
-  disc = load_int(opts, ptr, disc_size)
+  case_index = load_int(opts, ptr, disc_size)
   ptr += disc_size
-  trap_if(disc >= len(cases))
-  case = cases[disc]
+  trap_if(case_index >= len(cases))
+  c = cases[case_index]
   ptr = align_to(ptr, max_case_alignment(cases))
-  return { case_label_with_refinements(case, cases): load_tuple(opts, ptr, case.ts) }
+  case_label = case_label_with_refinements(c, cases)
+  if c.t is None:
+    return { case_label: None }
+  return { case_label: load(opts, ptr, c.t) }
 
-def case_label_with_refinements(case, cases):
-  label = case.label
-  while case.refines is not None:
-    case = cases[find_case(case.refines, cases)]
-    label += '|' + case.label
+def case_label_with_refinements(c, cases):
+  label = c.label
+  while c.refines is not None:
+    c = cases[find_case(c.refines, cases)]
+    label += '|' + c.label
   return label
 
 def find_case(label, cases):
@@ -387,14 +389,6 @@ def find_case(label, cases):
   if len(matches) == 1:
     return matches[0]
   return -1
-
-def load_tuple(opts, ptr, ts):
-  a = []
-  for t in ts:
-    ptr = align_to(ptr, alignment(t))
-    a.append(load(opts, ptr, t))
-    ptr += size(t)
-  return a
 ```
 
 Finally, flags are converted from a bit-vector to a dictionary whose keys are
@@ -695,7 +689,9 @@ def store_variant(opts, v, ptr, cases):
   store_int(opts, case_index, ptr, disc_size)
   ptr += disc_size
   ptr = align_to(ptr, max_case_alignment(cases))
-  store_tuple(opts, case_value, ptr, cases[case_index].ts)
+  c = cases[case_index]
+  if c.t is not None:
+    store(opts, case_value, c.t, ptr)
 
 def match_case(v, cases):
   assert(len(v.keys()) == 1)
@@ -705,12 +701,6 @@ def match_case(v, cases):
     case_index = find_case(label, cases)
     if case_index != -1:
       return (case_index, value)
-
-def store_tuple(opts, v, ptr, ts):
-  for i,t in enumerate(ts):
-    ptr = align_to(ptr, alignment(t))
-    store(opts, v[i], t, ptr)
-    ptr += size(t)
 ```
 
 Finally, flags are converted from a dictionary to a bit-vector by iterating
@@ -765,11 +755,11 @@ MAX_FLAT_PARAMS = 16
 MAX_FLAT_RESULTS = 1
 
 def flatten(functype, context):
-  flat_params = flatten_tuple(functype.params)
+  flat_params = flatten_types(functype.params)
   if len(flat_params) > MAX_FLAT_PARAMS:
     flat_params = ['i32']
 
-  flat_results = flatten_tuple(functype.results)
+  flat_results = flatten_types(functype.results)
   if len(flat_results) > MAX_FLAT_RESULTS:
     match context:
       case 'lift':
@@ -780,7 +770,7 @@ def flatten(functype, context):
 
   return { 'params': flat_params, 'results': flat_results }
 
-def flatten_tuple(ts):
+def flatten_types(ts):
   return [ft for t in ts for ft in flatten_type(t)]
 ```
 
@@ -797,9 +787,18 @@ def flatten_type(t):
     case Float64()            : return ['f64']
     case Char()               : return ['i32']
     case String() | List(_)   : return ['i32', 'i32']
-    case Record(fields)       : return flatten_tuple(field_types(fields))
+    case Record(fields)       : return flatten_record(fields)
     case Variant(cases)       : return flatten_variant(cases)
     case Flags(labels)        : return ['i32'] * num_i32_flags(labels)
+```
+
+Record flattening simply flattens each field in sequence.
+```python
+def flatten_record(fields):
+  flat = []
+  for f in fields:
+    flat += flatten_type(f.t)
+  return flat
 ```
 
 Variant flattening is more involved due to the fact that each case payload can
@@ -814,11 +813,12 @@ an `i32` into an `i64`.
 def flatten_variant(cases):
   flat = []
   for c in cases:
-    for i,ft in enumerate(flatten_tuple(c.ts)):
-      if i < len(flat):
-        flat[i] = join(flat[i], ft)
-      else:
-        flat.append(ft)
+    if c.t is not None:
+      for i,ft in enumerate(flatten_type(c.t)):
+        if i < len(flat):
+          flat[i] = join(flat[i], ft)
+        else:
+          flat.append(ft)
   return flatten_type(discriminant_type(cases)) + flat
 
 def join(a, b):
@@ -927,9 +927,8 @@ high bits of an `i64` are set for a 32-bit type:
 def lift_flat_variant(opts, vi, cases):
   flat_types = flatten_variant(cases)
   assert(flat_types.pop(0) == 'i32')
-  disc = vi.next('i32')
-  trap_if(disc >= len(cases))
-  case = cases[disc]
+  case_index = vi.next('i32')
+  trap_if(case_index >= len(cases))
   class CoerceValueIter:
     def next(self, want):
       have = flat_types.pop(0)
@@ -940,20 +939,18 @@ def lift_flat_variant(opts, vi, cases):
         case ('i64', 'f32') : return reinterpret_i32_as_float(wrap_i64_to_i32(x))
         case ('i64', 'f64') : return reinterpret_i64_as_float(x)
         case _              : return x
-  v = lift_flat_tuple(opts, CoerceValueIter(), case.ts)
+  c = cases[case_index]
+  if c.t is None:
+    v = None
+  else:
+    v = lift_flat(opts, CoerceValueIter(), c.t)
   for have in flat_types:
     _ = vi.next(have)
-  return { case_label_with_refinements(case, cases): v }
+  return { case_label_with_refinements(c, cases): v }
 
 def wrap_i64_to_i32(i):
   assert(0 <= i < (1 << 64))
   return i % (1 << 32)
-
-def lift_flat_tuple(opts, vi, ts):
-  a = []
-  for t in ts:
-    a.append(lift_flat(opts, vi, t))
-  return a
 ```
 
 Finally, flags are lifted by OR-ing together all the flattened `i32` values
@@ -1038,7 +1035,11 @@ def lower_flat_variant(opts, v, cases):
   case_index, case_value = match_case(v, cases)
   flat_types = flatten_variant(cases)
   assert(flat_types.pop(0) == 'i32')
-  payload = lower_flat_tuple(opts, case_value, cases[case_index].ts)
+  c = cases[case_index]
+  if c.t is None:
+    payload = []
+  else:
+    payload = lower_flat(opts, case_value, c.t)
   for i,have in enumerate(payload):
     want = flat_types.pop(0)
     match (have.t, want):
@@ -1050,12 +1051,6 @@ def lower_flat_variant(opts, v, cases):
   for want in flat_types:
     payload.append(Value(want, 0))
   return [Value('i32', case_index)] + payload
-
-def lower_flat_tuple(opts, v, ts):
-  flat = []
-  for i,t in enumerate(ts):
-    flat += lower_flat(opts, v[i], t)
-  return flat
 ```
 
 Finally, flags are lowered by slicing the bit vector into `i32` chunks:
@@ -1077,7 +1072,7 @@ parameters or results given by the `ValueIter` `vi` into a tuple of values with
 types `ts`:
 ```python
 def lift(opts, max_flat, vi, ts):
-  flat_types = flatten_tuple(ts)
+  flat_types = flatten_types(ts)
   if len(flat_types) > max_flat:
     ptr = vi.next('i32')
     tuple_type = Tuple(ts)
@@ -1094,7 +1089,7 @@ greater-than-`max_flat` case by either allocating storage with `realloc` or
 accepting a caller-allocated buffer as an out-param:
 ```python
 def lower(opts, max_flat, vs, ts, out_param = None):
-  flat_types = flatten_tuple(ts)
+  flat_types = flatten_types(ts)
   if len(flat_types) > max_flat:
     tuple_type = Tuple(functype.params)
     tuple_value = {str(i): v for i,v in enumerate(vs)}

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -452,7 +452,7 @@ defvaltype    ::= bool
                 | (enum <name>+)
                 | (union <valtype>+)
                 | (option <valtype>)
-                | (result <valtype> (error <valtype>*)?)
+                | (result <valtype>* (error <valtype>*)?)
 valtype       ::= <typeidx>
                 | <defvaltype>
 functype      ::= (func <paramlist> <resultlist>)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -445,14 +445,14 @@ defvaltype    ::= bool
                 | float32 | float64
                 | char | string
                 | (record (field <name> <valtype>)*)
-                | (variant (case <id>? <name> <valtype>* (refines <id>)?)+)
+                | (variant (case <id>? <name> <valtype>? (refines <id>)?)+)
                 | (list <valtype>)
                 | (tuple <valtype>*)
                 | (flags <name>*)
                 | (enum <name>+)
                 | (union <valtype>+)
                 | (option <valtype>)
-                | (result <valtype>* (error <valtype>*)?)
+                | (result <valtype>? (error <valtype>)?)
 valtype       ::= <typeidx>
                 | <defvaltype>
 functype      ::= (func <paramlist> <resultlist>)
@@ -515,13 +515,13 @@ some `case` in the supertype.
 The sets of values allowed for the remaining *specialized value types* are
 defined by the following mapping:
 ```
-                     (tuple <valtype>*) ↦ (record (field "𝒊" <valtype>)*) for 𝒊=0,1,...
-                        (flags <name>*) ↦ (record (field <name> bool)*)
-                         (enum <name>+) ↦ (variant (case <name>)+)
-                     (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
-                     (union <valtype>+) ↦ (variant (case "𝒊" <valtype>)+) for 𝒊=0,1,...
-(result <valtype>* (error <valtype>*)?) ↦ (variant (case "ok" <valtype>*) (case "error" <valtype>*))
-                                 string ↦ (list char)
+                    (tuple <valtype>*) ↦ (record (field "𝒊" <valtype>)*) for 𝒊=0,1,...
+                       (flags <name>*) ↦ (record (field <name> bool)*)
+                        (enum <name>+) ↦ (variant (case <name>)+)
+                    (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
+                    (union <valtype>+) ↦ (variant (case "𝒊" <valtype>)+) for 𝒊=0,1,...
+(result <valtype>? (error <valtype>)?) ↦ (variant (case "ok" <valtype>?) (case "error" <valtype>?))
+                                string ↦ (list char)
 ```
 Note that, at least initially, variants are required to have a non-empty list of
 cases. This could be relaxed in the future to allow an empty list of cases, with

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -459,7 +459,7 @@ functype      ::= (func <paramlist> <resultlist>)
 paramlist     ::= (param <name> <valtype>)*
                 | (param <valtype>)
 resultlist    ::= (result <name> <valtype>)*
-                | (result <valtype)
+                | (result <valtype>)
 componenttype ::= (component <componentdecl>*)
 instancetype  ::= (instance <instancedecl>*)
 componentdecl ::= <importdecl>

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -539,14 +539,24 @@ variety of source languages. As syntactic sugar, the text format of `functype`
 additionally allows `result` to be absent, interpreting this as `(result
 unit)`.
 
-The `instance` type constructor represents the result of instantiating a
-component and thus is the same as a `component` type minus the description
-of imports.
+The `instance` type constructor describes a list of named, typed definitions
+that can be imported or exported by a component. Informally, instance types
+correspond to the usual concept of an "interface" and instance types thus serve
+as static interface descriptions. In addition to the S-Expression text format
+defined here, which is meant to go inside component definitions, interfaces can
+also be defined as standalone, human-friendly text files in the [`wit`](WIT.md)
+[Interface Definition Language].
 
 The `component` type constructor is symmetric to the core `module` type
-constructor and is built from a sequence of "declarators" which are used to
-describe the imports and exports of the component. There are four kinds of
-declarators:
+constructor and contains *two* lists of named definitions for the imports
+and exports of a component, respectively. As suggested above, instance types
+can show up in *both* the import and export types of a component type.
+
+Both `instance` and `component` type constructors are built from a sequence of
+"declarators", of which there are four kinds&mdash;`type`, `alias`, `import` and
+`export`&mdash;where only `component` type constructors can contain `import`
+declarators. The meanings of these declarators is basically the same as the
+core module declarators introduced above.
 
 As with core modules, `importdecl` and `exportdecl` classify component `import`
 and `export` definitions, with `importdecl` allowing an identifier to be
@@ -1103,6 +1113,7 @@ and will be added over the coming months to complete the MVP proposal:
 [ABI]: https://en.wikipedia.org/wiki/Application_binary_interface
 [Environment Variables]: https://en.wikipedia.org/wiki/Environment_variable
 [Linear]: https://en.wikipedia.org/wiki/Substructural_type_system#Linear_type_systems
+[Interface Definition Language]: https://en.wikipedia.org/wiki/Interface_description_language
 
 [module-linking]: https://github.com/WebAssembly/module-linking/blob/main/design/proposals/module-linking/Explainer.md
 [interface-types]: https://github.com/WebAssembly/interface-types/blob/main/proposals/interface-types/Explainer.md

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -440,23 +440,26 @@ deftype       ::= <defvaltype>
                 | <functype>
                 | <componenttype>
                 | <instancetype>
-defvaltype    ::= unit
-                | bool
+defvaltype    ::= bool
                 | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64
                 | float32 | float64
                 | char | string
                 | (record (field <name> <valtype>)*)
-                | (variant (case <id>? <name> <valtype> (refines <id>)?)+)
+                | (variant (case <id>? <name> <valtype>* (refines <id>)?)+)
                 | (list <valtype>)
                 | (tuple <valtype>*)
                 | (flags <name>*)
                 | (enum <name>+)
                 | (union <valtype>+)
                 | (option <valtype>)
-                | (expected <valtype> <valtype>)
+                | (result <valtype> (error <valtype>*)?)
 valtype       ::= <typeidx>
                 | <defvaltype>
-functype      ::= (func (param <name>? <valtype>)* (result <valtype>))
+functype      ::= (func <paramlist> <resultlist>)
+paramlist     ::= (param <name> <valtype>)*
+                | (param <valtype>)
+resultlist    ::= (result <name> <valtype>)*
+                | (result <valtype)
 componenttype ::= (component <componentdecl>*)
 instancetype  ::= (instance <instancedecl>*)
 componentdecl ::= <importdecl>
@@ -512,14 +515,13 @@ some `case` in the supertype.
 The sets of values allowed for the remaining *specialized value types* are
 defined by the following mapping:
 ```
-            (tuple <valtype>*) ↦ (record (field "𝒊" <valtype>)*) for 𝒊=0,1,...
-               (flags <name>*) ↦ (record (field <name> bool)*)
-                          unit ↦ (record)
-                (enum <name>+) ↦ (variant (case <name> unit)+)
-            (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
-            (union <valtype>+) ↦ (variant (case "𝒊" <valtype>)+) for 𝒊=0,1,...
-(expected <valtype> <valtype>) ↦ (variant (case "ok" <valtype>) (case "error" <valtype>))
-                        string ↦ (list char)
+                     (tuple <valtype>*) ↦ (record (field "𝒊" <valtype>)*) for 𝒊=0,1,...
+                        (flags <name>*) ↦ (record (field <name> bool)*)
+                         (enum <name>+) ↦ (variant (case <name>)+)
+                     (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
+                     (union <valtype>+) ↦ (variant (case "𝒊" <valtype>)+) for 𝒊=0,1,...
+(result <valtype>* (error <valtype>*)?) ↦ (variant (case "ok" <valtype>*) (case "error" <valtype>*))
+                                 string ↦ (list char)
 ```
 Note that, at least initially, variants are required to have a non-empty list of
 cases. This could be relaxed in the future to allow an empty list of cases, with
@@ -530,14 +532,13 @@ The remaining 3 type constructors in `deftype` use `valtype` to describe
 shared-nothing functions, components and component instances:
 
 The `func` type constructor describes a component-level function definition
-that takes and returns `valtype`. In contrast to [`core:functype`] which, as a
-low-level compiler target for a stack machine, returns zero or more results,
-`functype` always returns a single type, with `unit` being used for functions
-that don't return an interesting value (analogous to "void" in some languages).
-Having a single return type simplifies the binding of `functype` into a wide
-variety of source languages. As syntactic sugar, the text format of `functype`
-additionally allows `result` to be absent, interpreting this as `(result
-unit)`.
+that takes and returns a list of `valtype`. In contrast to [`core:functype`],
+the parameters and results of `functype` can have associated names which
+validation requires to be unique. If a name is not present, the name is taken
+to be a special "empty" name and uniqueness still requires there to only be one
+unnamed parameter/result. To avoid unnecessary complexity for language binding
+generators, parameter and result lists are not allowed to contain both named
+and unnamed parameters.
 
 The `instance` type constructor describes a list of named, typed definitions
 that can be imported or exported by a component. Informally, instance types
@@ -687,7 +688,7 @@ type. For example, with Core WebAssembly [exception-handling] and
 [stack-switching], a core function with type `(func (result i32))` can return
 an `i32`, throw, suspend or trap. In contrast, a component function with type
 `(func (result string))` may only return a `string` or trap. To express
-failure, component functions can return `expected` and languages with exception
+failure, component functions can return `result` and languages with exception
 handling can bind exceptions to the `error` case. Similarly, the forthcoming
 addition of [future and stream types] would explicitly declare patterns of
 stack-switching in component function signatures.
@@ -955,7 +956,6 @@ At a high level, the additional coercions would be:
 
 | Type | `ToJSValue` | `ToWebAssemblyValue` |
 | ---- | ----------- | -------------------- |
-| `unit` | `null` | accept everything |
 | `bool` | `true` or `false` | `ToBoolean` |
 | `s8`, `s16`, `s32` | as a Number value | `ToInt8`, `ToInt16`, `ToInt32` |
 | `u8`, `u16`, `u32` | as a Number value | `ToUint8`, `ToUint16`, `ToUint32` |
@@ -972,9 +972,16 @@ At a high level, the additional coercions would be:
 | `enum` | same as [`enum`] | same as [`enum`] |
 | `option` | same as [`T?`] | same as [`T?`] |
 | `union` | same as [`union`] | same as [`union`] |
-| `expected` | same as `variant`, but coerce a top-level `error` return value to a thrown exception | same as `variant`, but coerce uncaught exceptions to top-level `error` return values |
+| `result` | same as `variant`, but coerce a top-level `error` return value to a thrown exception | same as `variant`, but coerce uncaught exceptions to top-level `error` return values |
 
 Notes:
+* Function parameter names are ignored since JavaScript doesn't have named
+  parameters.
+* If a function's result type list is empty, the JavaScript function returns
+  `undefined`. If the result type list contains a single unnamed result, then
+  the return value is specified by `ToJSValue` above. Otherwise, the function
+  result is wrapped into a JS object whose field names are taken from the result
+  names and whose field values are specified by `ToJSValue` above.
 * The forthcoming addition of [resource and handle types] would additionally
   allow coercion to and from the remaining Symbol and Object JavaScript value
   types.

--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -6,7 +6,6 @@ But roughly speaking:
 
 | Type                      | Subtyping |
 | ------------------------- | --------- |
-| `unit`                    | every value type is a subtype of `unit` |
 | `bool`                    | |
 | `s8`, `s16`, `s32`, `s64`, `u8`, `u16`, `u32`, `u64` | lossless coercions are allowed |
 | `float32`, `float64`      | `float32 <: float64` |

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -104,8 +104,7 @@ keyword ::= 'use'
           | 'string'
           | 'option'
           | 'list'
-          | 'expected'
-          | 'unit'
+          | 'result'
           | 'as'
           | 'from'
           | 'static'
@@ -349,15 +348,15 @@ sleep: async func(ms: u64)
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'func' '(' func-args ')' func-ret
+func-item ::= id ':' 'async'? 'func' func-tuple '->' func-tuple
 
-func-args ::= func-arg
-            | func-arg ',' func-args?
+func-tuple ::= ty
+             | '(' func-named-type-list ')'
 
-func-arg ::= id ':' ty
+func-named-type-list ::= nil
+                       | func-named-type ( ',' func-named-type )*
 
-func-ret ::= nil
-           | '->' ty
+func-named-type ::= id ':' ty
 ```
 
 ## Item: `resource`
@@ -405,7 +404,7 @@ such as built-ins. For example:
 
 ```wit
 type number = u32
-type fallible-function-result = expected<u32, string>
+type fallible-function-result = result<u32, string>
 type headers = list<string>
 ```
 
@@ -418,11 +417,10 @@ ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | 'char'
      | 'bool'
      | 'string'
-     | 'unit'
      | tuple
      | list
      | option
-     | expected
+     | result
      | future
      | stream
      | id
@@ -435,18 +433,25 @@ list ::= 'list' '<' ty '>'
 
 option ::= 'option' '<' ty '>'
 
-expected ::= 'expected' '<' ty ',' ty '>'
+result ::= 'result' '<' ty ',' ty '>'
+         | 'result' '<' '_' ',' ty '>'
+         | 'result' '<' ty '>'
+         | 'result'
 
 future ::= 'future' '<' ty '>'
+         | 'future'
 
 stream ::= 'stream' '<' ty ',' ty '>'
+         | 'stream' '<' '_' ',' ty '>'
+         | 'stream' '<' ty '>'
+         | 'stream'
 ```
 
 The `tuple` type is semantically equivalent to a `record` with numerical fields,
 but it frequently can have language-specific meaning so it's provided as a
 first-class type.
 
-Similarly the `option` and `expected` types are semantically equivalent to the
+Similarly the `option` and `result` types are semantically equivalent to the
 variants:
 
 ```wit
@@ -455,7 +460,7 @@ variant option {
     some(ty),
 }
 
-variant expected {
+variant result {
     ok(ok-ty)
     err(err-ty),
 }

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -340,15 +340,15 @@ parameters, and results. Functions can optionally also be declared as `async`
 functions.
 
 ```wit
-thunk: func()
+thunk: func() -> ()
 fibonacci: func(n: u32) -> u32
-sleep: async func(ms: u64)
+sleep: async func(ms: u64) -> ()
 ```
 
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'func' func-tuple ( '->' func-tuple )?
+func-item ::= id ':' 'async'? 'func' func-tuple '->' func-tuple
 
 func-tuple ::= ty
              | '(' func-named-type-list ')'
@@ -481,9 +481,9 @@ by '-'s starts with a `XID_Start` scalar value with a zero Canonical Combining
 Class:
 
 ```wit
-foo: func(bar: u32)
+foo: func(bar: u32) -> ()
 
-red-green-blue: func(r: u32, g: u32, b: u32)
+red-green-blue: func(r: u32, g: u32, b: u32) -> ()
 ```
 
 This form can't name identifiers which have the same name as wit keywords, so
@@ -491,12 +491,12 @@ the second form is the same syntax with the same restrictions as the first, but
 prefixed with '%':
 
 ```wit
-%foo: func(%bar: u32)
+%foo: func(%bar: u32) -> ()
 
-%red-green-blue: func(%r: u32, %g: u32, %b: u32)
+%red-green-blue: func(%r: u32, %g: u32, %b: u32) -> ()
 
 // This form also supports identifiers that would otherwise be keywords.
-%variant: func(%enum: s32)
+%variant: func(%enum: s32) -> ()
 ```
 
 [kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -348,7 +348,7 @@ sleep: async func(ms: u64)
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'func' func-tuple '->' func-tuple
+func-item ::= id ':' 'async'? 'func' func-tuple ( '->' func-tuple )?
 
 func-tuple ::= ty
              | '(' func-named-type-list ')'

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -348,10 +348,10 @@ sleep: async func(ms: u64) -> ()
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'func' func-tuple '->' func-tuple
+func-item ::= id ':' 'async'? 'func' func-vec '->' func-vec
 
-func-tuple ::= ty
-             | '(' func-named-type-list ')'
+func-vec ::= ty
+           | '(' func-named-type-list ')'
 
 func-named-type-list ::= nil
                        | func-named-type ( ',' func-named-type )*

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1,0 +1,550 @@
+# The `wit` format
+
+This is intended to document the `wit` format as it exists today. The goal is
+to provide an overview to understand what features `wit` files give you and how
+they're structured. This isn't intended to be a formal grammar, although it's
+expected that one day we'll have a formal grammar for `wit` files.
+
+If you're curious to give things a spin try out the [online
+demo](https://bytecodealliance.github.io/wit-bindgen/) of `wit-bindgen` where
+you can input `wit` on the left and see output of generated bindings for
+languages on the right. If you're looking to start you can try out the
+"markdown" output mode which generates documentation for the input document on
+the left.
+
+## Lexical structure
+
+The `wit` format is a curly-braced-based format where whitespace is optional (but
+recommended). It is intended to be easily human readable and supports features
+like comments, multi-line comments, and custom identifiers. A `wit` document
+is parsed as a unicode string, and when stored in a file is expected to be
+encoded as UTF-8.
+
+Additionally, wit files must not contain any bidirectional override scalar values,
+control codes other than newline, carriage return, and horizontal tab, or
+codepoints that Unicode officially deprecates or strongly discourages.
+
+The current structure of tokens are:
+
+```wit
+token ::= whitespace
+        | comment
+        | operator
+        | keyword
+        | identifier
+```
+
+Whitespace and comments are ignored when parsing structures defined elsewhere
+here.
+
+### Whitespace
+
+A `whitespace` token in `wit` is a space, a newline, a carriage return, or a
+tab character:
+
+```wit
+whitespace ::= ' ' | '\n' | '\r' | '\t'
+```
+
+### Comments
+
+A `comment` token in `wit` is either a line comment preceded with `//` which
+ends at the next newline (`\n`) character or it's a block comment which starts
+with `/*` and ends with `*/`. Note that block comments are allowed to be nested
+and their delimiters must be balanced
+
+```wit
+comment ::= '//' character-that-isnt-a-newline*
+          | '/*' any-unicode-character* '*/'
+```
+
+There is a special type of comment called `documentation comment`. A
+`doc-comment` is either a line comment preceded with `///` whichends at the next
+newline (`\n`) character or it's a block comment which starts with `/**` and ends
+with `*/`. Note that block comments are allowed to be nested and their delimiters
+must be balanced
+
+```wit
+doc-comment ::= '///' character-that-isnt-a-newline*
+          | '/**' any-unicode-character* '*/'
+```
+
+### Operators
+
+There are some common operators in the lexical structure of `wit` used for
+various constructs. Note that delimiters such as `{` and `(` must all be
+balanced.
+
+```wit
+operator ::= '=' | ',' | ':' | ';' | '(' | ')' | '{' | '}' | '<' | '>' | '*' | '->'
+```
+
+### Keywords
+
+Certain identifiers are reserved for use in `wit` documents and cannot be used
+bare as an identifier. These are used to help parse the format, and the list of
+keywords is still in flux at this time but the current set is:
+
+```wit
+keyword ::= 'use'
+          | 'type'
+          | 'resource'
+          | 'func'
+          | 'u8' | 'u16' | 'u32' | 'u64'
+          | 's8' | 's16' | 's32' | 's64'
+          | 'float32' | 'float64'
+          | 'char'
+          | 'handle'
+          | 'record'
+          | 'enum'
+          | 'flags'
+          | 'variant'
+          | 'union'
+          | 'bool'
+          | 'string'
+          | 'option'
+          | 'list'
+          | 'expected'
+          | 'unit'
+          | 'as'
+          | 'from'
+          | 'static'
+          | 'interface'
+          | 'tuple'
+          | 'async'
+          | 'future'
+          | 'stream'
+```
+
+## Top-level items
+
+A `wit` document is a sequence of items specified at the top level. These items
+come one after another and it's recommended to separate them with newlines for
+readability but this isn't required.
+
+## Item: `use`
+
+A `use` statement enables importing type or resource definitions from other
+wit documents. The structure of a use statement is:
+
+```wit
+use * from other-file
+use { a, list, of, names } from another-file
+use { name as other-name } from yet-another-file
+```
+
+Specifically the structure of this is:
+
+```wit
+use-item ::= 'use' use-names 'from' id
+
+use-names ::= '*'
+            | '{' use-names-list '}'
+
+use-names-list ::= use-names-item
+                 | use-names-item ',' use-names-list?
+
+use-names-item ::= id
+                 | id 'as' id
+```
+
+Note: Here `use-names-list?` means at least one `use-name-list` term.
+
+## Items: type
+
+There are a number of methods of defining types in a `wit` document, and all of
+the types that can be defined in `wit` are intended to map directly to types in
+the [interface types specification](https://github.com/WebAssembly/interface-types).
+
+### Item: `type` (alias)
+
+A `type` statement declares a new named type in the `wit` document. This name can
+be later referred to when defining items using this type. This construct is
+similar to a type alias in other languages
+
+```wit
+type my-awesome-u32 = u32
+type my-complicated-tuple = tuple<u32, s32, string>
+```
+
+Specifically the structure of this is:
+
+```wit
+type-item ::= 'type' id '=' ty
+```
+
+### Item: `record` (bag of named fields)
+
+A `record` statement declares a new named structure with named fields. Records
+are similar to a `struct` in many languages. Instances of a `record` always have
+their fields defined.
+
+```wit
+record pair {
+    x: u32,
+    y: u32,
+}
+
+record person {
+    name: string,
+    age: u32,
+    has-lego-action-figure: bool,
+}
+```
+
+Specifically the structure of this is:
+
+```wit
+record-item ::= 'record' id '{' record-fields '}'
+
+record-fields ::= record-field
+                | record-field ',' record-fields?
+
+record-field ::= id ':' ty
+```
+
+### Item: `flags` (bag-of-bools)
+
+A `flags` statement defines a new `record`-like structure where all the fields
+are booleans. The `flags` type is distinct from `record` in that it typically is
+represented as a bit flags representation in the canonical ABI. For the purposes
+of type-checking, however, it's simply syntactic sugar for a record-of-booleans.
+
+```wit
+flags properties {
+    lego,
+    marvel-superhero,
+    supervillan,
+}
+
+// type-wise equivalent to:
+//
+// record properties {
+//     lego: bool,
+//     marvel-superhero: bool,
+//     supervillan: bool,
+// }
+```
+
+Specifically the structure of this is:
+
+```wit
+flags-items ::= 'flags' id '{' flags-fields '}'
+
+flags-fields ::= id,
+               | id ',' flags-fields?
+```
+
+### Item: `variant` (one of a set of types)
+
+A `variant` statement defines a new type where instances of the type match
+exactly one of the variants listed for the type. This is similar to a "sum" type
+in algebraic datatypes (or an `enum` in Rust if you're familiar with it).
+Variants can be thought of as tagged unions as well.
+
+Each case of a variant can have an optional type associated with it which is
+present when values have that particular case's tag.
+
+All `variant` type must have at least one case specified.
+
+```wit
+variant filter {
+    all,
+    none,
+    some(list<string>),
+}
+```
+
+Specifically the structure of this is:
+
+```wit
+variant-items ::= 'variant' id '{' variant-cases '}'
+
+variant-cases ::= variant-case,
+                | variant-case ',' variant-cases?
+
+variant-case ::= id
+               | id '(' ty ')'
+```
+
+### Item: `enum` (variant but with no payload)
+
+An `enum` statement defines a new type which is semantically equivalent to a
+`variant` where none of the cases have a payload type. This is special-cased,
+however, to possibly have a different representation in the language ABIs or
+have different bindings generated in for languages.
+
+```wit
+enum color {
+    red,
+    green,
+    blue,
+    yellow,
+    other,
+}
+
+// type-wise equivalent to:
+//
+// variant color {
+//     red,
+//     green,
+//     blue,
+//     yellow,
+//     other,
+// }
+```
+
+Specifically the structure of this is:
+
+```wit
+enum-items ::= 'enum' id '{' enum-cases '}'
+
+enum-cases ::= id,
+             | id ',' enum-cases?
+```
+
+### Item: `union` (variant but with no case names)
+
+A `union` statement defines a new type which is semantically equivalent to a
+`variant` where all of the cases have a payload type and the case names are
+numerical. This is special-cased, however, to possibly have a different
+representation in the language ABIs or have different bindings generated in for
+languages.
+
+```wit
+union configuration {
+    string,
+    list<string>,
+}
+
+// type-wise equivalent to:
+//
+// variant configuration {
+//     0(string),
+//     1(list<string>),
+// }
+```
+
+Specifically the structure of this is:
+
+```wit
+union-items ::= 'union' id '{' union-cases '}'
+
+union-cases ::= ty,
+              | ty ',' union-cases?
+```
+
+## Item: `func`
+
+Functions can also be defined in a `wit` document. Functions have a name,
+parameters, and results. Functions can optionally also be declared as `async`
+functions.
+
+```wit
+thunk: func()
+fibonacci: func(n: u32) -> u32
+sleep: async func(ms: u64)
+```
+
+Specifically functions have the structure:
+
+```wit
+func-item ::= id ':' 'async'? 'func' '(' func-args ')' func-ret
+
+func-args ::= func-arg
+            | func-arg ',' func-args?
+
+func-arg ::= id ':' ty
+
+func-ret ::= nil
+           | '->' ty
+```
+
+## Item: `resource`
+
+Resources represent a value that has a hidden representation not known to the
+outside world. This means that the resource is operated on through a "handle" (a
+pointer of sorts). Resources also have ownership associated with them and
+languages will have to manage the lifetime of resources manually (they're
+similar to file descriptors).
+
+Resources can also optionally have functions defined within them which adds an
+implicit "self" argument as the first argument to each function of the same type
+of the including resource, unless the function is flagged as `static`.
+
+```wit
+resource file-descriptor
+
+resource request {
+    static new: func() -> request
+
+    body: async func() -> list<u8>
+    headers: func() -> list<string>
+}
+```
+
+Specifically resources have the structure:
+
+```wit
+resource-item ::= 'resource' id resource-contents
+
+resource-contents ::= nil
+                    | '{' resource-defs '}'
+
+resource-defs ::= resource-def resource-defs?
+
+resource-def ::= 'static'? func-item
+```
+
+## Types
+
+As mentioned previously the intention of `wit` is to allow defining types
+corresponding to the interface types specification. Many of the top-level items
+above are introducing new named types but "anonymous" types are also supported,
+such as built-ins. For example:
+
+```wit
+type number = u32
+type fallible-function-result = expected<u32, string>
+type headers = list<string>
+```
+
+Specifically the following types are available:
+
+```wit
+ty ::= 'u8' | 'u16' | 'u32' | 'u64'
+     | 's8' | 's16' | 's32' | 's64'
+     | 'float32' | 'float64'
+     | 'char'
+     | 'bool'
+     | 'string'
+     | 'unit'
+     | tuple
+     | list
+     | option
+     | expected
+     | future
+     | stream
+     | id
+
+tuple ::= 'tuple' '<' tuple-list '>'
+tuple-list ::= ty
+             | ty ',' tuple-list?
+
+list ::= 'list' '<' ty '>'
+
+option ::= 'option' '<' ty '>'
+
+expected ::= 'expected' '<' ty ',' ty '>'
+
+future ::= 'future' '<' ty '>'
+
+stream ::= 'stream' '<' ty ',' ty '>'
+```
+
+The `tuple` type is semantically equivalent to a `record` with numerical fields,
+but it frequently can have language-specific meaning so it's provided as a
+first-class type.
+
+Similarly the `option` and `expected` types are semantically equivalent to the
+variants:
+
+```wit
+variant option {
+    none,
+    some(ty),
+}
+
+variant expected {
+    ok(ok-ty)
+    err(err-ty),
+}
+```
+
+These types are so frequently used and frequently have language-specific
+meanings though so they're also provided as first-class types.
+
+Finally the last case of a `ty` is simply an `id` which is intended to refer to
+another type or resource defined in the document. Note that definitions can come
+through a `use` statement or they can be defined locally.
+
+## Identifiers
+
+Identifiers in `wit` can be defined with two different forms. The first is a
+lower-case [stream-safe] [NFC] [kebab-case] identifier where each part delimited
+by '-'s starts with a `XID_Start` scalar value with a zero Canonical Combining
+Class:
+
+```wit
+foo: func(bar: u32)
+
+red-green-blue: func(r: u32, g: u32, b: u32)
+```
+
+This form can't name identifiers which have the same name as wit keywords, so
+the second form is the same syntax with the same restrictions as the first, but
+prefixed with '%':
+
+```wit
+%foo: func(%bar: u32)
+
+%red-green-blue: func(%r: u32, %g: u32, %b: u32)
+
+// This form also supports identifiers that would otherwise be keywords.
+%variant: func(%enum: s32)
+```
+
+[kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
+[Unicode identifier]: http://www.unicode.org/reports/tr31/
+[stream-safe]: https://unicode.org/reports/tr15/#Stream_Safe_Text_Format
+[NFC]: https://unicode.org/reports/tr15/#Norm_Forms
+
+## Name resolution
+
+A `wit` document is resolved after parsing to ensure that all names resolve
+correctly. For example this is not a valid `wit` document:
+
+```wit
+type foo = bar  // ERROR: name `bar` not defined
+```
+
+Type references primarily happen through the `id` production of `ty`.
+
+Additionally names in a `wit` document can only be defined once:
+
+```wit
+type foo = u32
+type foo = u64  // ERROR: name `foo` already defined
+```
+
+Names do not need to be defined before they're used (unlike in C or C++),
+it's ok to define a type after it's used:
+
+```wit
+type foo = bar
+
+record bar {
+    age: u32,
+}
+```
+
+Types, however, cannot be recursive:
+
+```wit
+type foo = foo  // ERROR: cannot refer to itself
+
+record bar1 {
+    a: bar2,
+}
+
+record bar2 {
+    a: bar1,  // ERROR: record cannot refer to itself
+}
+```
+
+The intention of `wit` is that it maps down to interface types, so the goal of
+name resolution is to effectively create the type section of a wasm module using
+interface types. The restrictions about self-referential types and such come
+from how types can be defined in the interface types section. Additionally
+definitions of named types such as `record foo { ... }` are intended to map
+roughly to declarations in the type section of new types.

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -92,7 +92,7 @@ def test(t, vals_to_lift, v,
   if not equal_modulo_string_encoding(got, lower_v):
     fail("{} re-lift expected {} but got {}".format(test_name(), lower_v, got))
 
-test(Unit(), [], {})
+test(Record([]), [], {})
 test(Record([Field('x',U8()), Field('y',U16()), Field('z',U32())]), [1,2,3], {'x':1,'y':2,'z':3})
 test(Tuple([Tuple([U8(),U8()]),U8()]), [1,2,3], {'0':{'0':1,'1':2},'1':3})
 t = Flags(['a','b'])
@@ -101,45 +101,45 @@ test(t, [2], {'a':False,'b':True})
 test(t, [3], {'a':True,'b':True})
 test(t, [4], {'a':False,'b':False})
 test(Flags([str(i) for i in range(33)]), [0xffffffff,0x1], { str(i):True for i in range(33) })
-t = Variant([Case('x',U8()),Case('y',Float32()),Case('z',Unit())])
-test(t, [0,42], {'x': 42})
-test(t, [0,256], {'x': 0})
-test(t, [1,0x4048f5c3], {'y': 3.140000104904175})
-test(t, [2,0xffffffff], {'z': {}})
+t = Variant([Case('x',[U8()]),Case('y',[Float32()]),Case('z',[])])
+test(t, [0,42], {'x': [42]})
+test(t, [0,256], {'x': [0]})
+test(t, [1,0x4048f5c3], {'y':[3.140000104904175]})
+test(t, [2,0xffffffff], {'z':[]})
 t = Union([U32(),U64()])
-test(t, [0,42], {'0':42})
-test(t, [0,(1<<35)], {'0':0})
-test(t, [1,(1<<35)], {'1':(1<<35)})
+test(t, [0,42], {'0':[42]})
+test(t, [0,(1<<35)], {'0':[0]})
+test(t, [1,(1<<35)], {'1':[1<<35]})
 t = Union([Float32(), U64()])
-test(t, [0,0x4048f5c3], {'0': 3.140000104904175})
-test(t, [0,(1<<35)], {'0': 0})
-test(t, [1,(1<<35)], {'1': (1<<35)})
+test(t, [0,0x4048f5c3], {'0':[3.140000104904175]})
+test(t, [0,(1<<35)], {'0':[0]})
+test(t, [1,(1<<35)], {'1':[1<<35]})
 t = Union([Float64(), U64()])
-test(t, [0,0x40091EB851EB851F], {'0': 3.14})
-test(t, [0,(1<<35)], {'0': 1.69759663277e-313})
-test(t, [1,(1<<35)], {'1': (1<<35)})
+test(t, [0,0x40091EB851EB851F], {'0':[3.14]})
+test(t, [0,(1<<35)], {'0':[1.69759663277e-313]})
+test(t, [1,(1<<35)], {'1':[1<<35]})
 t = Union([U8()])
-test(t, [0,42], {'0':42})
+test(t, [0,42], {'0':[42]})
 test(t, [1,256], None)
-test(t, [0,256], {'0':0})
+test(t, [0,256], {'0':[0]})
 t = Union([Tuple([U8(),Float32()]), U64()])
-test(t, [0,42,3.14], {'0': {'0':42, '1':3.14}})
-test(t, [1,(1<<35),0], {'1': (1<<35)})
+test(t, [0,42,3.14], {'0':[{'0':42, '1':3.14}]})
+test(t, [1,(1<<35),0], {'1':[1<<35]})
 t = Option(Float32())
-test(t, [0,3.14], {'none':{}})
-test(t, [1,3.14], {'some':3.14})
-t = Expected(U8(),U32())
-test(t, [0, 42], {'ok':42})
-test(t, [1, 1000], {'error':1000})
-t = Variant([Case('w',U8()), Case('x',U8(),'w'), Case('y',U8()), Case('z',U8(),'x')])
-test(t, [0, 42], {'w':42})
-test(t, [1, 42], {'x|w':42})
-test(t, [2, 42], {'y':42})
-test(t, [3, 42], {'z|x|w':42})
-t2 = Variant([Case('w',U8())])
-test(t, [0, 42], {'w':42}, lower_t=t2, lower_v={'w':42})
-test(t, [1, 42], {'x|w':42}, lower_t=t2, lower_v={'w':42})
-test(t, [3, 42], {'z|x|w':42}, lower_t=t2, lower_v={'w':42})
+test(t, [0,3.14], {'none':[]})
+test(t, [1,3.14], {'some':[3.14]})
+t = Result([U8()],[U32()])
+test(t, [0, 42], {'ok':[42]})
+test(t, [1, 1000], {'error':[1000]})
+t = Variant([Case('w',[U8()]), Case('x',[U8()],'w'), Case('y',[U8()]), Case('z',[U8()],'x')])
+test(t, [0, 42], {'w':[42]})
+test(t, [1, 42], {'x|w':[42]})
+test(t, [2, 42], {'y':[42]})
+test(t, [3, 42], {'z|x|w':[42]})
+t2 = Variant([Case('w',[U8()])])
+test(t, [0, 42], {'w':[42]}, lower_t=t2, lower_v={'w':[42]})
+test(t, [1, 42], {'x|w':[42]}, lower_t=t2, lower_v={'w':[42]})
+test(t, [3, 42], {'z|x|w':[42]}, lower_t=t2, lower_v={'w':[42]})
 
 def test_pairs(t, pairs):
   for arg,expect in pairs:
@@ -162,7 +162,7 @@ test_pairs(Float32(), [(3.14,3.14)])
 test_pairs(Float64(), [(3.14,3.14)])
 test_pairs(Char(), [(0,'\x00'), (65,'A'), (0xD7FF,'\uD7FF'), (0xD800,None), (0xDFFF,None)])
 test_pairs(Char(), [(0xE000,'\uE000'), (0x10FFFF,'\U0010FFFF'), (0x110000,None), (0xFFFFFFFF,None)])
-test_pairs(Enum(['a','b']), [(0,{'a':{}}), (1,{'b':{}}), (2,None)])
+test_pairs(Enum(['a','b']), [(0,{'a':[]}), (1,{'b':[]}), (2,None)])
 
 def test_nan32(inbits, outbits):
   f = lift_flat(Opts(), ValueIter([Value('f32', reinterpret_i32_as_float(inbits))]), Float32())
@@ -240,7 +240,7 @@ def test_heap(t, expect, args, byte_array):
   opts = mk_opts(heap.memory, 'utf8', None, None)
   test(t, args, expect, opts)
 
-test_heap(List(Unit()), [{},{},{}], [0,3], [])
+test_heap(List(Record([])), [{},{},{}], [0,3], [])
 test_heap(List(Bool()), [True,False,True], [0,3], [1,0,1])
 test_heap(List(Bool()), [True,False,True], [0,3], [1,0,2])
 test_heap(List(Bool()), [True,False,True], [3,3], [0xff,0xff,0xff, 1,0,1])
@@ -274,14 +274,14 @@ test_heap(List(Tuple([U16(),U8()])), [mk_tup(6,7),mk_tup(8,9)], [0,2],
           [6,0, 7, 0x0ff, 8,0, 9, 0xff])
 test_heap(List(Tuple([Tuple([U16(),U8()]),U8()])), [mk_tup([4,5],6),mk_tup([7,8],9)], [0,2],
           [4,0, 5,0xff, 6,0xff,  7,0, 8,0xff, 9,0xff])
-test_heap(List(Union([Unit(),U8(),Tuple([U8(),U16()])])), [{'0':{}}, {'1':42}, {'2':mk_tup(6,7)}], [0,3],
+test_heap(List(Union([Tuple([]),U8(),Tuple([U8(),U16()])])), [{'0':[{}]}, {'1':[42]}, {'2':[mk_tup(6,7)]}], [0,3],
           [0,0xff,0xff,0xff,0xff,0xff,  1,0xff,42,0xff,0xff,0xff,  2,0xff,6,0xff,7,0])
-test_heap(List(Union([U32(),U8()])), [{'0':256}, {'1':42}], [0,2],
+test_heap(List(Union([U32(),U8()])), [{'0':[256]}, {'1':[42]}], [0,2],
           [0,0xff,0xff,0xff,0,1,0,0,  1,0xff,0xff,0xff,42,0xff,0xff,0xff])
 test_heap(List(Tuple([Union([U8(),Tuple([U16(),U8()])]),U8()])),
-          [mk_tup({'1':mk_tup(5,6)},7),mk_tup({'0':8},9)], [0,2],
+          [mk_tup({'1':[mk_tup(5,6)]},7),mk_tup({'0':[8]},9)], [0,2],
           [1,0xff,5,0,6,0xff,7,0xff,  0,0xff,8,0xff,0xff,0xff,9,0xff])
-test_heap(List(Union([U8()])), [{'0':6},{'0':7},{'0':8}], [0,3],
+test_heap(List(Union([U8()])), [{'0':[6]},{'0':[7]},{'0':[8]}], [0,3],
           [0,6, 0,7, 0,8])
 t = List(Flags(['a','b']))
 test_heap(t, [{'a':False,'b':False},{'a':False,'b':True},{'a':True,'b':True}], [0,3],
@@ -324,19 +324,20 @@ def test_flatten(t, params, results):
   got = flatten(t, 'lower')
   assert(got == expect)
   
-test_flatten(Func([U8(),Float32(),Float64()],Unit()), ['i32','f32','f64'], [])
-test_flatten(Func([U8(),Float32(),Float64()],Float32()), ['i32','f32','f64'], ['f32'])
-test_flatten(Func([U8(),Float32(),Float64()],U8()), ['i32','f32','f64'], ['i32'])
-test_flatten(Func([U8(),Float32(),Float64()],Tuple([Float32()])), ['i32','f32','f64'], ['f32'])
-test_flatten(Func([U8(),Float32(),Float64()],Tuple([Float32(),Float32()])), ['i32','f32','f64'], ['f32','f32'])
-test_flatten(Func([U8() for _ in range(17)],Unit()), ['i32' for _ in range(17)], [])
-test_flatten(Func([U8() for _ in range(17)],Tuple([U8(),U8()])), ['i32' for _ in range(17)], ['i32','i32'])
+test_flatten(Func([U8(),Float32(),Float64()],[]), ['i32','f32','f64'], [])
+test_flatten(Func([U8(),Float32(),Float64()],[Float32()]), ['i32','f32','f64'], ['f32'])
+test_flatten(Func([U8(),Float32(),Float64()],[U8()]), ['i32','f32','f64'], ['i32'])
+test_flatten(Func([U8(),Float32(),Float64()],[Tuple([Float32()])]), ['i32','f32','f64'], ['f32'])
+test_flatten(Func([U8(),Float32(),Float64()],[Tuple([Float32(),Float32()])]), ['i32','f32','f64'], ['f32','f32'])
+test_flatten(Func([U8(),Float32(),Float64()],[Float32(),Float32()]), ['i32','f32','f64'], ['f32','f32'])
+test_flatten(Func([U8() for _ in range(17)],[]), ['i32' for _ in range(17)], [])
+test_flatten(Func([U8() for _ in range(17)],[Tuple([U8(),U8()])]), ['i32' for _ in range(17)], ['i32','i32'])
 
 def test_roundtrip(t, v):
   before = definitions.MAX_FLAT_RESULTS
   definitions.MAX_FLAT_RESULTS = 16
 
-  ft = Func([t],t)
+  ft = Func([t],[t])
   callee_instance = Instance()
   callee = lambda x: x
 
@@ -363,6 +364,6 @@ test_roundtrip(S8(), -1)
 test_roundtrip(Tuple([U16(),U16()]), mk_tup(3,4))
 test_roundtrip(List(String()), [mk_str("hello there")])
 test_roundtrip(List(List(String())), [[mk_str("one"),mk_str("two")],[mk_str("three")]])
-test_roundtrip(List(Option(Tuple([String(),U16()]))), [{'some':mk_tup(mk_str("answer"),42)}])
+test_roundtrip(List(Option(Tuple([String(),U16()]))), [{'some':[mk_tup(mk_str("answer"),42)]}])
 
 print("All tests passed")

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -2,11 +2,11 @@ import definitions
 from definitions import *
 
 def equal_modulo_string_encoding(s, t):
+  if s is None and t is None:
+    return True
   if isinstance(s, (bool,int,float,str)) and isinstance(t, (bool,int,float,str)):
     return s == t
   if isinstance(s, tuple) and isinstance(t, tuple):
-    if s == () and t == ():
-      return True
     assert(isinstance(s[0], str))
     assert(isinstance(t[0], str))
     return s[0] == t[0]
@@ -101,45 +101,45 @@ test(t, [2], {'a':False,'b':True})
 test(t, [3], {'a':True,'b':True})
 test(t, [4], {'a':False,'b':False})
 test(Flags([str(i) for i in range(33)]), [0xffffffff,0x1], { str(i):True for i in range(33) })
-t = Variant([Case('x',[U8()]),Case('y',[Float32()]),Case('z',[])])
-test(t, [0,42], {'x': [42]})
-test(t, [0,256], {'x': [0]})
-test(t, [1,0x4048f5c3], {'y':[3.140000104904175]})
-test(t, [2,0xffffffff], {'z':[]})
+t = Variant([Case('x',U8()),Case('y',Float32()),Case('z',None)])
+test(t, [0,42], {'x': 42})
+test(t, [0,256], {'x': 0})
+test(t, [1,0x4048f5c3], {'y': 3.140000104904175})
+test(t, [2,0xffffffff], {'z': None})
 t = Union([U32(),U64()])
-test(t, [0,42], {'0':[42]})
-test(t, [0,(1<<35)], {'0':[0]})
-test(t, [1,(1<<35)], {'1':[1<<35]})
+test(t, [0,42], {'0':42})
+test(t, [0,(1<<35)], {'0':0})
+test(t, [1,(1<<35)], {'1':(1<<35)})
 t = Union([Float32(), U64()])
-test(t, [0,0x4048f5c3], {'0':[3.140000104904175]})
-test(t, [0,(1<<35)], {'0':[0]})
-test(t, [1,(1<<35)], {'1':[1<<35]})
+test(t, [0,0x4048f5c3], {'0': 3.140000104904175})
+test(t, [0,(1<<35)], {'0': 0})
+test(t, [1,(1<<35)], {'1': (1<<35)})
 t = Union([Float64(), U64()])
-test(t, [0,0x40091EB851EB851F], {'0':[3.14]})
-test(t, [0,(1<<35)], {'0':[1.69759663277e-313]})
-test(t, [1,(1<<35)], {'1':[1<<35]})
+test(t, [0,0x40091EB851EB851F], {'0': 3.14})
+test(t, [0,(1<<35)], {'0': 1.69759663277e-313})
+test(t, [1,(1<<35)], {'1': (1<<35)})
 t = Union([U8()])
-test(t, [0,42], {'0':[42]})
+test(t, [0,42], {'0':42})
 test(t, [1,256], None)
-test(t, [0,256], {'0':[0]})
+test(t, [0,256], {'0':0})
 t = Union([Tuple([U8(),Float32()]), U64()])
-test(t, [0,42,3.14], {'0':[{'0':42, '1':3.14}]})
-test(t, [1,(1<<35),0], {'1':[1<<35]})
+test(t, [0,42,3.14], {'0': {'0':42, '1':3.14}})
+test(t, [1,(1<<35),0], {'1': (1<<35)})
 t = Option(Float32())
-test(t, [0,3.14], {'none':[]})
-test(t, [1,3.14], {'some':[3.14]})
-t = Result([U8()],[U32()])
-test(t, [0, 42], {'ok':[42]})
-test(t, [1, 1000], {'error':[1000]})
-t = Variant([Case('w',[U8()]), Case('x',[U8()],'w'), Case('y',[U8()]), Case('z',[U8()],'x')])
-test(t, [0, 42], {'w':[42]})
-test(t, [1, 42], {'x|w':[42]})
-test(t, [2, 42], {'y':[42]})
-test(t, [3, 42], {'z|x|w':[42]})
-t2 = Variant([Case('w',[U8()])])
-test(t, [0, 42], {'w':[42]}, lower_t=t2, lower_v={'w':[42]})
-test(t, [1, 42], {'x|w':[42]}, lower_t=t2, lower_v={'w':[42]})
-test(t, [3, 42], {'z|x|w':[42]}, lower_t=t2, lower_v={'w':[42]})
+test(t, [0,3.14], {'none':None})
+test(t, [1,3.14], {'some':3.14})
+t = Result(U8(),U32())
+test(t, [0, 42], {'ok':42})
+test(t, [1, 1000], {'error':1000})
+t = Variant([Case('w',U8()), Case('x',U8(),'w'), Case('y',U8()), Case('z',U8(),'x')])
+test(t, [0, 42], {'w':42})
+test(t, [1, 42], {'x|w':42})
+test(t, [2, 42], {'y':42})
+test(t, [3, 42], {'z|x|w':42})
+t2 = Variant([Case('w',U8())])
+test(t, [0, 42], {'w':42}, lower_t=t2, lower_v={'w':42})
+test(t, [1, 42], {'x|w':42}, lower_t=t2, lower_v={'w':42})
+test(t, [3, 42], {'z|x|w':42}, lower_t=t2, lower_v={'w':42})
 
 def test_pairs(t, pairs):
   for arg,expect in pairs:
@@ -162,7 +162,7 @@ test_pairs(Float32(), [(3.14,3.14)])
 test_pairs(Float64(), [(3.14,3.14)])
 test_pairs(Char(), [(0,'\x00'), (65,'A'), (0xD7FF,'\uD7FF'), (0xD800,None), (0xDFFF,None)])
 test_pairs(Char(), [(0xE000,'\uE000'), (0x10FFFF,'\U0010FFFF'), (0x110000,None), (0xFFFFFFFF,None)])
-test_pairs(Enum(['a','b']), [(0,{'a':[]}), (1,{'b':[]}), (2,None)])
+test_pairs(Enum(['a','b']), [(0,{'a':None}), (1,{'b':None}), (2,None)])
 
 def test_nan32(inbits, outbits):
   f = lift_flat(Opts(), ValueIter([Value('f32', reinterpret_i32_as_float(inbits))]), Float32())
@@ -274,14 +274,14 @@ test_heap(List(Tuple([U16(),U8()])), [mk_tup(6,7),mk_tup(8,9)], [0,2],
           [6,0, 7, 0x0ff, 8,0, 9, 0xff])
 test_heap(List(Tuple([Tuple([U16(),U8()]),U8()])), [mk_tup([4,5],6),mk_tup([7,8],9)], [0,2],
           [4,0, 5,0xff, 6,0xff,  7,0, 8,0xff, 9,0xff])
-test_heap(List(Union([Tuple([]),U8(),Tuple([U8(),U16()])])), [{'0':[{}]}, {'1':[42]}, {'2':[mk_tup(6,7)]}], [0,3],
+test_heap(List(Union([Record([]),U8(),Tuple([U8(),U16()])])), [{'0':{}}, {'1':42}, {'2':mk_tup(6,7)}], [0,3],
           [0,0xff,0xff,0xff,0xff,0xff,  1,0xff,42,0xff,0xff,0xff,  2,0xff,6,0xff,7,0])
-test_heap(List(Union([U32(),U8()])), [{'0':[256]}, {'1':[42]}], [0,2],
+test_heap(List(Union([U32(),U8()])), [{'0':256}, {'1':42}], [0,2],
           [0,0xff,0xff,0xff,0,1,0,0,  1,0xff,0xff,0xff,42,0xff,0xff,0xff])
 test_heap(List(Tuple([Union([U8(),Tuple([U16(),U8()])]),U8()])),
-          [mk_tup({'1':[mk_tup(5,6)]},7),mk_tup({'0':[8]},9)], [0,2],
+          [mk_tup({'1':mk_tup(5,6)},7),mk_tup({'0':8},9)], [0,2],
           [1,0xff,5,0,6,0xff,7,0xff,  0,0xff,8,0xff,0xff,0xff,9,0xff])
-test_heap(List(Union([U8()])), [{'0':[6]},{'0':[7]},{'0':[8]}], [0,3],
+test_heap(List(Union([U8()])), [{'0':6},{'0':7},{'0':8}], [0,3],
           [0,6, 0,7, 0,8])
 t = List(Flags(['a','b']))
 test_heap(t, [{'a':False,'b':False},{'a':False,'b':True},{'a':True,'b':True}], [0,3],
@@ -364,6 +364,6 @@ test_roundtrip(S8(), -1)
 test_roundtrip(Tuple([U16(),U16()]), mk_tup(3,4))
 test_roundtrip(List(String()), [mk_str("hello there")])
 test_roundtrip(List(List(String())), [[mk_str("one"),mk_str("two")],[mk_str("three")]])
-test_roundtrip(List(Option(Tuple([String(),U16()]))), [{'some':[mk_tup(mk_str("answer"),42)]}])
+test_roundtrip(List(Option(Tuple([String(),U16()]))), [{'some':mk_tup(mk_str("answer"),42)}])
 
 print("All tests passed")


### PR DESCRIPTION
This PR switches back to multi-return and, for the reasons outlined in #41, makes several associated changes:
* `unit` is removed (empty return can be used instead)
* `variant` and `expected` case payloads are changed to ~~lists of values~~contain either 0 or 1 `valtype`
* `expected` is renamed to `result`
* parameter/result lists can either be all-named or have a single unnamed type
