### PR TITLE
Add explicit result arity to start definitions

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -266,10 +266,11 @@ Notes:
 
 (See [Start Definitions](Explainer.md#start-definitions) in the explainer.)
 ```
-start ::= f:<funcidx> arg*:vec(<valueidx>) => (start f (value arg)*)
+start ::= f:<funcidx> arg*:vec(<valueidx>) r:<u32> => (start f (value arg)* (result (value))ʳ)
 ```
 Notes:
-* Validation requires `f` have `functype` with `param` arity and types matching `arg*`.
+* Validation requires `f` have `functype` with `param` arity and types matching `arg*`
+  and `result` arity `r`.
 * Validation appends the `result` types of `f` to the value index space (making
   them available for reference by subsequent definitions).
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -758,13 +758,14 @@ instantiation. Unlike modules, components can call start functions at multiple
 points during instantiation with each such call having parameters and results.
 Thus, `start` definitions in components look like function calls:
 ```
-start ::= (start <funcidx> (value <valueidx>)* (result (value <id>))?)
+start ::= (start <funcidx> (value <valueidx>)* (result (value <id>?))*)
 ```
 The `(value <valueidx>)*` list specifies the arguments passed to `funcidx` by
 indexing into the *value index space*. Value definitions (in the value index
 space) are like immutable `global` definitions in Core WebAssembly except that
 validation requires them to be consumed exactly once at instantiation-time
-(i.e., they are [linear]).
+(i.e., they are [linear]). The arity and types of the two value lists are
+validated to match the signature of `funcidx`.
 
 As with all definition sorts, values may be imported and exported by
 components. As an example value import:


### PR DESCRIPTION
As discussed in #84, this PR adds an explicit result arity to the binary format.  Thinking about this a bit more, it seemed like maybe we should have a symmetric rule in the text format: namely that the arity of the `result` list should match the callee (with the identifiers being optional).  Thoughts?