### PR TITLE
Enums to be 1-indexed

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -74,11 +74,14 @@ def despecialize(t):
   match t:
     case Tuple(ts)         : return Record([ Field(str(i), t) for i,t in enumerate(ts) ])
     case Union(ts)         : return Variant([ Case(str(i), t) for i,t in enumerate(ts) ])
-    case Enum(labels)      : return Variant([ Case(l, None) for l in labels ])
+    case Enum(labels)      : return Variant([ Case("", None), ...Case(l, None) for l in labels ])
     case Option(t)         : return Variant([ Case("none", None), Case("some", t) ])
     case Result(ok, error) : return Variant([ Case("ok", ok), Case("error", error) ])
     case _                 : return t
 ```
+Enums start at the first index, permiting singular result code return patterns
+in corresponding core function ABIs.
+
 The specialized value types `string` and `flags` are missing from this list
 because they are given specialized canonical ABI representations distinct from
 their respective expansions.


### PR DESCRIPTION
In the guest C generator, it currently utilizes a pattern where a function that returns a `-> result<ok, code>` where `code` is an enum, will support outputting the common C-style error code function:

```c
typedef code_t uint8_t;
code_t func(ok_t* ret);
```

The success check on this function then effectively becomes - `code == -1` currently due to the `0` enum value being used, which is what is implemented currently in wit-bindgen.

If instead we start enums at 1, this check can be come a more standard `code == 0` success check.

I'm not sure the current ABI spec documents this coalescing fully yet, but at the very least it could be good to update the enum definition.