### PR TITLE
Loosen type-export validation rules

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -260,8 +260,6 @@ Notes:
 * Validation rejects `resourcetype` type definitions inside `componenttype` and
   `instancettype`. Thus, handle types inside a `componenttype` can only refer
   to resource types that are imported or exported.
-* Validation requires that all resource types transitively used in the type of an
-  export are introduced by a preceding `exportdecl`.
 * The uniqueness validation rules for `externname` described below are also
   applied at the instance- and component-type level.
 * Validation of `externdesc` requires the various `typeidx` type constructors
@@ -335,7 +333,7 @@ Notes:
 * All exports (of all `sort`s) introduce a new index that aliases the exported
   definition and can be used by all subsequent definitions just like an alias.
 * Validation requires that all resource types transitively used in the type of an
-  export are introduced by a preceding `exportdecl`.
+  export are introduced by a preceding `importdecl` or `exportdecl`.
 * The "parses as a URL" condition is defined by executing the [basic URL
   parser] with `char(b)*` as *input*, no optional parameters and non-fatal
   validation errors (which coincides with definition of `URL` in JS and `rust-url`).


### PR DESCRIPTION
This PR slightly relaxes the validation criteria around exports to allow them to refer to *either* imported or exported resource types (not just exported resource types).  What's still disallowed is referring to private resource types in the types of exports.  Because private resource type definitions cannot appear inside `componenttype`/`instancetype` (which this PR adds to Explainer.md to match Binary.md), that means that there is nothing extra to validate at the type-level, only at the component-definition-level.