### PR TITLE
Respect `MAX_FLAT_RESULTS` in Explainer.md

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -726,7 +726,7 @@ takes a string, does some logging, then returns a string.
     (import "libc" "memory" (memory 1))
     (import "libc" "realloc" (func (param i32 i32) (result i32)))
     (import "wasi:logging" "log" (func $log (param i32 i32)))
-    (func (export "run") (param i32 i32) (result i32 i32)
+    (func (export "run") (param i32 i32) (result i32)
       ... (call $log) ...
     )
   )
@@ -786,7 +786,7 @@ exported string at instantiation time:
   (core instance $libc (instantiate $Libc))
   (core module $Main
     (import "libc" ...)
-    (func (export "start") (param i32 i32) (result i32 i32)
+    (func (export "start") (param i32 i32) (result i32)
       ... general-purpose compute
     )
   )


### PR DESCRIPTION
I noticed a couple spots in Explainer.md where canonical-ABI functions return multiple values. This fixes those spots to return a pointer to those values instead, properly following the canonical ABI.