### PR TITLE
Add a custom `name` section specification

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -340,7 +340,7 @@ namesec    ::= section_0(namedata)
 namedata   ::= n:<name>                (if n = 'component-name')
                name:<componentnamesubsec>?
                decls*:<declnamesubsec>*
-namesubsection_N(B) ::= N: byte size:<u32> B     (if size == |B|)
+namesubsection_N(B) ::= N:<byte> size:<u32> B     (if size == |B|)
 
 componentnamesubsec ::= namesubsection_0(<name>)
 declnamesubsec ::= namesubsection_1(<declnames>)

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -338,9 +338,13 @@ engines should not reject components which have an invalid `name` section.
 ```
 namesec    ::= section_0(namedata)
 namedata   ::= n:<name>                (if n = 'name')
-               sections*:<subsection>*
-subsection ::= sort:<sort> namesubsection(<namemap>)
-namesubsection(B) ::= size:<u32> B     (if size == |B|)
+               name:<componentnamesubsec>?
+               decls*:<declnamesubsec>*
+namesubsection_N(B) ::= N: byte size:<u32> B     (if size == |B|)
+
+componentnamesubsec ::= namesubsection_0(<name>)
+declnamesubsec ::= namesubsection_1(<declnames>)
+declnames ::= sort:<sort> names:<namemap>
 
 namemap ::= names:vec(<nameassoc>)
 nameassoc ::= idx:<u32> name:<name>

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -310,6 +310,34 @@ Notes:
   independently unique among imports and exports, respectively.
 * URLs are compared for equality by plain byte identity.
 
+## Name Section
+
+Like the core wasm [name
+section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section)
+a similar `name` custom section is specified here for components to be able to
+name all the declarations that can happen within a component. Similarly like its
+core wasm counterpart validity of this custom section is not required and
+engines should not reject components which have an invalid `name` section.
+
+```
+namesec    ::= section_0(namedata)
+namedata   ::= n:<name>                (if n = 'component-name')
+               name:<componentnamesubsec>?
+               sortnames*:<sortnamesubsec>*
+namesubsection_N(B) ::= N:<byte> size:<u32> B     (if size == |B|)
+
+componentnamesubsec ::= namesubsection_0(<name>)
+sortnamesubsec ::= namesubsection_1(<sortnames>)
+sortnames ::= sort:<sort> names:<namemap>
+
+namemap ::= names:vec(<nameassoc>)
+nameassoc ::= idx:<u32> name:<name>
+```
+
+where `namemap` is the same as for core wasm. A particular `sort` should only
+appear once within a `name` section, for example component instances can only be
+named once.
+
 
 [`core:u32`]: https://webassembly.github.io/spec/core/binary/values.html#integers
 [`core:section`]: https://webassembly.github.io/spec/core/binary/modules.html#binary-section
@@ -325,31 +353,3 @@ Notes:
 [module-linking]: https://github.com/WebAssembly/module-linking/blob/main/proposals/module-linking/Explainer.md
 
 [Basic URL Parser]: https://url.spec.whatwg.org/#concept-basic-url-parser
-
-## Name Section
-
-Like the core wasm [name
-section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section)
-a similar `name` custom section is specified here for components to be able to
-name all the declarations that can happen within a component. Similarly like its
-core wasm counterpart validity of this custom section is not required and
-engines should not reject components which have an invalid `name` section.
-
-```
-namesec    ::= section_0(namedata)
-namedata   ::= n:<name>                (if n = 'component-name')
-               name:<componentnamesubsec>?
-               decls*:<declnamesubsec>*
-namesubsection_N(B) ::= N:<byte> size:<u32> B     (if size == |B|)
-
-componentnamesubsec ::= namesubsection_0(<name>)
-declnamesubsec ::= namesubsection_1(<declnames>)
-declnames ::= sort:<sort> names:<namemap>
-
-namemap ::= names:vec(<nameassoc>)
-nameassoc ::= idx:<u32> name:<name>
-```
-
-where `namemap` is the same as for core wasm. A particular `sort` should only
-appear once within a `name` section, for example component instances can only be
-named once.

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -339,7 +339,8 @@ engines should not reject components which have an invalid `name` section.
 namesec    ::= section_0(namedata)
 namedata   ::= n:<name>                (if n = 'name')
                sections*:<subsection>*
-subsection ::= sort:<sort> names:<namemap>
+subsection ::= sort:<sort> namesubsection(<namemap>)
+namesubsection(B) ::= size:<u32> B     (if size == |B|)
 
 namemap ::= names:vec(<nameassoc>)
 nameassoc ::= idx:<u32> name:<name>

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -339,32 +339,7 @@ engines should not reject components which have an invalid `name` section.
 namesec    ::= section_0(namedata)
 namedata   ::= n:<name>                (if n = 'name')
                sections*:<subsection>*
-subsection ::= 0x00 0x00 funcs:<corefuncsubsec>
-               0x00 0x01 tables:<coretablesubsec>
-               0x00 0x02 memories:<corememorysubsec>
-               0x00 0x03 globals:<coreglobalsubsec>
-               0x00 0x10 types:<coretypesubsec>
-               0x00 0x11 modules:<coremodulesubsec>
-               0x00 0x12 instances:<coreinstancesubsec>
-               0x01 funcs:<funcsubsec>
-               0x02 values:<valuesubsec>
-               0x03 types:<typesubsec>
-               0x04 components:<componentsubsec>
-               0x05 instances:<instancesubsec>
-
-corefuncsubsec ::= map:<namemap>
-coretablesubsec ::= map:<namemap>
-corememorysubsec ::= map:<namemap>
-coreglobalsubsec ::= map:<namemap>
-coretypesubsec ::= map:<namemap>
-coremodulesubsec ::= map:<namemap>
-coreinstancesubsec ::= map:<namemap>
-
-funcsubsec ::= map:<namemap>
-valuesubsec ::= map:<namemap>
-typesubsec ::= map:<namemap>
-componentsubsec ::= map:<namemap>
-instancesubsec ::= map:<namemap>
+subsection ::= sort:<sort> names:<namemap>
 
 namemap ::= names:vec(<nameassoc>)
 nameassoc ::= idx:<u32> name:<name>

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -325,3 +325,51 @@ Notes:
 [module-linking]: https://github.com/WebAssembly/module-linking/blob/main/proposals/module-linking/Explainer.md
 
 [Basic URL Parser]: https://url.spec.whatwg.org/#concept-basic-url-parser
+
+## Name Section
+
+Like the core wasm [name
+section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section)
+a similar `name` custom section is specified here for components to be able to
+name all the declarations that can happen within a component. Similarly like its
+core wasm counterpart validity of this custom section is not required and
+engines should not reject components which have an invalid `name` section.
+
+```
+namesec    ::= section_0(namedata)
+namedata   ::= n:<name>                (if n = 'name')
+               sections*:<subsection>*
+subsection ::= 0x00 0x00 funcs:<corefuncsubsec>
+               0x00 0x01 tables:<coretablesubsec>
+               0x00 0x02 memories:<corememorysubsec>
+               0x00 0x03 globals:<coreglobalsubsec>
+               0x00 0x10 types:<coretypesubsec>
+               0x00 0x11 modules:<coremodulesubsec>
+               0x00 0x12 instances:<coreinstancesubsec>
+               0x01 funcs:<funcsubsec>
+               0x02 values:<valuesubsec>
+               0x03 types:<typesubsec>
+               0x04 components:<componentsubsec>
+               0x05 instances:<instancesubsec>
+
+corefuncsubsec ::= map:<namemap>
+coretablesubsec ::= map:<namemap>
+corememorysubsec ::= map:<namemap>
+coreglobalsubsec ::= map:<namemap>
+coretypesubsec ::= map:<namemap>
+coremodulesubsec ::= map:<namemap>
+coreinstancesubsec ::= map:<namemap>
+
+funcsubsec ::= map:<namemap>
+valuesubsec ::= map:<namemap>
+typesubsec ::= map:<namemap>
+componentsubsec ::= map:<namemap>
+instancesubsec ::= map:<namemap>
+
+namemap ::= names:vec(<nameassoc>)
+nameassoc ::= idx:<u32> name:<name>
+```
+
+where `namemap` is the same as for core wasm. A particular `sort` should only
+appear once within a `name` section, for example component instances can only be
+named once.

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -337,7 +337,7 @@ engines should not reject components which have an invalid `name` section.
 
 ```
 namesec    ::= section_0(namedata)
-namedata   ::= n:<name>                (if n = 'name')
+namedata   ::= n:<name>                (if n = 'component-name')
                name:<componentnamesubsec>?
                decls*:<declnamesubsec>*
 namesubsection_N(B) ::= N: byte size:<u32> B     (if size == |B|)


### PR DESCRIPTION
This is intended to assist with debugging/reading/writing the text format of components by avoiding the need to have everything be numbers and allowing tools to annotate names of items optionally (or have the names preserved from the text format).

Closes #14