### PR TITLE
Add subsection headers for the mangling documentation.

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1431,7 +1431,7 @@ auxiliary Canonical ABI-induced imports/exports.
 
 #### Instance type mangling
 
-Instance-mangling recursively builds a dotted path string (of instance names)
+Instance-type mangling recursively builds a dotted path string (of instance names)
 that is included in the mangled core import/export name:
 ```python
 def mangle_instances(xs, path = ''):

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1459,7 +1459,7 @@ def mangle_instances(xs, path = ''):
 The three `TODO` cases are intended to be filled in by future PRs extending
 the Canonical ABI.
 
-#### Function and value type mangling
+#### Function type mangling
 
 Function and value types are recursively mangled into
 [`wit`](WIT.md)-compatible syntax:

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1429,7 +1429,7 @@ character in a component-level import/export (as is currently the case in `wit`
 [identifiers](WIT.md#identifiers)) and thus can safely be used to prefix
 auxiliary Canonical ABI-induced imports/exports.
 
-#### Instance mangling
+#### Instance type mangling
 
 Instance-mangling recursively builds a dotted path string (of instance names)
 that is included in the mangled core import/export name:

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1429,6 +1429,8 @@ character in a component-level import/export (as is currently the case in `wit`
 [identifiers](WIT.md#identifiers)) and thus can safely be used to prefix
 auxiliary Canonical ABI-induced imports/exports.
 
+#### Instance mangling
+
 Instance-mangling recursively builds a dotted path string (of instance names)
 that is included in the mangled core import/export name:
 ```python
@@ -1456,6 +1458,8 @@ def mangle_instances(xs, path = ''):
 ```
 The three `TODO` cases are intended to be filled in by future PRs extending
 the Canonical ABI.
+
+#### Function and value type mangling
 
 Function and value types are recursively mangled into
 [`wit`](WIT.md)-compatible syntax:

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1461,7 +1461,7 @@ the Canonical ABI.
 
 #### Function type mangling
 
-Function and value types are recursively mangled into
+Function types are mangled into
 [`wit`](WIT.md)-compatible syntax:
 ```python
 def mangle_funcname(name, ft):
@@ -1476,6 +1476,11 @@ def mangle_funcvec(es, pre_space):
   assert(all(type(e) == tuple and len(e) == 2 for e in es))
   mangled_elems = (e[0] + ': ' + mangle_valtype(e[1]) for e in es)
   return '(' + ', '.join(mangled_elems) + ')'
+
+#### Value type mangling
+
+Value types are similarly mangled into [`wit`](WIT.md)-compatible syntax,
+recursively:
 
 def mangle_valtype(t):
   match t:


### PR DESCRIPTION
This enables linking to specific subsections.