### PR TITLE
Add resource, own and borrow types

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -260,7 +260,7 @@ Notes:
 * Validation rejects `resourcetype` type definitions inside `componenttype` and
   `instancettype`. Thus, handle types inside a `componenttype` can only refer
   to resource types that are imported or exported.
-* Validation requires the all types used in the type of an export are introduced
+* Validation requires all types used in the type of an export are introduced
   by an `exportdecl` (not an `importdecl`).
 * The uniqueness validation rules for `externname` described below are also
   applied at the instance- and component-type level.

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -260,8 +260,8 @@ Notes:
 * Validation rejects `resourcetype` type definitions inside `componenttype` and
   `instancettype`. Thus, handle types inside a `componenttype` can only refer
   to resource types that are imported or exported.
-* Validation requires all types used in the type of an export are introduced
-  by an `exportdecl` (not an `importdecl`).
+* Validation requires that all resource types transitively used in the type of an
+  export are introduced by a preceding `exportdecl`.
 * The uniqueness validation rules for `externname` described below are also
   applied at the instance- and component-type level.
 * Validation of `externdesc` requires the various `typeidx` type constructors
@@ -334,8 +334,8 @@ URL        ::= b*:vec(byte)                    => char(b)*, if char(b)* parses a
 Notes:
 * All exports (of all `sort`s) introduce a new index that aliases the exported
   definition and can be used by all subsequent definitions just like an alias.
-* Validation requires that any handle type that is part of the type of any
-  export must refer to a resource type whose index was produced by an `export`.
+* Validation requires that all resource types transitively used in the type of an
+  export are introduced by a preceding `exportdecl`.
 * The "parses as a URL" condition is defined by executing the [basic URL
   parser] with `char(b)*` as *input*, no optional parameters and non-fatal
   validation errors (which coincides with definition of `URL` in JS and `rust-url`).

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -80,8 +80,12 @@ sort                ::= 0x00 cs:<core:sort>                                => co
                       | 0x05                                               => instance
 inlineexport        ::= n:<name> si:<sortidx>                              => (export n si)
 name                ::= len:<u32> n:<name-chars>                           => n (if len = |n|)
-name-chars          ::= w:<word>                                           => w
-                      | n:<name> 0x2d w:<word>                             => n-w
+name-chars          ::= l:<label>                                          => l
+                      | '[constructor]' r:<label>                          => [constructor]r
+                      | '[method]' r:<label> '.' m:<label>                 => [method]r.m
+                      | '[static]' r:<label> '.' s:<label>                 => [static]r.s
+label               ::= w:<word>                                           => w
+                      | l:<label> '-' w:<word>                             => l-w
 word                ::= w:[0x61-0x7a] x*:[0x30-0x39,0x61-0x7a]*            => char(w)char(x)*
                       | W:[0x41-0x5a] X*:[0x30-0x39,0x41-0x5a]*            => char(W)char(X)*
 ```
@@ -99,8 +103,21 @@ Notes:
   sort, but would be extended to accept other sorts as core wasm is extended.
 * Validation of `instantiate` requires that `name` is present in an
   `externname` of `c` (with a matching type).
+* When validating `instantiate`, after each individual type-import is supplied
+  via `with`, the actual type supplied is immediately substituted for all uses
+  of the import, so that subsequent imports and all exports are now specialized
+  to the actual type.
 * The indices in `sortidx` are validated according to their `sort`'s index
   spaces, which are built incrementally as each definition is validated.
+* Validation requires that all annotated `name`s only occur on `func` `export`s
+  and that the `r` `label` matches the `name` of a preceding `resource` export.
+* Validation of `[constructor]` names requires that the `func` returns a
+  `(result (own $R))`, where `$R` is the resource labeled `r`.
+* Validation of `[method]` names requires the first parameter of the function
+  to be `(param "self" (borrow $R))`, where `$R` is the resource labeled `r`.
+* Validation of `[method]` and `[static]` names ensures that all field names
+  are disjoint.
+
 
 ## Alias Definitions
 
@@ -120,7 +137,8 @@ Notes:
   index in the `sort` index space of the `i`th enclosing component (counting
   outward, starting with `0` referring to the current component).
 * For `outer` aliases, validation restricts the `sort` to one
-  of `type`, `module` or `component`.
+  of `type`, `module` or `component` and additionally requires that the
+  outer-aliased type is not a `resource` type (which is generative).
 
 
 ## Type Definitions
@@ -174,25 +192,28 @@ primvaltype   ::= 0x7f                                    => bool
                 | 0x74                                    => char
                 | 0x73                                    => string
 defvaltype    ::= pvt:<primvaltype>                       => pvt
-                | 0x72 nt*:vec(<namedvaltype>)            => (record (field nt)*)
+                | 0x72 lt*:vec(<labelvaltype>)            => (record (field lt)*)
                 | 0x71 case*:vec(<case>)                  => (variant case*)
                 | 0x70 t:<valtype>                        => (list t)
                 | 0x6f t*:vec(<valtype>)                  => (tuple t*)
-                | 0x6e n*:vec(<name>)                     => (flags n*)
-                | 0x6d n*:vec(<name>)                     => (enum n*)
+                | 0x6e l*:vec(<label>)                    => (flags l*)
+                | 0x6d l*:vec(<label>)                    => (enum l*)
                 | 0x6c t*:vec(<valtype>)                  => (union t*)
                 | 0x6b t:<valtype>                        => (option t)
                 | 0x6a t?:<valtype>? u?:<valtype>?        => (result t? (error u)?)
-namedvaltype  ::= n:<name> t:<valtype>                    => n t
-case          ::= n:<name> t?:<valtype>? r?:<u32>?        => (case n t? (refines case-label[r])?)
+                | 0x69 i:<typeidx>                        => (own i)
+                | 0x68 i:<typeidx>                        => (borrow i)
+labelvaltype  ::= l:<label> t:<valtype>                   => l t
+case          ::= l:<label> t?:<valtype>? r?:<u32>?       => (case l t? (refines case-label[r])?)
 <T>?          ::= 0x00                                    =>
                 | 0x01 t:<T>                              => t
 valtype       ::= i:<typeidx>                             => i
                 | pvt:<primvaltype>                       => pvt
+resourcetype  ::= 0x3f 0x7f f?:<funcidx>?                 => (resource (rep i32) (dtor f)?)
 functype      ::= 0x40 ps:<paramlist> rs:<resultlist>     => (func ps rs)
-paramlist     ::= nt*:vec(<namedvaltype>)                 => (param nt)*
+paramlist     ::= lt*:vec(<labelvaltype>)                 => (param lt)*
 resultlist    ::= 0x00 t:<valtype>                        => (result t)
-                | 0x01 nt*:vec(<namedvaltype>)            => (result nt)*
+                | 0x01 lt*:vec(<labelvaltype>)            => (result lt)*
 componenttype ::= 0x41 cd*:vec(<componentdecl>)           => (component cd*)
 instancetype  ::= 0x42 id*:vec(<instancedecl>)            => (instance id*)
 componentdecl ::= 0x03 id:<importdecl>                    => id
@@ -210,17 +231,37 @@ externdesc    ::= 0x00 0x11 i:<core:typeidx>              => (core module (type 
                 | 0x04 i:<typeidx>                        => (instance (type i))
                 | 0x05 i:<typeidx>                        => (component (type i))
 typebound     ::= 0x00 i:<typeidx>                        => (eq i)
+                | 0x01                                    => (sub resource)
 ```
 Notes:
 * The type opcodes follow the same negative-SLEB128 scheme as Core WebAssembly,
   with type opcodes starting at SLEB128(-1) (`0x7f`) and going down,
   reserving the nonnegative SLEB128s for type indices.
 * Validation of `valtype` requires the `typeidx` to refer to a `defvaltype`.
-* Validation of `instancedecl` (currently) only allows `outer` `type` `alias`
-  declarators.
+* Validation of `own` and `borrow` requires the `typeidx` to refer to a
+  resource type.
+* Validation only allows `borrow` to be used inside the `param` of a `functype`.
+  (This is likely to change in a future PR, converting `functype` into a
+  compound type constructor analogous to `moduletype` and `componenttype` and
+  using scoping to enforce this constraint instead.)
+* Validation of `resourcetype` requires the destructor (if present) to have
+  type `[i32] -> []`.
+* Validation of `instancedecl` (currently) only allows the `type` and
+  `instance` sorts in `alias` declarators.
 * As described in the explainer, each component and instance type is validated
   with an initially-empty type index space. Outer aliases can be used to pull
   in type definitions from containing components.
+* `exportdecl` introduces a new type index that can be used by subsequent type
+  definitions. In the `(eq i)` case, the new type index is effectively an alias
+  to type `i`. In the `(sub resource)` case, the new type index refers to a
+  *fresh* abstract type unequal to every existing type in all existing type
+  index spaces. (Note: *subsequent* aliases can introduce new type indices
+  equivalent to this fresh type.)
+* Validation rejects `resourcetype` type definitions inside `componenttype` and
+  `instancettype`. Thus, handle types inside a `componenttype` can only refer
+  to resource types that are imported or exported.
+* Validation requires the all types used in the type of an export are introduced
+  by an `exportdecl` (not an `importdecl`).
 * The uniqueness validation rules for `externname` described below are also
   applied at the instance- and component-type level.
 * Validation of `externdesc` requires the various `typeidx` type constructors
@@ -239,6 +280,9 @@ Notes:
 ```
 canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift f opts type-index-space[ft])
            | 0x01 0x00 f:<funcidx> opts:<opts>                   => (canon lower f opts (core func))
+           | 0x02 t:<typeidx>                                    => (canon resource.new t (core func))
+           | 0x03 t:<valtype>                                    => (canon resource.drop t (core func))
+           | 0x04 t:<typeidx>                                    => (canon resource.rep t (core func))
 opts     ::= opt*:vec(<canonopt>)                                => opt*
 canonopt ::= 0x00                                                => string-encoding=utf8
            | 0x01                                                => string-encoding=utf16
@@ -251,20 +295,8 @@ Notes:
 * The second `0x00` byte in `canon` stands for the `func` sort and thus the
   `0x00 <u32>` pair standards for a `func` `sortidx` or `core:sortidx`.
 * Validation prevents duplicate or conflicting `canonopt`.
-* Validation of `canon lift` requires `f` to have type `flatten(ft)` (defined
-  by the [Canonical ABI](CanonicalABI.md#flattening)). The function being
-  defined is given type `ft`.
-* Validation of `canon lower` requires `f` to be a component function. The
-  function being defined is given core function type `flatten(ft)` where `ft`
-  is the `functype` of `f`.
-* If the lifting/lowering operations implied by `lift` or `lower` require
-  access to `memory` or `realloc`, then validation requires these options to be
-  present. If present, `realloc` must have core type
-  `(func (param i32 i32 i32 i32) (result i32))`.
-* The `post-return` option is only valid for `canon lift` and it is always
-  optional; if present, it must have core type `(func (param ...))` where the
-  number and types of the parameters must match the results of the core function
-  being lifted and itself have no result values.
+* Validation of the individual canonical definitions is described in
+  [`CanonicalABI.md`](CanonicalABI.md#canonical-definitions).
 
 
 ## Start Definitions
@@ -300,6 +332,10 @@ externname ::= n:<name> u?:<URL>?              => n u?
 URL        ::= b*:vec(byte)                    => char(b)*, if char(b)* parses as a URL
 ```
 Notes:
+* All exports (of all `sort`s) introduce a new index that aliases the exported
+  definition and can be used by all subsequent definitions just like an alias.
+* Validation requires that any handle type that is part of the type of any
+  export must refer to a resource type whose index was produced by an `export`.
 * The "parses as a URL" condition is defined by executing the [basic URL
   parser] with `char(b)*` as *input*, no optional parameters and non-fatal
   validation errors (which coincides with definition of `URL` in JS and `rust-url`).

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -18,6 +18,9 @@ of modules in Core WebAssembly.
 * [Canonical definitions](#canonical-definitions)
   * [`canon lift`](#canon-lift)
   * [`canon lower`](#canon-lower)
+  * [`canon resource.new`](#canon-resourcenew)
+  * [`canon resource.drop`](#canon-resourcedrop)
+  * [`canon resource.rep`](#canon-resourcerep)
 * [Canonical ABI](#canonical-abi)
   * [Canonical Module Type](#canonical-module-type)
   * [Lifting Canonical Modules](#lifting-canonical-modules)
@@ -104,6 +107,7 @@ def alignment(t):
     case Record(fields)     : return alignment_record(fields)
     case Variant(cases)     : return alignment_variant(cases)
     case Flags(labels)      : return alignment_flags(labels)
+    case Own(_) | Borrow(_) : return 4
 ```
 
 Record alignment is tuple alignment, with the definitions split for reuse below:
@@ -152,6 +156,9 @@ def alignment_flags(labels):
   return 4
 ```
 
+Handle types are passed as `i32` indices into the `HandleTable` introduced
+below.
+
 
 ### Size
 
@@ -172,6 +179,7 @@ def size(t):
     case Record(fields)     : return size_record(fields)
     case Variant(cases)     : return size_variant(cases)
     case Flags(labels)      : return size_flags(labels)
+    case Own(_) | Borrow(_) : return 4
 
 def size_record(fields):
   s = 0
@@ -213,6 +221,7 @@ definitions via the `cx` parameter:
 class Context:
   opts: CanonicalOptions
   inst: ComponentInstance
+  call: Call
   called_as_export: bool
 ```
 
@@ -231,18 +240,201 @@ canonical definition is defined to execute inside. The `may_enter` and
 `may_leave` fields are used to enforce the [component invariants]: `may_leave`
 indicates whether the instance may call out to an import and the `may_enter`
 state indicates whether the instance may be called from the outside world
-through an export.
+through an export. The `HandleTable` is defined next.
 ```python
 class ComponentInstance:
   may_leave = True
   may_enter = True
-  # ...
+  handles: HandleTable
+
+  def __init__(self):
+    handles = HandleTable()
 ```
 
-Lastly, the `called_as_export` field indicates whether the lifted function is
-being called through a component export or whether this is an internal call,
-(for example, when a child component calls an import that is defined by its
-parent component).
+Lastly, the `called_as_export` field of `Context` indicates whether the lifted
+function is being called through a component export or whether this is an
+internal call (for example, when a child component calls an import that is
+defined by its parent component).
+
+The `HandleTable` class is defined in terms of a collection of supporting
+runtime bookkeeping classes that we'll go through first.
+
+The `Resource` class represents a runtime instance of a resource type:
+```python
+class Resource:
+  t: ResourceType
+  rep: int
+  borrowers: MutableMapping[ComponentInstance, int]
+
+  def __init__(self, t, rep):
+    self.t = t
+    self.rep = rep
+    self.borrowers = {}
+```
+The `t` field points to the [`resourcetype`](Explainer.md#type-definitions)
+used to create this `Resource` and is used to perform dynamic type checking
+below. Next, `rep` is the core representation of this `Resource` which is
+currently fixed to `i32` as described in the Explainer. Lastly, `borrowers` is
+a list of component instances that currently hold a `borrow` handle along with
+the index of this `borrow` handle in the `HandleTable`. This map is used to
+deduplicate `borrow` handles, preserving the invariant that a component
+instance contains *at most one* handle referring to a particular `Resource`.
+While the map here is a Python dictionary, using static analysis of the flow of
+resource types throughout a component instance DAG, an AOT compiler can
+alternatively implement `borrowers` with a fixed-size array embedded directly
+in the resource, assigning a static index to each potential client instance in
+the DAG.
+
+The `OwnHandle` and `BorrowHandle` classes represent runtime handle values of
+`own` and `borrow` type, resp:
+```python
+class Handle:
+  resource: Resource
+  lend_count: int
+
+  def __init__(self, resource):
+    self.resource = resource
+    self.lend_count = 0
+
+class OwnHandle(Handle): pass
+class BorrowHandle(Handle): pass
+```
+The `resource` field points to the resource instance this handle refers to. The
+`lend_count` field maintains a count of the outstanding handles that were lent
+from this handle (by calls to `borrow`-taking functions). This count is used
+below to dynamically enforce the invariant that a handle cannot be dropped
+while it has currently lent out a `borrow`.
+
+The `Call` class represents a single runtime call (activation) of a
+component-level function. A `Call` is finished in two steps by `finish_lift`
+and `finish_lower`, which are called at the end of `canon lift` and
+`canon lower`, resp.
+```python
+class Call:
+  borrow_count: int
+  lenders: [OwnHandle]
+
+  def __init__(self):
+    self.borrow_count = 0
+    self.lenders = []
+
+  def finish_lift(self):
+    trap_if(self.borrow_count != 0)
+
+  def finish_lower(self):
+    assert(self.borrow_count == 0)
+    for h in self.lenders:
+      h.lend_count -= 1
+```
+The `borrow_count` field tracks the number of outstanding `borrow` handles that
+were lent out for the duration of this call, trapping when the call finishes if
+there are any un-dropped `borrow` handles. The `lenders` field maintains a list
+of `own` handles that have lent out a `borrow` handle for the duration of the
+call. In an optimizing implementation, a `Call` can be stored directly on the
+stack with a layout specialized to the function signature which allows a
+fixed-size inline `lenders` list in the common case.
+
+`Call` objects serve as an intermediate reference point for both the caller and
+callee: the caller keeps lent resources alive *at least as long* as the `Call`;
+the callee holds on to borrowed resources *at most as long* as the `Call`. This
+decoupling ensures that when *exactly* the callee drops a borrowed handle isn't
+observable to the caller thereby avoiding implicit, non-contractual ordering
+dependencies.
+
+Based on these supporting runtime data structures, we can define the
+`HandleTable` in pieces, starting with its fields and the `insert` method:
+```python
+class HandleTable:
+  array: [Optional[Handle]]
+  free: [int]
+
+  def __init__(self):
+    self.array = []
+    self.free = []
+
+  def insert(self, cx, h):
+    match h:
+      case OwnHandle():
+        assert(len(h.resource.borrowers) == 0)
+      case BorrowHandle():
+        if cx.inst in h.resource.borrowers:
+          return h.resource.borrowers[cx.inst]
+
+    if self.free:
+      i = self.free.pop()
+      assert(self.array[i] is None)
+      self.array[i] = h
+    else:
+      i = len(self.array)
+      self.array.append(h)
+
+    if isinstance(h, BorrowHandle):
+      h.resource.borrowers[cx.inst] = i
+      cx.call.borrow_count += 1
+    return i
+```
+The `HandleTable` class maintains a dense array of handles that can contain
+holes created by the `remove` method (defined below). These holes are kept
+in a separate Python list here, but an optimizing implementation could instead
+store the free list in the free elements of `array`. When inserting a new
+handle, `HandleTable` first consults the `free` list, which is popped LIFO to
+better detect use-after-free bugs in the guest code. The `insert` method
+uses the `Handle.borrowers` map to deduplicate borrowed handles. For
+non-deduplicated handles, `insert` increments `Call.borrow_count` to guard that
+this handle has been dropped by the end of the call.
+
+The `get` method is used by other `HandleTable` methods and canonical
+definitions below and uses dynamic guards to catch out-of-bounds and
+use-after-free:
+```python
+  def get(self, i, rt):
+    trap_if(i >= len(self.array))
+    trap_if(self.array[i] is None)
+    trap_if(self.array[i].resource.t is not rt)
+    return self.array[i]
+```
+Additionally, the `get` method takes the runtime resource type tag and checks
+a tag match before returning the handle with this new-valid resource type. Note
+that this is a non-structural, pointer-equality-based check to implement the
+[type-checking rules](Explainer.md) of resource types.
+
+The `lend` method is called when borrowing a handle. `lend` uses `Call.lenders`
+to decrement the handle's `lend_count` at the end of the call.
+```python
+  def lend(self, cx, i, rt):
+    h = self.get(i, rt)
+    h.lend_count += 1
+    cx.call.lenders.append(h)
+    return h
+```
+
+Finally, the `remove` method is used when dropping or transferring a handle
+out of the handle table. `remove` adds the removed handle to the `free` list
+for later recycling by `insert` (above).
+```python
+  def remove(self, cx, i, t):
+    h = self.get(i, t.rt)
+    trap_if(h.lend_count != 0)
+    match t:
+      case Own(_):
+        trap_if(not isinstance(h, OwnHandle))
+        assert(len(h.resource.borrowers) == 0)
+      case Borrow(_):
+        trap_if(not isinstance(h, BorrowHandle))
+        cx.call.borrow_count -= 1
+        del h.resource.borrowers[cx.inst]
+    self.array[i] = None
+    self.free.append(i)
+    return h
+```
+The `lend_count` guard ensures that no dangling borrows are created when
+destroying a resource. Because `remove` is used for cross-component transfer
+of `own` handles (via `lift_own` below), this `lend_count` guard ensures that
+when a component receives an `own`, it receives a unique reference to the
+resource and that there aren't any dangling borrows hanging around from the
+previous owner. The bookkeeping performed by `remove` for borrowed handles
+records the fulfillment of the obligation of the borrower to drop the handle
+before the end of the call.
 
 
 ### Loading
@@ -273,6 +465,8 @@ def load(cx, ptr, t):
     case Record(fields) : return load_record(cx, ptr, fields)
     case Variant(cases) : return load_variant(cx, ptr, cases)
     case Flags(labels)  : return load_flags(cx, ptr, labels)
+    case Own(_)         : return lift_own(cx, load_int(opts, ptr, 4), t)
+    case Borrow(_)      : return lift_borrow(cx, load_int(opts, ptr, 4), t)
 ```
 
 Integers are loaded directly from memory, with their high-order bit interpreted
@@ -433,7 +627,7 @@ def find_case(label, cases):
   return -1
 ```
 
-Finally, flags are converted from a bit-vector to a dictionary whose keys are
+Flags are converted from a bit-vector to a dictionary whose keys are
 derived from the ordered labels of the `flags` type. The code here takes
 advantage of Python's support for integers of arbitrary width.
 ```python
@@ -448,6 +642,23 @@ def unpack_flags_from_int(i, labels):
     i >>= 1
   return record
 ```
+
+Finally, `own` and `borrow` handles are lifted by loading their referenced resources
+out of the current component instance's handle table:
+```python
+def lift_own(cx, i, t):
+  h = cx.inst.handles.remove(cx, i, t)
+  return h.resource
+
+def lift_borrow(cx, i, t):
+  h = cx.inst.handles.lend(cx, i, t.rt)
+  return h.resource
+```
+The `remove` method is used in `lift_own` and thus passing an `own` handle
+across a component boundary transfers ownership. Note that `remove` checks
+*both* the resource type tag *and* that the indexed handle is an `OwnHandle`
+while `lend` only checks the resource type, thereby allowing both handle types.
+
 
 ### Storing
 
@@ -476,6 +687,8 @@ def store(cx, v, t, ptr):
     case Record(fields) : store_record(cx, v, ptr, fields)
     case Variant(cases) : store_variant(cx, v, ptr, cases)
     case Flags(labels)  : store_flags(cx, v, ptr, labels)
+    case Own(rt)        : store_int(cx, lower_own(opts, v, rt), ptr, 4)
+    case Borrow(rt)     : store_int(cx, lower_borrow(opts, v, rt), ptr, 4)
 ```
 
 Integers are stored directly into memory. Because the input domain is exactly
@@ -765,7 +978,7 @@ def match_case(v, cases):
       return (case_index, value)
 ```
 
-Finally, flags are converted from a dictionary to a bit-vector by iterating
+Flags are converted from a dictionary to a bit-vector by iterating
 through the case-labels of the variant in the order they were listed in the
 type definition and OR-ing all the bits together. Flag lifting/lowering can be
 statically fused into array/integer operations (with a simple byte copy when
@@ -784,6 +997,21 @@ def pack_flags_into_int(v, labels):
     shift += 1
   return i
 ```
+
+Finally, `own` and `borrow` handles are lowered by inserting them into the
+current component instance's `HandleTable`:
+```python
+def lower_own(cx, resource, rt):
+  assert(resource.t is rt)
+  h = OwnHandle(resource)
+  return cx.inst.handles.insert(cx, h)
+
+def lower_borrow(cx, resource, rt):
+  assert(resource.t is rt)
+  h = BorrowHandle(resource)
+  return cx.inst.handles.insert(cx, h)
+```
+The assertions are ensured by validation.
 
 ### Flattening
 
@@ -852,6 +1080,7 @@ def flatten_type(t):
     case Record(fields)       : return flatten_record(fields)
     case Variant(cases)       : return flatten_variant(cases)
     case Flags(labels)        : return ['i32'] * num_i32_flags(labels)
+    case Own(_) | Borrow(_)   : return ['i32']
 ```
 
 Record flattening simply flattens each field in sequence.
@@ -931,6 +1160,8 @@ def lift_flat(cx, vi, t):
     case Record(fields) : return lift_flat_record(cx, vi, fields)
     case Variant(cases) : return lift_flat_variant(cx, vi, cases)
     case Flags(labels)  : return lift_flat_flags(vi, labels)
+    case Own(_)         : return lift_own(cx, vi.next('i32'), t)
+    case Borrow(_)      : return lift_borrow(cx, vi.next('i32'), t)
 ```
 
 Integers are lifted from core `i32` or `i64` values using the signedness of the
@@ -1053,6 +1284,8 @@ def lower_flat(cx, v, t):
     case Record(fields) : return lower_flat_record(cx, v, fields)
     case Variant(cases) : return lower_flat_variant(cx, v, cases)
     case Flags(labels)  : return lower_flat_flags(v, labels)
+    case Own(rt)        : return [Value('i32', lower_own(cx, v, rt))]
+    case Borrow(rt)     : return [Value('i32', lower_borrow(cx, v, rt))]
 ```
 
 Since component-level values are assumed in-range and, as previously stated,
@@ -1175,10 +1408,7 @@ def lower_values(cx, max_flat, vs, ts, out_param = None):
 
 Using the above supporting definitions, we can describe the static and dynamic
 semantics of component-level [`canon`] definitions. The following subsections
-cover each of these `canon` cases (which will soon be
-extended to include [async](https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE/edit#slide=id.g13600a23b7f_16_0)
-and [resource/handle](https://github.com/alexcrichton/interface-types/blob/40f157ad429772c2b6a8b66ce7b4df01e83ae76d/proposals/interface-types/CanonicalABI.md#handle-intrinsics)
-built-ins).
+cover each of these `canon` cases.
 
 ### `canon lift`
 
@@ -1194,7 +1424,7 @@ validation specifies:
 * if a `post-return` is present, it has type `(func (param flatten($ft)['results']))`
 
 When instantiating component instance `$inst`:
-* Define `$f` to be the closure `lambda args: canon_lift(Context($opts, $inst), $callee, $ft, args)`
+* Define `$f` to be the closure `lambda call, args: canon_lift(Context($opts, $inst), $callee, $ft, call, args)`
 
 Thus, `$f` captures `$opts`, `$inst`, `$callee` and `$ft` in a closure which
 can be subsequently exported or passed into a child instance (via `with`). If
@@ -1212,12 +1442,15 @@ component*.
 
 Given the above closure arguments, `canon_lift` is defined:
 ```python
-def canon_lift(cx, callee, ft, args):
+def canon_lift(cx, callee, ft, call, args):
   if cx.called_as_export:
     trap_if(not cx.inst.may_enter)
     cx.inst.may_enter = False
   else:
     assert(not cx.inst.may_enter)
+
+  outer_call = cx.call
+  cx.call = call
 
   assert(cx.inst.may_leave)
   cx.inst.may_leave = False
@@ -1230,11 +1463,16 @@ def canon_lift(cx, callee, ft, args):
     trap()
 
   results = lift_values(cx, MAX_FLAT_RESULTS, ValueIter(flat_results), ft.result_types())
+
   def post_return():
     if cx.opts.post_return is not None:
       cx.opts.post_return(flat_results)
+
     if cx.called_as_export:
       cx.inst.may_enter = True
+
+    cx.call.finish_lift()
+    cx.call = outer_call
 
   return (results, post_return)
 ```
@@ -1252,6 +1490,11 @@ because `may_enter` is not cleared on the exceptional exit path taken by
 `trap()`, if there is a trap during Core WebAssembly execution of lifting or
 lowering, the component is left permanently un-enterable, ensuring the
 lockdown-after-trap [component invariant].
+
+The `call` parameter is assumed to have been created by the caller (the host or
+`canon lower`) for this one call. Since, in `not cx.called_as_export` scenarios
+a single component instance may be reentered (by its children), `cx.call` must
+save-and-restore a possible outer `Call` during an inner call.
 
 The contract assumed by `canon_lift` (and ensured by `canon_lower` below) is
 that the caller of `canon_lift` *must* call `post_return` right after lowering
@@ -1272,7 +1515,7 @@ where `$callee` has type `$ft`, validation specifies:
 * there is no `post-return` in `$opts`
 
 When instantiating component instance `$inst`:
-* Define `$f` to be the closure: `lambda args: canon_lower(Context($opts, $inst), $callee, $ft, args)`
+* Define `$f` to be the closure: `lambda call, args: canon_lower(Context($opts, $inst), $callee, $ft, call, args)`
 
 Thus, from the perspective of Core WebAssembly, `$f` is a [function instance]
 containing a `hostfunc` that closes over `$opts`, `$inst`, `$callee` and `$ft`
@@ -1281,16 +1524,22 @@ and, when called from Core WebAssembly code, calls `canon_lower`, which is defin
 def canon_lower(cx, callee, ft, flat_args):
   trap_if(not cx.inst.may_leave)
 
+  outer_call = cx.call
+  cx.call = Call()
+
   flat_args = ValueIter(flat_args)
   args = lift_values(cx, MAX_FLAT_PARAMS, flat_args, ft.param_types())
 
-  results, post_return = callee(args)
+  results, post_return = callee(cx.call, args)
 
   cx.inst.may_leave = False
   flat_results = lower_values(cx, MAX_FLAT_RESULTS, results, ft.result_types(), flat_args)
   cx.inst.may_leave = True
 
   post_return()
+
+  cx.call.finish_lower()
+  cx.call = outer_call
 
   return flat_results
 ```
@@ -1322,6 +1571,67 @@ are technically allowed by the above rules (and may arise unintentionally in
 component reexport scenarios). Such cases can be statically distinguished by
 the AOT compiler as requiring an intermediate copy to implement the above
 `lift`-then-`lower` semantics.
+
+
+### `canon resource.new`
+
+For a canonical definition:
+```
+(canon resource.new $t (core func $f))
+```
+validation specifies:
+* `$t` must refer to locally-defined (not imported) resource type `$rt`
+* `$f` is given type `(func (param $rt.rep) (result i32))`, where `$rt.rep` is
+  currently fixed to be `i32`.
+
+Calling `$f` invokes the following function, which creates a resource object
+and inserts it into the current instance's handle table:
+```python
+def canon_resource_new(cx, rt, rep):
+  h = OwnHandle(Resource(rt, rep))
+  return cx.inst.handles.insert(cx, h)
+```
+
+### `canon resource.drop`
+
+For a canonical definition:
+```
+(canon resource.drop $t (core func $f))
+```
+validation specifies:
+* `$t` must refer to a handle type `(own $rt)` or `(borrow $rt)`
+* `$f` is given type `(func (param i32))`
+
+Calling `$f` invokes the following function, which removes a handle guarded to
+be of type `$t` from the handle table and then, for an `own` handle, calls the
+optional destructor.
+```python
+def canon_resource_drop(cx, t, i):
+  h = cx.inst.handles.remove(cx, i, t)
+  if isinstance(t, Own) and t.rt.dtor:
+    t.rt.dtor(h.resource.rep)
+```
+
+### `canon resource.rep`
+
+For a canonical definition:
+```
+(canon resource.rep $t (core func $f))
+```
+validation specifies:
+* `$t` must refer to a locally-defined (not imported) resource type `$rt`
+* `$f` is given type `(func (param i32) (result $rt.rep))`, where `$rt.rep` is
+  currently fixed to be `i32`.
+
+Calling `$f` invokes the following function, which extracts the core
+representation of the indexed handle after checking that the resource type
+matches. Note that the "locally-defined" requirement above ensures that only
+the component instance defining a resource can access its representation.
+```python
+def canon_resource_rep(cx, rt, i):
+  h = cx.inst.handles.get(i, rt)
+  return h.resource.rep
+```
 
 
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -928,18 +928,21 @@ the fact that the underlying concrete type is the same is kept an encapsulated
 implementation detail. For example, in the following component:
 ```wasm
 (component
-  (component $C
-    (type $r (resource (rep i32)))
-    (export "r1" (type (sub $r)))
-    (export "r2" (type (sub $r)))
-  )
-  (instance $c (instantiate $C))
-  (type $r1 (alias export $c "r1"))
-  (type $r2 (alias export $c "r2"))
+  (type $r (resource (rep i32)))
+  (export "r1" (type (sub $r)))
+  (export "r2" (type (sub $r)))
 )
 ```
-The types `$r1` and `$r2` are unequal. These type-checking rules for
-type exports mirror the *introduction* rule of [existential types]  (∃T).
+Any client of this component will treat `r1` and `r2` as totally distinct
+types since this component definition has the `componenttype`:
+```wasm
+(component
+  (export "r1" (type (sub resource)))
+  (export "r2" (type (sub resource)))
+)
+```
+The assignment of this type to the above component mirrors the *introduction*
+rule of [existential types]  (∃T).
 
 When supplying a resource type (imported *or* defined) to a type import via
 `instantiate`, type checking performs a substitution, replacing all uses of the

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -837,23 +837,33 @@ the types `$T2` and `$T3` are equal to each other but not to `$T1`. By the
 above transitive structural equality rules, the types `$List2` and `$List3` are
 equal to each other but not to `$List1`.
 
-Handle types (`own` and `borrow`) are purely structural, but, since they refer
-to resource types, transitively "inherit" the freshness of abstract resource
-types. For example, in the following component:
+Handle types (`own` and `borrow`) are structural types (like `list`) but, since
+they refer to resource types, transitively "inherit" the freshness of abstract
+resource types. For example, in the following component:
 ```wasm
 (component
   (import "T" (type $T (sub resource)))
   (import "U" (type $U (sub resource)))
-  (type $Handle1 (own $T))
-  (type $Handle2 (own $T))
-  (type $Handle3 (own $U))
+  (type $Own1 (own $T))
+  (type $Own2 (own $T))
+  (type $Own3 (own $U))
+  (type $ListOwn1 (list $Own1))
+  (type $ListOwn2 (list $Own2))
+  (type $ListOwn3 (list $Own3))
+  (type $Borrow1 (borrow $T))
+  (type $Borrow2 (borrow $T))
+  (type $Borrow3 (borrow $U))
+  (type $ListBorrow1 (list $Borrow1))
+  (type $ListBorrow2 (list $Borrow2))
+  (type $ListBorrow3 (list $Borrow3))
 )
 ```
-the types `$Handle1` and `$Handle2` are equal to each other but not to
-`$Handle3`. Transitively, any types containing `$Handle1` or `$Handle2` are
-equal, such as a `(list $Handle1)` and `(list $Handle2)` or function types
-using handles in their parameters and results. These type-checking rules for
-type imports mirror the *introduction* rule of [universal types]  (∀T).
+the types `$Own1` and `$Own2` are equal to each other but not to `$Own3` or
+any of the `$Borrow*`.  Similarly, `$Borrow1` and `$Borrow2` are equal to
+each other but not `$Borrow3`. Transitively, the types `$ListOwn1` and
+`$ListOwn2` are equal to each other but not `$ListOwn3` or any of the
+`$ListBorrow*`. These type-checking rules for type imports mirror the
+*introduction* rule of [universal types]  (∀T).
 
 The above examples all show abstract types in terms of *imports*, but the same
 "freshness" condition applies when aliasing the *exports* of another component

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1006,7 +1006,7 @@ component is instantiated multiple times. In this case, a single resource type
 definition that is exported with a single `externname` will get a fresh type
 with each component instance, with the abstract typing rules mentioned above
 ensuring that each of the component's instance's resource types are kept
-distinct. Thus, in a sense, the generativity of resource types *generalize*
+distinct. Thus, in a sense, the generativity of resource types *generalizes*
 traditional name-based nominal typing, providing a finer granularity of
 isolation than otherwise achievable with a shared global namespace.
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -947,8 +947,7 @@ rule of [existential types]  (∃T).
 When supplying a resource type (imported *or* defined) to a type import via
 `instantiate`, type checking performs a substitution, replacing all uses of the
 `import` in the instantiated component with the actual type supplied via
-`with`. This means that, from the parent's point of view, the type imports stop
-being abstract. For example, the following component validates:
+`with`. For example, the following component validates:
 ```wasm
 (component $P
   (import "C1" (component $C1

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -752,10 +752,11 @@ example, in the following compound component:
     (type $ListListString3 (list $ListString3))
     (type $ListString4 (alias outer $A $ListString))
     (type $ListListString4 (list $ListString4))
+    (type $ListListString5 (alias outer $A $ListString2))
   )
 )
 ```
-all 4 variations of `$ListListStringX` are considered equal since, after
+all 5 variations of `$ListListStringX` are considered equal since, after
 decoding, they all have the same AST.
 
 Next, the type equality relation on ASTs is relaxed to a more flexible

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -883,13 +883,18 @@ the types `$T2` and `$T3` are equal to each other but not to `$T1`. These
 type-checking rules for aliases of type exports mirror the *elimination* rule
 of [existential types]  (∃T).
 
-Next, we consider resource type definitions, which are half-like abstract types
-in that they also produce a *fresh* type that is unequal to every preceding
-type. However, a resource type definition is **not** abstract; it has a
-concrete representation that is known to the containing component (and *only*
-the containing component). Thus, local resource type definitions are neither
-structural nor abstract: they are "[generative]". For example, in the following
-example component:
+Next, we consider resource type *definitions* which are a *third* source of
+abstract types. Unlike the abstract types introduced by type imports and
+exports, resource type definitions provide operations for setting and getting a
+resource's private representation value: `resource.new` and `resource.rep`
+(introduced [below](#canonical-built-ins)). However, these accessor operations
+are necessarily scoped to the component instance that generated the resource
+type, thereby hiding access to a resource type's representation from the outside
+world. Because each component instantiation generates fresh resource types
+distinct from all preceding instances of the same component, resource types are
+["generative"].
+
+For example, in the following example component:
 ```wasm
 (component
   (type $R1 (resource (rep i32)))
@@ -901,10 +906,9 @@ example component:
 the types `$R1` and `$R2` are unequal and thus the return type of `$f1`
 is incompatible with the parameter type of `$f2`.
 
-The generativity of resource type definitions is well-suited to the abstract
-typing rules of type exports mentioned above, which force all clients of the
-component to bind a fresh abstract type. For example, in the following
-component:
+The generativity of resource type definitions matches the abstract typing rules
+of type exports mentioned above, which force all clients of the component to
+bind a fresh abstract type. For example, in the following component:
 ```wasm
 (component
   (component $C
@@ -992,9 +996,9 @@ standard [avoidance problem] that appears in module systems with abstract
 types.
 
 In summary: all type constructors are *structural* with the exception of
-`resource`, which is *generative*. Type imports and exports that have a subtype
-bound are *abstract (resource) types* and follow the standard introduction and
-elimination rules of universal and existential types.
+`resource`, which is *abstract* and *generative*. Type imports and exports that
+have a subtype bound also introduce abstract types and follow the standard
+introduction and elimination rules of universal and existential types.
 
 Lastly, since "nominal" is often taken to mean "the opposite of structural", a
 valid question is whether any of the above "nominal typing". Inside a

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -996,25 +996,19 @@ In summary: all type constructors are *structural* with the exception of
 bound are *abstract (resource) types* and follow the standard introduction and
 elimination rules of universal and existential types.
 
-Lastly, since "nominal" is sometimes intended to mean "the opposite of
-structural", a valid question is whether any of this is "nominal typing".
-Unfortunately, "nominal" has a fuzzy meaning in modular contexts like the
-Component Model where there is [necessarily](../high-level/Choices.md) no
-shared global namespace. Instead, the main use cases for nominal types are
-independently addressed by the addition of abstract and generative types
-mentioned above. In particular, while importing or exporting an abstract type
-allows a name to be assigned to a type that is visible to the outside world,
-this name is ultimately just a *parameter name* or a *field name*, resp., whose
-linkage to the outside world is entirely controlled by the component's
-immediate parent (which can be another component). Note that a common
-assumption concerning "nominal" types is that "the same name means the same
-thing everywhere" which is definitely *not* the case for resource types but
-*is* the case for *structural* types like `string` and `list`. See also the
-explanation [below](#import-and-export-definitions) of how the URL field of
-`externname` can be used by a component to name the semantic contract it
-*expects* of imports or *claims* for exports. This naming of a contract with
-a URL meant to have a global meaning is "nominal" in spirit but independent of
-the type system.
+Lastly, since "nominal" is often taken to mean "the opposite of structural", a
+valid question is whether any of the above "nominal typing". Inside a
+component, resource types act "nominally": each resource type definition
+produces a new local "name" for a resource type that is distinct from all
+preceding resource types. The interesting case is when resource type equality
+is considered from *outside* the component, particularly when a single
+component is instantiated multiple times. In this case, a single resource type
+definition that is exported with a single `externname` will get a fresh type
+with each component instance, with the abstract typing rules mentioned above
+ensuring that each of the component's instance's resource types are kept
+distinct. Thus, in a sense, the generativity of resource types *generalize*
+traditional name-based nominal typing, providing a finer granularity of
+isolation than otherwise achievable with a shared global namespace.
 
 
 ### Canonical Definitions

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -816,9 +816,7 @@ following component:
   (import "T2" (type $T2 (sub resource)))
 )
 ```
-the types `$T1` and `$T2` are not equal. If type imports worked purely
-structurally, then they would be equal because structurally they have the same
-AST.
+the types `$T1` and `$T2` are not equal.
 
 Once a type is imported, it can be referred to by subsequent equality-bound
 type imports, thereby adding more types that it is equal to. For example, in

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -952,11 +952,11 @@ When supplying a resource type (imported *or* defined) to a type import via
 (component $P
   (import "C1" (component $C1
     (import "T" (type $T (sub resource)))
-    (export "foo" (param (own $T)))
+    (export "foo" (func (param (own $T))))
   ))
   (import "C2" (component $C2
     (import "T" (type $T (sub resource)))
-    (import "foo" (param (own $T)))
+    (import "foo" (func (param (own $T))))
   ))
   (type $R (resource (rep i32)))
   (instance $c1 (instantiate $C1 (with "T" (type $R))))

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -9,7 +9,9 @@ native JavaScript runtimes.
   * [Instance definitions](#instance-definitions)
   * [Alias definitions](#alias-definitions)
   * [Type definitions](#type-definitions)
+    * [Type checking](#type-checking)
   * [Canonical definitions](#canonical-definitions)
+    * [Canonical built-ins](#canonical-built-ins)
   * [Start definitions](#start-definitions)
   * [Import and export definitions](#import-and-export-definitions)
 * [Component invariants](#component-invariants)
@@ -198,8 +200,12 @@ sort           ::= core <core:sort>
                  | component
                  | instance
 inlineexport   ::= (export <name> <sortidx>)
-name           ::= <word>
-                 | <name>-<word>
+name           ::= <label>
+                 | [constructor]<label>
+                 | [method]<label>.<label>
+                 | [static]<label>.<label>
+label          ::= <word>
+                 | <label>-<word>
 word           ::= [a-z][0-9a-z]*
                  | [A-Z][0-9A-Z]*
 ```
@@ -216,20 +222,35 @@ The `value` sort refers to a value that is provided and consumed during
 instantiation. How this works is described in the
 [start definitions](#start-definitions) section.
 
-The component-level definition of `name` above corresponds to [kebab case]. The
-reason for this particular form of casing is to unambiguously separate words
-and acronyms (represented as all-caps words) so that source language bindings
-can convert a `name` into the idiomatic casing of that language. (Indeed,
-because hyphens are often invalid in identifiers, kebab case practically forces
-language bindings to make such a conversion.) For example, the `name` `is-XML`
+The component-level definition of `name` captures several language-neutral
+syntactic hints that allow bindings generators to produce more idiomatic
+bindings in their target language. Having this structured data encoded as a
+plain string provides a single canonical name for use in tools and
+language-agnostic contexts, without requiring each to invent its own custom
+interpretation which would likely lead to inconsistencies followed by a need to
+canonicalize.
+
+At the top-level, a `name` allows functions to be annotated as being a
+constructor, method or static function of a preceding resource. In each of
+these cases, the first `label` is the name of the resource and the second
+`label` is the logical field name of the function. This additional nesting
+information allows bindings generators to insert the function into the nested
+scope of a class, abstract data type, object, namespace, package, module or
+whatever resources get bound to. For example, a function named `[method]C.foo`
+could be bound in C++ to a member function `foo` in a class `C`. The JS API
+[below](#JS-API) describes how the native JavaScript bindings could look.
+Validation described in [Binary.md](Binary.md) inspects the contents of `name`
+and ensures that the function has a compatible signature.
+
+The `label`s inside a `name` are required to have [kebab case]. The reason
+for this particular form of casing is to unambiguously separate words and
+acronyms (represented as all-caps words) so that source language bindings can
+convert a `name` into the idiomatic casing of that language. (Indeed, because
+hyphens are often invalid in identifiers, kebab case practically forces
+language bindings to make such a conversion.) For example, the `label` `is-XML`
 could be mapped to `isXML`, `IsXml` or `is_XML`, depending on the target
 language. The highly-restricted character set ensures that capitalization is
-trivial and does not require consulting Unicode tables. Having this structured
-data encoded as a plain string provides a single canonical name for use in
-tools and language-agnostic contexts, without requiring each to invent its own
-custom interpretation. While the use of `name` above is mostly for internal
-wiring, `name` is used in a number of productions below that are
-developer-facing and imply bindings generation.
+trivial and does not require consulting Unicode tables.
 
 To see a non-trivial example of component instantiation, we'll first need to
 introduce a few other definitions below that allow components to import, define
@@ -265,10 +286,10 @@ outer aliases are only allowed to refer to *preceding* outer definitions.
 Components containing outer aliases effectively produce a [closure] at
 instantiation time, including a copy of the outer-aliased definitions. Because
 of the prevalent assumption that components are immutable values, outer aliases
-are restricted to only refer to immutable definitions: types, modules and
-components. (In the future, outer aliases to all sorts of definitions could be
-allowed by recording the statefulness of the resulting component in its type
-via some kind of "`stateful`" type attribute.)
+are restricted to only refer to immutable definitions: non-resource types,
+modules and components. (In the future, outer aliases to all sorts of
+definitions could be allowed by recording the statefulness of the resulting
+component in its type via some kind of "`stateful`" type attribute.)
 
 Both kinds of aliases come with syntactic sugar for implicitly declaring them
 inline:
@@ -456,6 +477,7 @@ therefore be high-level, describing entire compound values.
 ```
 type          ::= (type <id>? <deftype>)
 deftype       ::= <defvaltype>
+                | <resourcetype>
                 | <functype>
                 | <componenttype>
                 | <instancetype>
@@ -463,20 +485,23 @@ defvaltype    ::= bool
                 | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64
                 | float32 | float64
                 | char | string
-                | (record (field <name> <valtype>)*)
-                | (variant (case <id>? <name> <valtype>? (refines <id>)?)+)
+                | (record (field <label> <valtype>)*)
+                | (variant (case <id>? <label> <valtype>? (refines <id>)?)+)
                 | (list <valtype>)
                 | (tuple <valtype>*)
-                | (flags <name>*)
-                | (enum <name>+)
+                | (flags <label>*)
+                | (enum <label>+)
                 | (union <valtype>+)
                 | (option <valtype>)
                 | (result <valtype>? (error <valtype>)?)
+                | (own <typeidx>)
+                | (borrow <typeidx>)
 valtype       ::= <typeidx>
                 | <defvaltype>
+resourcetype  ::= (resource (rep i32) (dtor <funcidx>)?)
 functype      ::= (func <paramlist> <resultlist>)
-paramlist     ::= (param <name> <valtype>)*
-resultlist    ::= (result <name> <valtype>)*
+paramlist     ::= (param <label> <valtype>)*
+resultlist    ::= (result <label> <valtype>)*
                 | (result <valtype>)
 componenttype ::= (component <componentdecl>*)
 instancetype  ::= (instance <instancedecl>*)
@@ -487,7 +512,7 @@ instancedecl  ::= core-prefix(<core:type>)
                 | <alias>
                 | <exportdecl>
 importdecl    ::= (import <externname> bind-id(<externdesc>))
-exportdecl    ::= (export <externname> <externdesc>)
+exportdecl    ::= (export <externname> bind-id(<externdesc>))
 externdesc    ::= (<sort> (type <u32>) )
                 | core-prefix(<core:moduletype>)
                 | <functype>
@@ -496,6 +521,7 @@ externdesc    ::= (<sort> (type <u32>) )
                 | (value <valtype>)
                 | (type <typebound>)
 typebound     ::= (eq <typeidx>)
+                | (sub resource)
 
 where bind-id(X) parses '(' sort <id>? Y ')' when X parses '(' sort Y ')'
 ```
@@ -513,6 +539,15 @@ sets of abstract values:
 | `record`                  | heterogeneous [tuples] of named values |
 | `variant`                 | heterogeneous [tagged unions] of named values |
 | `list`                    | homogeneous, variable-length [sequences] of values |
+| `own`                     | a unique, opaque address of a resource that will be destroyed when this value is dropped |
+| `borrow`                  | an opaque address of a resource that must be dropped before the current export call returns |
+
+How these abstract values are produced and consumed from Core WebAssembly
+values and linear memory is configured by the component via *canonical lifting
+and lowering definitions*, which are introduced [below](#canonical-definitions).
+For example, while abstract `variant`s contain a list of `case`s labelled by
+name, canonical lifting and lowering map each case to an `i32` value starting
+at `0`.
 
 The `float32` and `float64` values have their NaNs canonicalized to a single
 value so that:
@@ -523,26 +558,33 @@ value so that:
    assumptions that NaN payload bits are preserved by the other side (since
    they often aren't).
 
-The subtyping between all these types is described in a separate
+The `own` and `borrow` value types are both *handle types*. Handles logically
+contain the "address" of a resource instance. Handles avoid copying the
+underlying resource in cases where copying is impossible or undesirable for
+performance reasons. By way of metaphor to operating systems, handles are
+analogous to file descriptors, which are indices into a table of resources
+maintained by the kernel. In the Component Model, handles are lifted-from and
+lowered-into `i32` values that index an encapsulated per-component-instance
+*handle table* that is maintained by the canonical function definitions
+described [below](#canonical-definitions). The uniqueness and dropping
+conditions mentioned above are enforced at runtime by the Component Model
+through these canonical definitions. The `typeidx` immediate of a handle type
+must refer to a `resource` type (described below) that statically classifies
+the particular kinds of resources the handle can point to.
+
+The [subtyping] between all these types is described in a separate
 [subtyping explainer](Subtyping.md). Of note here, though: the optional
 `refines` field in the `case`s of `variant`s is exclusively concerned with
 subtyping. In particular, a `variant` subtype can contain a `case` not present
 in the supertype if the subtype's `case` `refines` (directly or transitively)
 some `case` in the supertype.
 
-How these abstract values are produced and consumed from Core WebAssembly
-values and linear memory is configured by the component via *canonical lifting
-and lowering definitions*, which are introduced [below](#canonical-definitions).
-For example, while abstract `variant`s contain a list of `case`s labelled by
-name, canonical lifting and lowering map each case to an `i32` value starting
-at `0`.
-
 The sets of values allowed for the remaining *specialized value types* are
 defined by the following mapping:
 ```
                     (tuple <valtype>*) ↦ (record (field "𝒊" <valtype>)*) for 𝒊=0,1,...
-                       (flags <name>*) ↦ (record (field <name> bool)*)
-                        (enum <name>+) ↦ (variant (case <name>)+)
+                      (flags <label>*) ↦ (record (field <label> bool)*)
+                       (enum <label>+) ↦ (variant (case <label>)+)
                     (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
                     (union <valtype>+) ↦ (variant (case "𝒊" <valtype>)+) for 𝒊=0,1,...
 (result <valtype>? (error <valtype>)?) ↦ (variant (case "ok" <valtype>?) (case "error" <valtype>?))
@@ -565,6 +607,18 @@ additionally have a single unnamed return type. For this special case, bindings
 generators are naturally encouraged to return the single value directly without
 wrapping it in any containing record/object/struct.
 
+The `resource` type constructor creates a fresh type for each instance of the
+containing component (with "freshness" and its interaction with general
+type-checking described in more detail [below](#type-checking)). Resource types
+can be referred to by handle types (`own` and `borrow`) as well as the
+`resource.new` canonical built-in described [below](#canonical-built-ins). The
+`rep` immediate of a `resource` type specifies its *core representation type*,
+which is currently fixed to `i32`, but will be relaxed in the future (to at
+least include `i64`, but also potentially other types). When the owning handle
+of a resource is dropped, the resource's `dtor` function will be called (if
+present), allowing the implementing component to perform clean-up like freeing
+linear memory allocations.
+
 The `instance` type constructor describes a list of named, typed definitions
 that can be imported or exported by a component. Informally, instance types
 correspond to the usual concept of an "interface" and instance types thus serve
@@ -582,11 +636,12 @@ Both `instance` and `component` type constructors are built from a sequence of
 "declarators", of which there are four kinds&mdash;`type`, `alias`, `import` and
 `export`&mdash;where only `component` type constructors can contain `import`
 declarators. The meanings of these declarators is basically the same as the
-core module declarators introduced above.
+core module declarators introduced above, but expanded to cover the additional
+capabilities of the component model.
 
-As with core modules, `importdecl` and `exportdecl` classify component `import`
-and `export` definitions, with `importdecl` allowing an identifier to be
-bound for use within the type. The definition of `externname` is given in the
+The `importdecl` and `exportdecl` declarators correspond to component `import`
+and `export` definitions, respectively, allowing an identifier to be bound for
+use by subsequent declarators. The definition of `externname` is given in the
 [imports and exports](#import-and-export-definitions) section below. Following
 the precedent of [`core:typeuse`], the text format allows both references to
 out-of-line type definitions (via `(type <typeidx>)`) and inline type
@@ -597,21 +652,48 @@ exported at instantiation time as described in the
 [start definitions](#start-definitions) section below.
 
 The `type` case of `externdesc` describes an imported or exported type along
-with its bounds. The bounds currently only have an `eq` option that says that
-the imported/exported type must be exactly equal to the referenced type. There
-are two main use cases for this in the short-term:
-* Type exports allow a component or interface to associate a name with a
-  structural type (e.g., `(export "nanos" (type (eq u64)))`) which bindings
-  generators can use to generate type aliases (e.g., `typedef uint64_t nanos;`).
-* Type imports and exports can provide additional information to toolchains and
-  runtimes for defining the behavior of host APIs.
+with its "bound":
 
-When [resource and handle types] are added to the explainer, `typebound` will
-be extended with a `sub` option (symmetric to the [type-imports] proposal) that
-allows importing and exporting *abstract* types.
+The `sub` bound declares that the imported/exported type is an *abstract type*
+which is a *subtype* of some other type. Currently, the only supported bound is
+`resource` which (following the naming conventions of the [GC] proposal) means
+"any resource type". Thus, only resource types can be imported/exported
+abstractly, not arbitrary value types. This allows type imports to always be
+compiled independently of their arguments using a "universal representation" for
+handle values (viz., `i32`, as defined by the [Canonical ABI](CanonicalABI.md)).
+In the future, `sub` may be extended to allow referencing other resource types,
+thereby allowing abstract resource subtyping.
 
-With what's defined so far, we can define component types using a mix of inline
-and out-of-line type definitions:
+The `eq` bound says that the imported/exported type must be structurally equal
+to some preceding type definition. This allows:
+* an imported abstract type to be re-exported;
+* components to introduce another label for a preceding abstract type (which
+  can be necessary when implementing multiple independent interfaces with the
+  same resource); and
+* components to attach transparent type aliases to structural types to be
+  reflected in source-level bindings (e.g., `(export "bytes" (type (eq (list u64))))`
+  could generate in C++ a `typedef std::vector<uint64_t> bytes` or in JS an
+  exported field named `bytes` that aliases `Uint64Array`.
+
+Relaxing the restrictions of `core:alias` declarators mentioned above, `alias`
+declarators allow both `outer` and `export` aliases of `type` and `instance`
+sorts. This allows the type exports of `instance`-typed import and export
+declarators to be used by subsequent declarators in the type:
+```wasm
+(component
+  (import "fancy-fs" (instance $fancy-fs
+    (export "fs" (instance $fs
+      (export "file" (type $file (sub resource)))
+      ...
+    ))
+    (alias export $fs "file" (type $file))
+    (export "fancy-op" (func (param (borrow $file))))
+  ))
+)
+```
+
+With what's defined so far, we can define component types using a mix of type
+definitions:
 ```wasm
 (component $C
   (type $T (list (tuple string bool)))
@@ -624,11 +706,303 @@ and out-of-line type definitions:
     (import "g" (func (type $G)))
     (export "g" (func (type $G)))
     (export "h" (func (result $U)))
+    (import "T" (type $T (sub resource)))
+    (import "i" (func (param (list (own $T)))))
+    (export "T" (type $T' (eq $T)))
+    (export "U" (type $U (sub resource)))
+    (export "j" (func (param (borrow $T')) (result (own $U))))
   ))
 )
 ```
 Note that the inline use of `$G` and `$U` are syntactic sugar for `outer`
 aliases.
+
+#### Type Checking
+
+Like core modules, components have an up-front validation phase in which the
+definitions of a component are checked for basic consistency. Type checking
+is a central part of validation and, e.g., occurs when validating that the
+`with` arguments of an [`instantiate`](#instance-definitions) expression are
+type-compatible with the `import`s of the component being instantiated. To allow
+backwards-compatible API evolution, "compatibility" is defined in terms of a
+[subtyping] relation, saying that `t1` is "compatible" with `t2` when a value
+of type `t1` is *substitutable* for a value of `t2` without breaking any basic
+assumptions the receiver has about `t2` values.
+
+To incrementally describe how type-checking works, we'll start by asking how
+*type equality* works for non-resource, non-handle, local type definitions and
+build up from there.
+
+Type equality for almost all types (except as described below) is purely
+*structural*. In a structural setting, types are considered to be Abstract
+Syntax Trees whose nodes are type constructors with types like `u8` and
+`string` considered to be "nullary" type constructors that appear at leaves and
+non-nullary type constructors like `list` and `record` appearing at parent
+nodes. Then, type equality is defined to be AST equality. Importantly, these
+type ASTs do *not* contain any type indices or depend on index space layout;
+these binary format details are consumed by decoding to produce the AST. For
+example, in the following compound component:
+```wasm
+(component $A
+  (type $ListString1 (list string))
+  (type $ListListString1 (list $ListString1))
+  (type $ListListString2 (list $ListString1))
+  (component $B
+    (type $ListString3 (list string))
+    (type $ListListString3 (list $ListString3))
+    (type $ListString4 (alias outer $A $ListString))
+    (type $ListListString4 (list $ListString4))
+  )
+)
+```
+all 4 variations of `$ListListStringX` are considered equal since, after
+decoding, they all have the same AST.
+
+Next, the type equality relation on ASTs is relaxed to a more flexible
+subtyping relation. This subtyping relation is recursively defined starting
+with a set of base-case rules such as:
+* `u8` is a subtype of `u16`
+* `f32` is a subtype of `f64`
+
+and then a set of inductive rules like:
+* If `t1` is a subtype of `t2`, `list t1` is a subtype of `list t2`
+* If `t1` is a subtype of `t2`, `option t1` is a subtype of `option t2`
+
+The full list of rules is in [`Subtyping.md`](Subtyping.md). The rules are
+defined so that a type-checking implementation can simply recurse on the ASTs
+of two types in tandem to determine at each node whether the "left-hand side" is
+a subtype of the "right-hand side". For example, the following component is
+valid because, using the rules just given, the decoded AST of `$L1` is a
+subtype of the decoded AST of `$L2`:
+```wasm
+(component
+  (import "v1" (value $v1 (list (list u8))))
+  (component $C
+    (import "v2" (value $v2 (list (list u16))))
+  )
+  (instance $c (instantiate $C (with "v2" (value $v1))))
+)
+```
+
+When we next consider type imports and exports, there are two distinct
+subcases of `typebound` to consider: `eq` and `sub`.
+
+The `eq` bound adds a type equality rule (extending the built-in set of
+subtyping rules mentioned above) saying that the imported type is structurally
+equivalent to the type referenced in the bound. For example, in the component:
+```wasm
+(component
+  (type $L1 (list u8))
+  (import "L2" (type $L2 (eq $L1)))
+  (import "L3" (type $L2 (eq $L1)))
+  (import "L4" (type $L2 (eq $L3)))
+)
+```
+all four `$L*` types are equal (in subtyping terms, they are all subtypes of
+each other).
+
+In contrast, the `sub` bound introduces a new *abstract* type which the rest of
+the component must conservatively assume can be *any* type that is a subtype of
+the bound. What this means for type-checking is that each subtype-bound type
+import/export introduces a *fresh* abstract type that is unequal to every
+preceding type definition. Currently (and likely in the MVP), the only
+supported type bound is `resource` (which means "any resource type") and thus
+the only abstract types are abstract *resource* types. As an example, in the
+following component:
+```wasm
+(component
+  (import "T1" (type $T1 (sub resource)))
+  (import "T2" (type $T2 (sub resource)))
+)
+```
+the types `$T1` and `$T2` are not equal. If type imports worked purely
+structurally, then they would be equal because structurally they have the same
+AST.
+
+Once a type is imported, it can be referred to by subsequent equality-bound
+type imports, thereby adding more types that it is equal to. For example, in
+the following component:
+```wasm
+(component $C
+  (import "T1" (type $T1 (sub resource)))
+  (import "T2" (type $T2 (sub resource)))
+  (import "T3" (type $T3 (eq $T2))
+  (type $ListT1 (list $T1))
+  (type $ListT2 (list $T2))
+  (type $ListT3 (list $T3))
+)
+```
+the types `$T2` and `$T3` are equal to each other but not to `$T1`. By the
+above transitive structural equality rules, the types `$List2` and `$List3` are
+equal to each other but not to `$List1`.
+
+Handle types (`own` and `borrow`) are purely structural, but, since they refer
+to resource types, transitively "inherit" the freshness of abstract resource
+types. For example, in the following component:
+```wasm
+(component
+  (import "T" (type $T (sub resource)))
+  (import "U" (type $U (sub resource)))
+  (type $Handle1 (own $T))
+  (type $Handle2 (own $T))
+  (type $Handle3 (own $U))
+)
+```
+the types `$Handle1` and `$Handle2` are equal to each other but not to
+`$Handle3`. Transitively, any types containing `$Handle1` or `$Handle2` are
+equal, such as a `(list $Handle1)` and `(list $Handle2)` or function types
+using handles in their parameters and results. These type-checking rules for
+type imports mirror the *introduction* rule of [universal types]  (∀T).
+
+The above examples all show abstract types in terms of *imports*, but the same
+"freshness" condition applies when aliasing the *exports* of another component
+as well. For example, in this component:
+```wasm
+(component
+  (import "i" (instance $i
+    (export "T1" (type $T1 (sub resource)))
+    (export "T2" (type $T2 (sub resource)))
+    (export "T3" (type $T3 (eq $T2)))
+  ))
+  (type $T1 (alias export $i "T1"))
+  (type $T2 (alias export $i "T2"))
+  (type $T3 (alias export $i "T3"))
+)
+```
+the types `$T2` and `$T3` are equal to each other but not to `$T1`. These
+type-checking rules for aliases of type exports mirror the *elimination* rule
+of [existential types]  (∃T).
+
+Next, we consider resource type definitions, which are half-like abstract types
+in that they also produce a *fresh* type that is unequal to every preceding
+type. However, a resource type definition is **not** abstract; it has a
+concrete representation that is known to the containing component (and *only*
+the containing component). Thus, local resource type definitions are neither
+structural nor abstract: they are "[generative]". For example, in the following
+example component:
+```wasm
+(component
+  (type $R1 (resource (rep i32)))
+  (type $R2 (resource (rep i32)))
+  (func $f1 (result (own $R1)) (canon lift ...))
+  (func $f2 (param (own $R2)) (canon lift ...))
+)
+```
+the types `$R1` and `$R2` are unequal and thus the return type of `$f1`
+is incompatible with the parameter type of `$f2`.
+
+The generativity of resource type definitions is well-suited to the abstract
+typing rules of type exports mentioned above, which force all clients of the
+component to bind a fresh abstract type. For example, in the following
+component:
+```wasm
+(component
+  (component $C
+    (type $r1 (export "r1") (resource (rep i32)))
+    (type $r2 (export "r2") (resource (rep i32)))
+  )
+  (instance $c1 (instantiate $C))
+  (instance $c2 (instantiate $C))
+  (type $c1r1 (alias export $c1 "r1"))
+  (type $c1r2 (alias export $c1 "r2"))
+  (type $c2r1 (alias export $c2 "r1"))
+  (type $c2r2 (alias export $c2 "r2"))
+)
+```
+all four types aliases in the outer component are unequal, reflecting the fact
+that each instance of `$C` generates two fresh resource types.
+
+However, even if a single resource type definition is exported twice with `sub`
+bounds, clients must *still* treat the two types as abstract and thus unequal;
+the fact that the underlying concrete type is the same is kept an encapsulated
+implementation detail. For example, in the following component:
+```wasm
+(component
+  (component $C
+    (type $r (resource (rep i32)))
+    (export "r1" (type (sub $r)))
+    (export "r2" (type (sub $r)))
+  )
+  (instance $c (instantiate $C))
+  (type $r1 (alias export $c "r1"))
+  (type $r2 (alias export $c "r2"))
+)
+```
+The types `$r1` and `$r2` are unequal. These type-checking rules for
+type exports mirror the *introduction* rule of [existential types]  (∃T).
+
+When supplying a resource type (imported *or* defined) to a type import via
+`instantiate`, type checking performs a substitution, replacing all uses of the
+`import` in the instantiated component with the actual type supplied via
+`with`. This means that, from the parent's point of view, the type imports stop
+being abstract. For example, the following component validates:
+```wasm
+(component $P
+  (import "C1" (component $C1
+    (import "T" (type $T (sub resource)))
+    (export "foo" (param (own $T)))
+  ))
+  (import "C2" (component $C2
+    (import "T" (type $T (sub resource)))
+    (import "foo" (param (own $T)))
+  ))
+  (type $R (resource (rep i32)))
+  (instance $c1 (instantiate $C1 (with "T" (type $R))))
+  (alias export $c1 "foo" (func $foo))
+  (instance $c2 (instantiate $C2 (with "T" (type $R)) (with "foo" (func $foo))))
+)
+```
+This depends critically on the `T` imports of `$C1` and `$C2` having been
+replaced by `$R` when validating the instantiations of `$c1` and `$c2`. These
+type-checking rules for instantiating type imports mirror the *elimination*
+rule of [universal types]  (∀T).
+
+As a final constraint on both the `export` declarators of a `componenttype` and
+the `export` definitions of a `component`, all transitive uses of abstract
+types in the types of exported functions or values must refer to *exported*
+abstract types (concretely, via the type index introduced by the `export`).
+This ensures that the client of a component is *always* able to define, in the
+client's own type index space, a type compatible with the component's exports.
+For example, in the following component:
+```wasm
+(component
+  (type $R (resource (rep i32)))
+  (export $R' "R" (type (sub $R)))
+  (func $f1 (result (own $R)) (canon lift ...))
+  (func $f2 (result (own $R') (canon lift ...))
+  ;; (export "f" (func $f1)) -- invalid
+  (export "f" (func $f2))
+)
+```
+the commented-out `export` is invalid because its type transitively refers to
+`$R`, which is not a type-export. This requirement is meant to address the
+standard [avoidance problem] that appears in module systems with abstract
+types.
+
+In summary: all type constructors are *structural* with the exception of
+`resource`, which is *generative*. Type imports and exports that have a subtype
+bound are *abstract (resource) types* and follow the standard introduction and
+elimination rules of universal and existential types.
+
+Lastly, since "nominal" is sometimes intended to mean "the opposite of
+structural", a valid question is whether any of this is "nominal typing".
+Unfortunately, "nominal" has a fuzzy meaning in modular contexts like the
+Component Model where there is [necessarily](../high-level/Choices.md) no
+shared global namespace. Instead, the main use cases for nominal types are
+independently addressed by the addition of abstract and generative types
+mentioned above. In particular, while importing or exporting an abstract type
+allows a name to be assigned to a type that is visible to the outside world,
+this name is ultimately just a *parameter name* or a *field name*, resp., whose
+linkage to the outside world is entirely controlled by the component's
+immediate parent (which can be another component). Note that a common
+assumption concerning "nominal" types is that "the same name means the same
+thing everywhere" which is definitely *not* the case for resource types but
+*is* the case for *structural* types like `string` and `list`. See also the
+explanation [below](#import-and-export-definitions) of how the URL field of
+`externname` can be used by a component to name the semantic contract it
+*expects* of imports or *claims* for exports. This naming of a contract with
+a URL meant to have a global meaning is "nominal" in spirit but independent of
+the type system.
 
 
 ### Canonical Definitions
@@ -729,8 +1103,8 @@ definitions can also be written in an inverted form that puts the sort first:
 Note: in the future, `canon` may be generalized to define other sorts than
 functions (such as types), hence the explicit `sort`.
 
-Using canonical definitions, we can finally write a non-trivial component that
-takes a string, does some logging, then returns a string.
+Using canonical function definitions, we can finally write a non-trivial
+component that takes a string, does some logging, then returns a string.
 ```wasm
 (component
   (import "wasi:logging" (instance $logging
@@ -772,6 +1146,80 @@ exports are available for reference by `canon lower`. Without this separation
 (if `$Main` contained the `memory` and allocation functions), there would be a
 cyclic dependency between `canon lower` and `$Main` that would have to be
 broken using an auxiliary module performing `call_indirect`.
+
+#### Canonical Built-ins
+
+In addition to the `lift` and `lower` canonical function definitions which
+adapt *existing* functions, there are also a set of canonical "built-ins" that
+define core functions out of nothing that can be imported by core modules to
+dynamically interact with Canonical ABI entities like resources (and, when
+async is added to the proposal, [tasks][Future and Stream Types]).
+```
+canon ::= ...
+        | (canon resource.new <typeidx> (core func <id>?))
+        | (canon resource.drop <valtype> (core func <id>?))
+        | (canon resource.rep <typeidx> (core func <id>?))
+```
+The `resource.new` built-in requires that the given `typeidx` refers to a
+`resource` `deftype` (a resource defined within this component). The parameters
+of `resource.new` are the value types from the `(rep <valtype>)` immediate of
+the resource type. The return value of `resource.new` is an `i32` index
+referring to an `own` handle in the current component instance's handle table.
+Because resource type representations are currently fixed to be `i32`, the core
+function signature of `resource.new` is currently always `[i32] -> [i32]`.
+
+The `resource.drop` built-in has core function signature `[i32] -> []` and
+drops the handle at the given index from the handle table. The `valtype`
+immediate must either be an `own` or `borrow` handle type. If `own`, the
+resource type's `dtor` function is called synchronously, if present.
+
+In-between `resource.new` and `resource.drop`, `own` handles can be passed
+between components via import and export calls using `own` and `borrow` handle
+types in parameters and results. The Canonical ABI specifies that `own` handles
+are *transferred* from the producer component instance's handle table into the
+consumer component instance's handle table. In contrast, `borrow` handles are
+*copied* into the callee component instance's handle table, but with runtime
+(trapping) guards to ensure that the callee calls `resource.drop` on the
+borrowed handle before the end of the call and that the owner of the resource
+does not destroy the resource for the duration of the call.
+
+Lastly, given the `i32` index of an `own` or `borrow` handle, the component
+that defined a resource type (and only that component) can call the
+`resource.rep` built-in to access the `rep` value. (In the future a
+`resource.set` could potentially be added, if needed.) Because of the fixed
+`(rep i32)`, the core signature of `resource.rep` is `[i32] -> [i32]`.
+
+As an example, the following component imports the `resource.new` built-in,
+allowing it to create and return new resources to its client:
+```wasm
+(component
+  (import "Libc" (core module $Libc ...))
+  (core instance $libc (instantiate $Libc))
+  (type $R (resource (rep i32) (dtor (func $libc "free"))))
+  (core func $R_new (param i32) (result i32)
+    (canon resource.new $R)
+  )
+  (core module $Main
+    (import "canon" "R_new" (func $R_new (param i32) (result i32)))
+    (func (export "make_R") (param ...) (result i32)
+      (return (call $R_new ...))
+    )
+  )
+  (core instance $main (instantiate $Main
+    (with "canon" (instance (export "R_new" (func $R_new))))
+  ))
+  (export $R' "r" (type $R))
+  (func (export "make-r") (param ...) (result (own $R'))
+    (canon lift (core func $main "make_R"))
+  )
+)
+```
+Here, the `i32` returned by `resource.new`, which is an index into the
+component's handle-table, is immediately returned by `make_R`, thereby
+transferring ownership of the newly-created resource to the export's caller.
+
+See the [CanonicalABI.md](CanonicalABI.md#canonical-definitions) for detailed
+definitions of each of these built-ins and their interactions.
 
 
 ### Start Definitions
@@ -833,9 +1281,17 @@ of core linear memory.
 Lastly, imports and exports are defined as:
 ```
 import     ::= (import <externname> bind-id(<externdesc>))
-export     ::= (export <externname> <sortidx>)
+export     ::= (export <id>? <externname> <sortidx>)
 externname ::= <name> <URL>?
 ```
+Both import and export definitions append a new element to the index space of
+the imported/exported `sort` which can be optionally bound to an identifier in
+the text format. In the case of imports, the identifier is bound just like Core
+WebAssembly, as part of the `externdesc` (e.g., `(import "x" (func $iden))`).
+In the case of exports, the `<id>?` right after the `export` is bound (the
+`<id>` inside the `<sortidx>` is a reference to the preceding definition being
+exported).
+
 Components split the single externally-visible name of imports and exports into
 two sub-fields: a kebab-case `name` (as defined [above](#instance-definitions))
 and a `URL` (defined by the [URL Standard], noting that, in this URL Standard,
@@ -1047,6 +1503,32 @@ same value). Since `name` and `URL` are necessarily disjoint sets of strings
 (in particular, `URL`s must contain a `:`, `name` must not), there should not
 be any conflicts in either of these cases.
 
+Types are a new sort of definition that are not ([yet][type-imports]) present
+in Core WebAssembly and so the [*read the imports*] and [*create an exports
+object*] steps need to be expanded to cover them:
+
+For type exports, each type definition would export a JS constructor function.
+This function would be callable iff a `[constructor]`-annotated function was
+also exported. All `[method]`- and `[static]`-annotated functions would be
+dynamically installed on the constructor's prototype chain. In the case of
+re-exports and multiple exports of the same definition, the same constructor
+function object would be exported (following the same rules as WebAssembly
+Exported Functions today). In pathological cases (which, importantly, don't
+concern the global namespace, but involve the same actual type definition being
+imported and re-exported by multiple components), there can be collisions when
+installing constructors, methods and statics on the same constructor function
+object. In such cases, a conservative option is to undo the initial
+installation and require all clients to instead use the full explicit names
+as normal instance exports.
+
+For type imports, the constructors created by type exports would naturally
+be importable. Additionally, certain JS- and Web-defined objects that correspond
+to types (e.g., the `RegExp` and `ArrayBuffer` constructors or any Web IDL
+[interface object]) could be imported. The `ToWebAssemblyValue` checks on
+handle values mentioned below can then be defined to perform the associated
+[internal slot] type test, thereby providing static type guarantees for
+outgoing handles that can avoid runtime dynamic type tests.
+
 Lastly, when given a component binary, the compile-then-instantiate overloads
 of `WebAssembly.instantiate(Streaming)` would inherit the compound behavior of
 the abovementioned functions (again, using the `layer` field to eagerly
@@ -1115,6 +1597,7 @@ At a high level, the additional coercions would be:
 | `option` | same as [`T?`] | same as [`T?`] |
 | `union` | same as [`union`] | same as [`union`] |
 | `result` | same as `variant`, but coerce a top-level `error` return value to a thrown exception | same as `variant`, but coerce uncaught exceptions to top-level `error` return values |
+| `own`, `borrow` | see below | see below |
 
 Notes:
 * Function parameter names are ignored since JavaScript doesn't have named
@@ -1133,9 +1616,19 @@ Notes:
   the JS API of the unspecialized `variant` (e.g.,
   `(variant (case "some" (option u32)) (case "none"))`, despecializing only
   the problematic outer `option`).
-* The forthcoming addition of [resource and handle types] would additionally
-  allow coercion to and from the remaining Symbol and Object JavaScript value
-  types.
+* When coercing `ToWebAssemblyValue`, `own` and `borrow` handle types would
+  dynamically guard that the incoming JS value's dynamic type was compatible
+  with the imported resource type referenced by the handle type. For example,
+  if a component contains `(import "Object" (type $Object (sub resource)))` and
+  is instantiated with the JS `Object` constructor, then `(own $Object)` and
+  `(borrow $Object)` could accept JS `object` values.
+* When coercing `ToJSValue`, handle values would be wrapped with JS objects
+  that are instances of the handles' resource type's exported constructor
+  (described above). For `own` handles, a [`FinalizationRegistry`] would be
+  used to drop the `own` handle (thereby calling the resource destructor) when
+  its wrapper object was unreachable from JS. For `borrow` handles, the wrapper
+  object would become dynamically invalid (throwing on any access) at the end
+  of the export call.
 * The forthcoming addition of [future and stream types] would allow `Promise`
   and `ReadableStream` values to be passed directly to and from components
   without requiring handles or callbacks.
@@ -1222,7 +1715,6 @@ For some use-case-focused, worked examples, see:
 The following features are needed to address the [MVP Use Cases](../high-level/UseCases.md)
 and will be added over the coming months to complete the MVP proposal:
 * concurrency support ([slides][Future And Stream Types])
-* abstract ("resource") types ([slides][Resource and Handle Types])
 * optional imports, definitions and exports (subsuming
   [WASI Optional Imports](https://github.com/WebAssembly/WASI/blob/main/legacy/optional-imports.md)
   and maybe [conditional-sections](https://github.com/WebAssembly/conditional-sections/issues/22))
@@ -1248,10 +1740,12 @@ and will be added over the coming months to complete the MVP proposal:
 [`core:version`]: https://webassembly.github.io/spec/core/binary/modules.html#binary-version
 
 [`WebAssembly.instantiate()`]: https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate
+[`FinalizationRegistry`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
 
 [JS API]: https://webassembly.github.io/spec/js-api/index.html
 [*read the imports*]: https://webassembly.github.io/spec/js-api/index.html#read-the-imports
-[*create the exports*]: https://webassembly.github.io/spec/js-api/index.html#create-an-exports-object
+[*create an exports object*]: https://webassembly.github.io/spec/js-api/index.html#create-an-exports-object
+[Interface Object]: https://webidl.spec.whatwg.org/#interface-object
 [`ToJSValue`]: https://webassembly.github.io/spec/js-api/index.html#tojsvalue
 [`ToWebAssemblyValue`]: https://webassembly.github.io/spec/js-api/index.html#towebassemblyvalue
 [`USVString`]: https://webidl.spec.whatwg.org/#es-USVString
@@ -1269,6 +1763,7 @@ and will be added over the coming months to complete the MVP proposal:
 [Imported Default Binding]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-ImportedDefaultBinding
 [JS Tuple]: https://github.com/tc39/proposal-record-tuple
 [JS Record]: https://github.com/tc39/proposal-record-tuple
+[Internal Slot]: https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots
 
 [Kebab Case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
 [De Bruijn Index]: https://en.wikipedia.org/wiki/De_Bruijn_index
@@ -1285,6 +1780,11 @@ and will be added over the coming months to complete the MVP proposal:
 [Environment Variables]: https://en.wikipedia.org/wiki/Environment_variable
 [Linear]: https://en.wikipedia.org/wiki/Substructural_type_system#Linear_type_systems
 [Interface Definition Language]: https://en.wikipedia.org/wiki/Interface_description_language
+[Subtyping]: https://en.wikipedia.org/wiki/Subtyping
+[Universal Types]: https://en.wikipedia.org/wiki/System_F
+[Existential Types]: https://en.wikipedia.org/wiki/System_F
+[Generative]: https://www.researchgate.net/publication/2426300_A_Syntactic_Theory_of_Type_Generativity_and_Sharing
+[Avoidance Problem]: https://counterexamples.org/avoidance.html
 
 [URL Standard]: https://url.spec.whatwg.org
 [URI]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
@@ -1307,5 +1807,4 @@ and will be added over the coming months to complete the MVP proposal:
 [`wizer`]: https://github.com/bytecodealliance/wizer
 
 [Scoping and Layering]: https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8
-[Resource and Handle Types]: https://docs.google.com/presentation/d/1ikwS2Ps-KLXFofuS5VAs6Bn14q4LBEaxMjPfLj61UZE
 [Future and Stream Types]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -868,11 +868,12 @@ The above examples all show abstract types in terms of *imports*, but the same
 as well. For example, in this component:
 ```wasm
 (component
-  (import "i" (instance $i
+  (import "C" (component $C
     (export "T1" (type $T1 (sub resource)))
     (export "T2" (type $T2 (sub resource)))
     (export "T3" (type $T3 (eq $T2)))
   ))
+  (instance $c (instantiate $C))
   (type $T1 (alias export $i "T1"))
   (type $T2 (alias export $i "T2"))
   (type $T3 (alias export $i "T3"))

--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -17,6 +17,7 @@ But roughly speaking:
 | `option`                  | `T <: (option T)` |
 | `expected`                | `T <: (expected T _)` |
 | `union`                   | `T <: (union ... T ...)` |
+| `own`, `borrow`           | none (although resource subtyping may be introduced in the future which would imply handle subtyping) |
 | `func`                    | parameter names must match in order; contravariant parameter subtyping; superfluous parameters can be ignored in the subtype; `option` parameters can be ignored in the supertype; covariant result subtyping |
 | `component`               | all imports in the subtype must be present in the supertype with matching types; all exports in the supertype must be present in the subtype; the `URL` is treated as the complete name, when present, ignoring the `name` field |
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -438,6 +438,7 @@ ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | list
      | option
      | result
+     | handle
      | future
      | stream
      | id
@@ -489,6 +490,41 @@ meanings though so they're also provided as first-class types.
 Finally the last case of a `ty` is simply an `id` which is intended to refer to
 another type or resource defined in the document. Note that definitions can come
 through a `use` statement or they can be defined locally.
+
+## Handles
+
+There are two types of handles in Wit: "owned" handles and "borrowed" handles.
+Owned handles represent the passing of unique ownership of a resource between
+two components. When the owner of an owned handle drops that handle, the
+resource is destroyed. In contrast, a borrowed handle represents a temporary
+loan of a handle from the caller to the callee for the duration of the call.
+
+The syntax for handles is:
+```
+handle ::= id
+         | 'borrow' '<' id '>'
+```
+
+The `id` case denotes an owned handle, where `id` is the name of a preceding
+`resource` item. Thus, the "default" way that resources are passed between
+components is via transfer of unique ownership.
+
+The resource method syntax defined above is syntactic sugar that expands into
+separate function items that take a first parameter named `self` of type
+`borrow`. For example, the compound definition:
+```
+resource file {
+    read: func(n: u32) -> list<u8>
+}
+```
+is expanded into:
+```
+resource file
+%[method]file.read: func(self: borrow<file>, n: u32) -> list<u8>
+```
+where `%[method]file.read` is the desugared name of a method according to the
+Component Model's definition of [`name`](Explainer.md).
+
 
 ## Identifiers
 

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import typing
 from typing import Optional
 from typing import Callable
+from typing import MutableMapping
 
 class Trap(BaseException): pass
 class CoreWebAssemblyException(BaseException): pass
@@ -158,6 +159,18 @@ class Result(ValType):
   ok: Optional[ValType]
   error: Optional[ValType]
 
+@dataclass
+class ResourceType(Type):
+  dtor: Optional[Callable[[int],None]]
+
+@dataclass
+class Own(ValType):
+  rt: ResourceType
+
+@dataclass
+class Borrow(ValType):
+  rt: ResourceType
+
 ### Despecialization
 
 def despecialize(t):
@@ -185,6 +198,7 @@ def alignment(t):
     case Record(fields)     : return alignment_record(fields)
     case Variant(cases)     : return alignment_variant(cases)
     case Flags(labels)      : return alignment_flags(labels)
+    case Own(_) | Borrow(_) : return 4
 
 #
 
@@ -239,6 +253,7 @@ def size(t):
     case Record(fields)     : return size_record(fields)
     case Variant(cases)     : return size_variant(cases)
     case Flags(labels)      : return size_flags(labels)
+    case Own(_) | Borrow(_) : return 4
 
 def size_record(fields):
   s = 0
@@ -275,6 +290,7 @@ def num_i32_flags(labels):
 class Context:
   opts: CanonicalOptions
   inst: ComponentInstance
+  call: Call
   called_as_export: bool
 
 #
@@ -290,7 +306,117 @@ class CanonicalOptions:
 class ComponentInstance:
   may_leave = True
   may_enter = True
-  # ...
+  handles: HandleTable
+
+  def __init__(self):
+    handles = HandleTable()
+
+#
+
+class Resource:
+  t: ResourceType
+  rep: int
+  borrowers: MutableMapping[ComponentInstance, int]
+
+  def __init__(self, t, rep):
+    self.t = t
+    self.rep = rep
+    self.borrowers = {}
+
+#
+
+class Handle:
+  resource: Resource
+  lend_count: int
+
+  def __init__(self, resource):
+    self.resource = resource
+    self.lend_count = 0
+
+class OwnHandle(Handle): pass
+class BorrowHandle(Handle): pass
+
+#
+
+class Call:
+  borrow_count: int
+  lenders: [OwnHandle]
+
+  def __init__(self):
+    self.borrow_count = 0
+    self.lenders = []
+
+  def finish_lift(self):
+    trap_if(self.borrow_count != 0)
+
+  def finish_lower(self):
+    assert(self.borrow_count == 0)
+    for h in self.lenders:
+      h.lend_count -= 1
+
+#
+
+class HandleTable:
+  array: [Optional[Handle]]
+  free: [int]
+
+  def __init__(self):
+    self.array = []
+    self.free = []
+
+  def insert(self, cx, h):
+    match h:
+      case OwnHandle():
+        assert(len(h.resource.borrowers) == 0)
+      case BorrowHandle():
+        if cx.inst in h.resource.borrowers:
+          return h.resource.borrowers[cx.inst]
+
+    if self.free:
+      i = self.free.pop()
+      assert(self.array[i] is None)
+      self.array[i] = h
+    else:
+      i = len(self.array)
+      self.array.append(h)
+
+    if isinstance(h, BorrowHandle):
+      h.resource.borrowers[cx.inst] = i
+      cx.call.borrow_count += 1
+    return i
+
+#
+
+  def get(self, i, rt):
+    trap_if(i >= len(self.array))
+    trap_if(self.array[i] is None)
+    trap_if(self.array[i].resource.t is not rt)
+    return self.array[i]
+
+#
+
+  def lend(self, cx, i, rt):
+    h = self.get(i, rt)
+    h.lend_count += 1
+    cx.call.lenders.append(h)
+    return h
+
+#
+
+  def remove(self, cx, i, t):
+    h = self.get(i, t.rt)
+    trap_if(h.lend_count != 0)
+    match t:
+      case Own(_):
+        trap_if(not isinstance(h, OwnHandle))
+        assert(len(h.resource.borrowers) == 0)
+      case Borrow(_):
+        trap_if(not isinstance(h, BorrowHandle))
+        cx.call.borrow_count -= 1
+        del h.resource.borrowers[cx.inst]
+    self.array[i] = None
+    self.free.append(i)
+    return h
 
 ### Loading
 
@@ -315,6 +441,8 @@ def load(cx, ptr, t):
     case Record(fields) : return load_record(cx, ptr, fields)
     case Variant(cases) : return load_variant(cx, ptr, cases)
     case Flags(labels)  : return load_flags(cx, ptr, labels)
+    case Own(_)         : return lift_own(cx, load_int(opts, ptr, 4), t)
+    case Borrow(_)      : return lift_borrow(cx, load_int(opts, ptr, 4), t)
 
 #
 
@@ -456,6 +584,16 @@ def unpack_flags_from_int(i, labels):
     i >>= 1
   return record
 
+#
+
+def lift_own(cx, i, t):
+  h = cx.inst.handles.remove(cx, i, t)
+  return h.resource
+
+def lift_borrow(cx, i, t):
+  h = cx.inst.handles.lend(cx, i, t.rt)
+  return h.resource
+
 ### Storing
 
 def store(cx, v, t, ptr):
@@ -479,6 +617,8 @@ def store(cx, v, t, ptr):
     case Record(fields) : store_record(cx, v, ptr, fields)
     case Variant(cases) : store_variant(cx, v, ptr, cases)
     case Flags(labels)  : store_flags(cx, v, ptr, labels)
+    case Own(rt)        : store_int(cx, lower_own(opts, v, rt), ptr, 4)
+    case Borrow(rt)     : store_int(cx, lower_borrow(opts, v, rt), ptr, 4)
 
 #
 
@@ -713,6 +853,18 @@ def pack_flags_into_int(v, labels):
     shift += 1
   return i
 
+#
+
+def lower_own(cx, resource, rt):
+  assert(resource.t is rt)
+  h = OwnHandle(resource)
+  return cx.inst.handles.insert(cx, h)
+
+def lower_borrow(cx, resource, rt):
+  assert(resource.t is rt)
+  h = BorrowHandle(resource)
+  return cx.inst.handles.insert(cx, h)
+
 ### Flattening
 
 MAX_FLAT_PARAMS = 16
@@ -752,6 +904,7 @@ def flatten_type(t):
     case Record(fields)       : return flatten_record(fields)
     case Variant(cases)       : return flatten_variant(cases)
     case Flags(labels)        : return ['i32'] * num_i32_flags(labels)
+    case Own(_) | Borrow(_)   : return ['i32']
 
 #
 
@@ -815,6 +968,8 @@ def lift_flat(cx, vi, t):
     case Record(fields) : return lift_flat_record(cx, vi, fields)
     case Variant(cases) : return lift_flat_variant(cx, vi, cases)
     case Flags(labels)  : return lift_flat_flags(vi, labels)
+    case Own(_)         : return lift_own(cx, vi.next('i32'), t)
+    case Borrow(_)      : return lift_borrow(cx, vi.next('i32'), t)
 
 #
 
@@ -912,6 +1067,8 @@ def lower_flat(cx, v, t):
     case Record(fields) : return lower_flat_record(cx, v, fields)
     case Variant(cases) : return lower_flat_variant(cx, v, cases)
     case Flags(labels)  : return lower_flat_flags(v, labels)
+    case Own(rt)        : return [Value('i32', lower_own(cx, v, rt))]
+    case Borrow(rt)     : return [Value('i32', lower_borrow(cx, v, rt))]
 
 #
 
@@ -1008,12 +1165,15 @@ def lower_values(cx, max_flat, vs, ts, out_param = None):
 
 ### `lift`
 
-def canon_lift(cx, callee, ft, args):
+def canon_lift(cx, callee, ft, call, args):
   if cx.called_as_export:
     trap_if(not cx.inst.may_enter)
     cx.inst.may_enter = False
   else:
     assert(not cx.inst.may_enter)
+
+  outer_call = cx.call
+  cx.call = call
 
   assert(cx.inst.may_leave)
   cx.inst.may_leave = False
@@ -1026,11 +1186,16 @@ def canon_lift(cx, callee, ft, args):
     trap()
 
   results = lift_values(cx, MAX_FLAT_RESULTS, ValueIter(flat_results), ft.result_types())
+
   def post_return():
     if cx.opts.post_return is not None:
       cx.opts.post_return(flat_results)
+
     if cx.called_as_export:
       cx.inst.may_enter = True
+
+    cx.call.finish_lift()
+    cx.call = outer_call
 
   return (results, post_return)
 
@@ -1039,10 +1204,13 @@ def canon_lift(cx, callee, ft, args):
 def canon_lower(cx, callee, ft, flat_args):
   trap_if(not cx.inst.may_leave)
 
+  outer_call = cx.call
+  cx.call = Call()
+
   flat_args = ValueIter(flat_args)
   args = lift_values(cx, MAX_FLAT_PARAMS, flat_args, ft.param_types())
 
-  results, post_return = callee(args)
+  results, post_return = callee(cx.call, args)
 
   cx.inst.may_leave = False
   flat_results = lower_values(cx, MAX_FLAT_RESULTS, results, ft.result_types(), flat_args)
@@ -1050,5 +1218,26 @@ def canon_lower(cx, callee, ft, flat_args):
 
   post_return()
 
+  cx.call.finish_lower()
+  cx.call = outer_call
+
   return flat_results
 
+### `resource.new`
+
+def canon_resource_new(cx, rt, rep):
+  h = OwnHandle(Resource(rt, rep))
+  return cx.inst.handles.insert(cx, h)
+
+### `resource.drop`
+
+def canon_resource_drop(cx, t, i):
+  h = cx.inst.handles.remove(cx, i, t)
+  if isinstance(t, Own) and t.rt.dtor:
+    t.rt.dtor(h.resource.rep)
+
+### `resource.rep`
+
+def canon_resource_rep(cx, rt, i):
+  h = cx.inst.handles.get(i, rt)
+  return h.resource.rep


### PR DESCRIPTION
(I'm publishing in draft state in case anyone wants to look at it before all the TODOs are filled in.  I think the essential additions in the AST and binary format are roughly right, I'm just filling in a bunch of explanatory prose/examples and the Canonical ABI Python definitions.)

This PR adds `resource`, `own` and `borrow` type constructors to the component model AST, binary format, text format which can serve as the underlying component-model semantics targeted by the current Wit syntax for resources.  The biggest change here is that, instead of having one shareable ref-counted handle type, we have two handle types: `own` representing unique ownership (like a `std::unique_ptr` in C++) and `borrow` representing a reference that can only be held onto for the duration of an export call (like a reference in C++ or Rust).  Based on feedback from the previous experiments, this unique ownership is important for performance, allowing host implementations to know, when they are passed a host resource (e.g., an HTTP Request) that the guest wasm code is no longer holding onto a handle, thereby allowing the host to do whatever it wants with the memory without first having to preserve a copy.  This also has software-engineering/composability benefits, preventing accidental interference when two components are linked together and pass handles between themselves.  There's more explanation of this in the PR itself (well, currently as TODOs, but there will be soon).


