### PR TITLE
Remove the `async` keyword from WIT.md.

### DIFF
--- a/design/high-level/UseCases.md
+++ b/design/high-level/UseCases.md
@@ -180,7 +180,7 @@ use cases that require additional features:
    can encapsulate `i32` pointers to linear memory allocations that need to be
    safely freed when the last handle goes away.
 3. Developers import or export functions with signatures containing
-   concurrency-oriented types (e.g., async, future and stream) to address
+   concurrency-oriented types (e.g., future and stream) to address
    concurrency use cases like non-blocking I/O, early return and streaming. Both
    developers (the caller and callee) are able to use their respective languages'
    native concurrency support, if it exists, using the concurrency-oriented types

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -110,7 +110,6 @@ keyword ::= 'use'
           | 'static'
           | 'interface'
           | 'tuple'
-          | 'async'
           | 'future'
           | 'stream'
 ```
@@ -336,19 +335,17 @@ union-cases ::= ty,
 ## Item: `func`
 
 Functions can also be defined in a `wit` document. Functions have a name,
-parameters, and results. Functions can optionally also be declared as `async`
-functions.
+parameters, and results.
 
 ```wit
 thunk: func() -> ()
 fibonacci: func(n: u32) -> u32
-sleep: async func(ms: u64) -> ()
 ```
 
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'func' func-vec '->' func-vec
+func-item ::= id ':' 'func' func-vec '->' func-vec
 
 func-vec ::= ty
            | '(' func-named-type-list ')'
@@ -377,7 +374,7 @@ resource file-descriptor
 resource request {
     static new: func() -> request
 
-    body: async func() -> list<u8>
+    body: func() -> future<list<u8>>
     headers: func() -> list<string>
 }
 ```


### PR DESCRIPTION
In the current [async proposal], there are no longer `async` functions; there
are instead functions that return `future` or `stream`.

[async proposal]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE/edit#slide=id.g1270ef7d5b6_0_111