### PR TITLE
Remove unnamed function parameter case

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -183,9 +183,10 @@ casetype      ::= 0x00                                    =>
                 | 0x01 t:<valtype>                        => t
 valtype       ::= i:<typeidx>                             => i
                 | pvt:<primvaltype>                       => pvt
-functype      ::= 0x40 p*:<funcvec> r*:<funcvec>          => (func (param p)* (result r)*)
-funcvec       ::= 0x00 t:<valtype>                        => [t]
-                | 0x01 nt*:vec(<namedvaltype>)            => nt*
+functype      ::= 0x40 ps:<paramlist> rs:<resultlist>     => (func ps rs)
+paramlist     ::= nt*:vec(<namedvaltype>)                 => (param nt)*
+resultlist    ::= 0x00 t:<valtype>                        => (result t)
+                | 0x01 nt*:vec(<namedvaltype>)            => (result nt)*
 componenttype ::= 0x41 cd*:vec(<componentdecl>)           => (component cd*)
 instancetype  ::= 0x42 id*:vec(<instancedecl>)            => (instance id*)
 componentdecl ::= 0x03 id:<importdecl>                    => id

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -456,7 +456,6 @@ valtype       ::= <typeidx>
                 | <defvaltype>
 functype      ::= (func <paramlist> <resultlist>)
 paramlist     ::= (param <name> <valtype>)*
-                | (param <valtype>)
 resultlist    ::= (result <name> <valtype>)*
                 | (result <valtype>)
 componenttype ::= (component <componentdecl>*)
@@ -533,11 +532,11 @@ shared-nothing functions, components and component instances:
 The `func` type constructor describes a component-level function definition
 that takes and returns a list of `valtype`. In contrast to [`core:functype`],
 the parameters and results of `functype` can have associated names which
-validation requires to be unique. If a name is not present, the name is taken
-to be a special "empty" name and uniqueness still requires there to only be one
-unnamed parameter/result. To avoid unnecessary complexity for language binding
-generators, parameter and result lists are not allowed to contain both named
-and unnamed parameters.
+validation requires to be unique. To improve the ergonomics and performance of
+the common case of single-value-returning functions, function types may
+additionally have a single unnamed return type. For this special case, bindings
+generators are naturally encouraged to return the single value directly without
+wrapping it in any containing record/object/struct.
 
 The `instance` type constructor describes a list of named, typed definitions
 that can be imported or exported by a component. Informally, instance types

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -345,15 +345,17 @@ fibonacci: func(n: u32) -> u32
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'func' func-vec '->' func-vec
+func-item ::= id ':' 'func' param-list '->' result-list
 
-func-vec ::= ty
-           | '(' func-named-type-list ')'
+param-list ::= '(' named-type-list ')'
 
-func-named-type-list ::= nil
-                       | func-named-type ( ',' func-named-type )*
+result-list ::= ty
+              | '(' named-type-list ')
 
-func-named-type ::= id ':' ty
+named-type-list ::= nil
+                  | named-type ( ',' named-type )*
+
+named-type ::= id ':' ty
 ```
 
 ## Item: `resource`

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -1106,17 +1106,19 @@ def mangle_instances(xs, path = ''):
 #
 
 def mangle_funcname(name, ft):
-  return '{name}: func{params} -> {results}'.format(
-           name = name,
-           params = mangle_funcvec(ft.params, pre_space = False),
-           results = mangle_funcvec(ft.results, pre_space = True))
+  params = mangle_named_types(ft.params)
+  if len(ft.results) == 1 and isinstance(ft.results[0], ValType):
+    results = mangle_valtype(ft.results[0])
+  else:
+    results = mangle_named_types(ft.results)
+  return f'{name}: func{params} -> {results}'
 
-def mangle_funcvec(es, pre_space):
-  if len(es) == 1 and isinstance(es[0], ValType):
-    return (' ' if not pre_space else '') + mangle_valtype(es[0])
-  assert(all(type(e) == tuple and len(e) == 2 for e in es))
-  mangled_elems = (e[0] + ': ' + mangle_valtype(e[1]) for e in es)
+def mangle_named_types(nts):
+  assert(all(type(nt) == tuple and len(nt) == 2 for nt in nts))
+  mangled_elems = (nt[0] + ': ' + mangle_valtype(nt[1]) for nt in nts)
   return '(' + ', '.join(mangled_elems) + ')'
+
+#
 
 def mangle_valtype(t):
   match t:

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -381,25 +381,25 @@ def test_mangle_functype(params, results, expect):
   if got != expect:
     fail("test_mangle_func() got:\n  {}\nexpected:\n  {}".format(got, expect))
 
-test_mangle_functype([U8()], [U8()], 'func u8 -> u8')
-test_mangle_functype([U8()], [], 'func u8 -> ()')
+test_mangle_functype([('x',U8())], [U8()], 'func(x: u8) -> u8')
+test_mangle_functype([('x',U8())], [], 'func(x: u8) -> ()')
 test_mangle_functype([], [U8()], 'func() -> u8')
 test_mangle_functype([('x',U8())], [('y',U8())], 'func(x: u8) -> (y: u8)')
 test_mangle_functype([('a',Bool()),('b',U8()),('c',S16()),('d',U32()),('e',S64())],
                      [('a',S8()),('b',U16()),('c',S32()),('d',U64())],
                      'func(a: bool, b: u8, c: s16, d: u32, e: s64) -> (a: s8, b: u16, c: s32, d: u64)')
-test_mangle_functype([List(List(String()))], [],
-                     'func list<list<string>> -> ()')
-test_mangle_functype([Record([Field('x',Record([Field('y',String())])),Field('z',U32())])], [],
-                     'func record { x: record { y: string }, z: u32 } -> ()')
-test_mangle_functype([Tuple([U8()])], [Tuple([U8(),U8()])],
-                     'func tuple<u8> -> tuple<u8, u8>')
-test_mangle_functype([Flags(['a','b'])], [Enum(['a','b'])],
-                     'func flags { a, b } -> enum { a, b }')
-test_mangle_functype([Variant([Case('a',None),Case('b',U8())])], [Union([U8(),List(String())])],
-                     'func variant { a, b(u8) } -> union { u8, list<string> }')
-test_mangle_functype([Option(Bool())],[Option(List(U8()))],
-                     'func option<bool> -> option<list<u8>>')
+test_mangle_functype([('l',List(List(String())))], [],
+                     'func(l: list<list<string>>) -> ()')
+test_mangle_functype([('r',Record([Field('x',Record([Field('y',String())])),Field('z',U32())]))], [],
+                     'func(r: record { x: record { y: string }, z: u32 }) -> ()')
+test_mangle_functype([('t',Tuple([U8()]))], [Tuple([U8(),U8()])],
+                     'func(t: tuple<u8>) -> tuple<u8, u8>')
+test_mangle_functype([('f',Flags(['a','b']))], [Enum(['a','b'])],
+                     'func(f: flags { a, b }) -> enum { a, b }')
+test_mangle_functype([('v',Variant([Case('a',None),Case('b',U8())]))], [Union([U8(),List(String())])],
+                     'func(v: variant { a, b(u8) }) -> union { u8, list<string> }')
+test_mangle_functype([('o',Option(Bool()))],[Option(List(U8()))],
+                     'func(o: option<bool>) -> option<list<u8>>')
 test_mangle_functype([], [('a',Result(None,None)),('b',Result(U8(),None)),('c',Result(None,U8()))],
                      'func() -> (a: result, b: result<u8>, c: result<_, u8>)')
 
@@ -410,24 +410,24 @@ def test_cabi(ct, expect):
 
 test_cabi(
   ComponentType(
-    [ExternDecl('a', FuncType([U8()],[U8()])),
+    [ExternDecl('a', FuncType([('x',U8())],[U8()])),
      ExternDecl('b', ValueType(String()))],
-    [ExternDecl('c', FuncType([S8()],[S8()])),
+    [ExternDecl('c', FuncType([('x',S8())],[S8()])),
      ExternDecl('d', ValueType(List(U8())))]
   ),
   ModuleType(
-    [CoreImportDecl('','a: func u8 -> u8', CoreFuncType(['i32'],['i32']))],
+    [CoreImportDecl('','a: func(x: u8) -> u8', CoreFuncType(['i32'],['i32']))],
     [CoreExportDecl('cabi_memory', CoreMemoryType(0, None)),
      CoreExportDecl('cabi_realloc', CoreFuncType(['i32','i32','i32','i32'],['i32'])),
      CoreExportDecl('cabi_start{cabi=0.1}: func(b: string) -> (d: list<u8>)',
                     CoreFuncType(['i32','i32'],['i32'])),
-     CoreExportDecl('c: func s8 -> s8', CoreFuncType(['i32'],['i32']))]
+     CoreExportDecl('c: func(x: s8) -> s8', CoreFuncType(['i32'],['i32']))]
   )
 )
 test_cabi(
   ComponentType(
     [ExternDecl('a', InstanceType([
-      ExternDecl('b', FuncType([U8()],[U8()])),
+      ExternDecl('b', FuncType([('x',U8())],[U8()])),
       ExternDecl('c', ValueType(Float32()))
     ]))],
     [ExternDecl('d', InstanceType([
@@ -436,7 +436,7 @@ test_cabi(
     ]))]
   ),
   ModuleType(
-    [CoreImportDecl('','a.b: func u8 -> u8', CoreFuncType(['i32'],['i32']))],
+    [CoreImportDecl('','a.b: func(x: u8) -> u8', CoreFuncType(['i32'],['i32']))],
     [CoreExportDecl('cabi_memory', CoreMemoryType(0, None)),
      CoreExportDecl('cabi_realloc', CoreFuncType(['i32','i32','i32','i32'],['i32'])),
      CoreExportDecl('cabi_start{cabi=0.1}: func(a.c: float32) -> (d.f: float64)',
@@ -452,7 +452,7 @@ test_cabi( # from CanonicalABI.md
        ExternDecl('bar', FuncType([('x', U32()),('y', U32())],[U32()]))
      ])),
      ExternDecl('v1', ValueType(String()))],
-    [ExternDecl('baz', FuncType([String()], [String()])),
+    [ExternDecl('baz', FuncType([('s',String())], [String()])),
      ExternDecl('v2', ValueType(List(List(String()))))]
   ),
   ModuleType(
@@ -462,7 +462,7 @@ test_cabi( # from CanonicalABI.md
      CoreExportDecl('cabi_realloc', CoreFuncType(['i32','i32','i32','i32'],['i32'])),
      CoreExportDecl('cabi_start{cabi=0.1}: func(v1: string) -> (v2: list<list<string>>)',
                     CoreFuncType(['i32','i32'],['i32'])),
-     CoreExportDecl('baz: func string -> string', CoreFuncType(['i32','i32'],['i32'])),
+     CoreExportDecl('baz: func(s: string) -> string', CoreFuncType(['i32','i32'],['i32'])),
      CoreExportDecl('cabi_post_baz', CoreFuncType(['i32'],[]))]
   )
 )


### PR DESCRIPTION
As discussed in #107, this PR removes the unnamed function parameter case in the AST, text, binary and Wit formats.