### PR TITLE
Allow using exported types in component and instance types

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -221,6 +221,8 @@ Notes:
 * As described in the explainer, each component and instance type is validated
   with an initially-empty type index space. Outer aliases can be used to pull
   in type definitions from containing components.
+* Not only type declarators and type import declarators add to the
+  type index space; type export declarators do so as well.
 * The uniqueness validation rules for `externname` described below are also
   applied at the instance- and component-type level.
 * Validation of `externdesc` requires the various `typeidx` type constructors


### PR DESCRIPTION
This changes the syntax of component and instance types so that it is possible to name a type with a typebound when it is declared, rather than when it is exported, in order to create an entry for the abstract type so created in the type index space which may be used in the types of future exported definitions.  For uniformity's sake, the same treatment is given to all definition sorts.