### PR TITLE
Prepare binary/text format of imports/exports for future additions

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -324,10 +324,12 @@ flags are set.
 (See [Import and Export Definitions](Explainer.md#import-and-export-definitions)
 in the explainer.)
 ```
-import     ::= en:<externname> ed:<externdesc>                => (import en ed)
-export     ::= en:<externname> si:<sortidx> ed?:<externdesc>? => (export en si ed?)
-externname ::= n:<name> u?:<URL>?                             => n u?
-URL        ::= b*:vec(byte)                                   => char(b)*, if char(b)* parses as a URL
+import      ::= en:<externname> ed:<externdesc>                => (import en ed)
+export      ::= en:<externname> si:<sortidx> ed?:<externdesc>? => (export en si ed?)
+externname  ::= n:<name> ea:<externattrs>                      => n ea
+externattrs ::= 0x00                                           => ϵ
+              | 0x01 url:<URL>                                 => (id url)
+URL         ::= b*:vec(byte)                                   => char(b)*, if char(b)* parses as a URL
 ```
 Notes:
 * All exports (of all `sort`s) introduce a new index that aliases the exported


### PR DESCRIPTION
This PR tweaks the text format so that additional sub-fields of `externname` (such as versions) can be added in the future without introducing grammatical ambiguities by wrapping the existing `<URL>?` field with `(id <URL>)?`.

The PR also refactors the binary format grammar of `externname` so that new subfields of `externname` can be added by setting new bits in a flags byte (that could be extended to a LEB128 if more than 7 were needed), with one bit per subsequent optional immediate.  This is just a refactoring though because the binary format doesn't actually change; the leading boolean byte of the `<URL>?` immediate is simply recast as a flags byte.

~~Lastly, and this is also purely spec-internal refactoring, the grammatical production `externdesc` is renamed to `externtype` (since it just holds a type) so that "`externdesc`" can be repurposed to be a sub-production of `externname` that holds the "descriptive" part of the name.~~[EDIT: This would've been asymmetric with core wasm's use of `externdesc`, so reverted this part of the change and introduced the new production name `externattrs` instead.]