### PR TITLE
Fix example which used one-level imports in a core module type

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -420,14 +420,14 @@ module types always start with an empty type index space.
 (component $C
   (core type $C1 (module
     (type (func (param i32) (result i32)))
-    (import "a" (func (type 0)))
-    (export "b" (func (type 0)))
+    (import "a" "b" (func (type 0)))
+    (export "c" (func (type 0)))
   ))
   (core type $F (func (param i32) (result i32)))
   (core type $C2 (module
     (alias outer 1 $F (type))
-    (import "a" (func (type 0)))
-    (export "b" (func (type 0)))
+    (import "a" "b" (func (type 0)))
+    (export "c" (func (type 0)))
   ))
 )
 ```


### PR DESCRIPTION
This fixes a small typo in one of the examples in the explainer.