### PR TITLE
Move resource type tag to handle

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -995,6 +995,14 @@ replaced by `$R` when validating the instantiations of `$c1` and `$c2`. These
 type-checking rules for instantiating type imports mirror the *elimination*
 rule of [universal types]  (∀T).
 
+Importantly, this type substitution performed by the parent is not visible to
+the child at validation- or run-time. In particular, the type checks performed
+by the [Canonical ABI](CanonicalABI.md#context) use distinct type tags for
+distinct type imports and associate type tags with *handles*, not the underlying
+*resource*, leveraging the shared-nothing nature of components to type-tag handles
+at component boundaries and avoid the usual [type-exposure problems with
+dynamic casts][non-parametric parametricity].
+
 In summary: all type constructors are *structural* with the exception of
 `resource`, which is *abstract* and *generative*. Type imports and exports that
 have a subtype bound also introduce abstract types and follow the standard
@@ -1816,8 +1824,10 @@ and will be added over the coming months to complete the MVP proposal:
 [Subtyping]: https://en.wikipedia.org/wiki/Subtyping
 [Universal Types]: https://en.wikipedia.org/wiki/System_F
 [Existential Types]: https://en.wikipedia.org/wiki/System_F
+
 [Generative]: https://www.researchgate.net/publication/2426300_A_Syntactic_Theory_of_Type_Generativity_and_Sharing
 [Avoidance Problem]: https://counterexamples.org/avoidance.html
+[Non-Parametric Parametricity]: https://people.mpi-sws.org/~dreyer/papers/npp/main.pdf
 
 [URL Standard]: https://url.spec.whatwg.org
 [URI]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -315,22 +315,20 @@ class ComponentInstance:
 
 #
 
+@dataclass
 class Resource:
-  t: ResourceType
   rep: int
-
-  def __init__(self, t, rep):
-    self.t = t
-    self.rep = rep
 
 #
 
 class Handle:
   resource: Resource
+  rt: ResourceType
   lend_count: int
 
-  def __init__(self, resource):
+  def __init__(self, resource, rt):
     self.resource = resource
+    self.rt = rt
     self.lend_count = 0
 
 class OwnHandle(Handle): pass
@@ -381,7 +379,7 @@ class HandleTable:
   def get(self, i, rt):
     trap_if(i >= len(self.array))
     trap_if(self.array[i] is None)
-    trap_if(self.array[i].resource.t is not rt)
+    trap_if(self.array[i].rt is not rt)
     return self.array[i]
 
 #
@@ -845,13 +843,11 @@ def pack_flags_into_int(v, labels):
 #
 
 def lower_own(cx, resource, rt):
-  assert(resource.t is rt)
-  h = OwnHandle(resource)
+  h = OwnHandle(resource, rt)
   return cx.inst.handles.insert(cx, h)
 
 def lower_borrow(cx, resource, rt):
-  assert(resource.t is rt)
-  h = BorrowHandle(resource)
+  h = BorrowHandle(resource, rt)
   return cx.inst.handles.insert(cx, h)
 
 ### Flattening
@@ -1215,7 +1211,7 @@ def canon_lower(cx, callee, ft, flat_args):
 ### `resource.new`
 
 def canon_resource_new(cx, rt, rep):
-  h = OwnHandle(Resource(rt, rep))
+  h = OwnHandle(Resource(rep), rt)
   return cx.inst.handles.insert(cx, h)
 
 ### `resource.drop`

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -381,15 +381,15 @@ def test_handles():
     nonlocal dtor_value
     dtor_value = x
   rt = ResourceType(dtor)
-  r1 = Resource(rt, 42)
-  r2 = Resource(rt, 43)
-  r3 = Resource(rt, 44)
+  r1 = Resource(42)
+  r2 = Resource(43)
+  r3 = Resource(44)
 
   def host_import(act, args):
     assert(len(args) == 2)
     assert(args[0] is r1)
     assert(args[1] is r3)
-    return ([Resource(rt, 45)], lambda:())
+    return ([Resource(45)], lambda:())
 
   cx = mk_cx()
   def core_wasm(args):


### PR DESCRIPTION
This tweak to the runtime semantics of the Canonical ABI ensures that components can't use the dynamic type checks (performed when lifting a handle from an untyped `i32` index into a homogeneous table) to uncover whether different type imports are in fact the same or, in a future state with resource subtyping, to uncover undeclared subtyping relationships between type imports.  The problem and solution to this problem were presented [way back](https://docs.google.com/presentation/d/1ikwS2Ps-KLXFofuS5VAs6Bn14q4LBEaxMjPfLj61UZE/edit#slide=id.gb40360eb39_0_290) but then I forgot all about it.