### PR TITLE
Add `use` and a binary format to WIT.md

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -102,10 +102,11 @@ not need to be specified as it's the `default`.
 ## WIT Worlds
 [worlds]: #wit-worlds
 
-WIT documents can contain a `world` annotation at the top-level in addition to
-[`interface`][interfaces]. A world is a complete description of both imports and
-exports of a component. A world can be thought of as an equivalent of a
-`component` type in the component model. For example this world:
+WIT documents can contain a `world` definition at the top-level in addition to
+[`interface`][interfaces] definitions. A world is a complete description of
+both imports and exports of a component. A world can be thought of as an
+equivalent of a `component` type in the component model. For example this
+world:
 
 ```wit
 world my-world {
@@ -136,13 +137,13 @@ Worlds can contain any number of imports and exports, and can be either a
 function or an interface.
 
 ```wit
-world wasi {
-  import wasi-fs: wasi.fs
-  import wasi-random: wasi.random
-  import wasi-clock: wasi.clock
+world command {
+  import fs: wasi-fs.fs
+  import random: wasi-random.random
+  import clock: wasi-clock.clock
   // ...
 
-  export command: func(args: list<string>)
+  export main: func(args: list<string>)
 }
 ```
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -513,30 +513,6 @@ characters and numbers that are `-` separated.
 
 For more information on this see the [binary format](./Binary.md).
 
-## WIT in Markdown
-[markdown]: #wit-in-markdown
-
-The WIT text format can also additionally be parsed from markdown files with the
-extension `wit.md`, for example `foo.wit.md`:
-
-    # This would be
-
-    Some markdown text
-
-    ```wit
-    // interspersed with actual `*.wit`
-    interface my-interface {
-    ```
-
-    ```wit
-    // which can be broken up between multiple blocks
-    }
-    ```
-
-Triple-fence code blocks with the `wit` marker will be extracted from a markdown
-file and concatenated into a single string which is then parsed as a normal
-`*.wit` file.
-
 # Lexical structure
 [lexical-structure]: #lexical-structure
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -160,7 +160,7 @@ interface out-of-line {
 
 world your-world {
   import out-of-line: self.out-of-line
-  // ... is roughtly equivalent to ...
+  // ... is roughly equivalent to ...
   import out-of-line2: interface {
     the-function: func()
   }
@@ -259,7 +259,7 @@ interface my-host-functions {
 }
 ```
 
-Here `more-types in the `use` path indicates that it's the specific interface
+Here `more-types` in the `use` path indicates that it's the specific interface
 being referenced. Documents in a WIT package must be named after a [valid
 identifier][identifiers] and be unique within the package. Documents cannot
 contain cycles between them as well with `use` statements.
@@ -303,7 +303,7 @@ do not need to conflict with dependency names in other packages. This enables
 each package to be resolved entirely separately and, if necessary, the name
 `foo` could mean different things to different packages.
 
-> **Note**: The tooling for and mechanism for precisly how these external names
+> **Note**: The tooling for and mechanism for precisely how these external names
 > are defined is not specified here. This is something that will be iterated on
 > to create documentation of the tooling in question and community standards
 > about how best to do this.

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -34,7 +34,7 @@ would correspond to:
 
 ```wasm
 (component
-  (import "host" (insance $host
+  (import "host" (instance $host
     (export "log" (func (param "msg" string)))
   ))
   ;; ...
@@ -157,7 +157,7 @@ reusability. This enables a sort of module system for WIT syntax where files may
 import from one another.
 
 > **Note**: The precise semantics of imports and how everything maps out is
-> still being design. Basic filesystem-based organization works but it's
+> still being designed. Basic filesystem-based organization works but it's
 > intended to extend to URL-based organization in the near future. For example
 > the strings below are intended to integrate into a registry-based workflow as
 > well in addition to looking up files on the filesystem.
@@ -343,7 +343,7 @@ world my-world {
 }
 ```
 
-This is an invalid WIT document due because `my-world` needs to import two
+This is an invalid WIT document because `my-world` needs to import two
 unique interfaces called `shared`. To disambiguate a manual import is required:
 
 ```

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -606,6 +606,7 @@ keyword ::= 'use'
           | 'import'
           | 'export'
           | 'default'
+          | 'in'
 ```
 
 ## Top-level items

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -627,16 +627,17 @@ Worlds define a [componenttype](https://github.com/WebAssembly/component-model/b
 Concretely, the structure of a world is:
 
 ```wit
-world-item ::= 'world' id '{' world-items* '}'
+world-item ::= 'default'? 'world' id '{' world-items* '}'
 
 world-items ::= export-item | import-item
 
 export-item ::= 'export' id ':' extern-type
 import-item ::= 'import' id ':' extern-type
 
-extern-type ::= ty | func-type | interface-type
+extern-type ::= func-type | interface-type
 
 interface-type ::= 'interface' '{' interface-items* '}'
+                 | use-from
 ```
 
 ## Item: `interface`

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -368,7 +368,7 @@ interface shared {
 
 world my-world {
   import host: interface {
-    use self.shared.{metadata})
+    use self.shared.{metadata}
 
     get: func() -> metadata
   }

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -390,9 +390,9 @@ would generate this component:
 ```
 
 Here it can be seen that despite the `world` only listing `host` as an import
-the component additionally import a `shared` instance. This is due to the fact
+the component additionally imports a `shared` instance. This is due to the fact
 that the `use { ... } from shared` implicitly requires that `shared` is imported
-to the component as well.
+into the component as well.
 
 Note that the name `"shared"` here is derived from the name of the `interface`
 which can also lead to conflicts:
@@ -1124,7 +1124,7 @@ would correspond to:
 (component
   (type (export "host") (component
     (type $types (instance
-      (export "enum" (type (enum "info" "debug")))
+      (export "level" (type (enum "info" "debug")))
     ))
     (export $types "types" (instance (type $types)))
     (alias export $types "level" (type $level))


### PR DESCRIPTION
This commit brings the `WIT.md` file up-to-date with recent developments in WIT, chifely the `use` syntax. I've added a new "introduction section" which is a higher-level explanation of the format than the lexical/syntactic structure. I've also edited the syntactic structure to clarify a few old references and remove `resource`, `future`, and `stream` types for now. (resources to be added soon I suspect)

Additionally I've added a description of a binary format for WIT based on the component model. This binary format is intended to be the "types only" mode of the `wasm-tools component` tooling, although it doesn't match the current implementation and the `wasm-tools` repo will need to be updated. This representation, however, provides the means by which to understand what it means for a component to have the type of a `world`, namely it's a subtype of the binary representation's component type.

Closes #140