### PR TITLE
tweak type ascription validation rules to check subtyping

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -339,9 +339,8 @@ Notes:
   validation errors (which coincides with definition of `URL` in JS and `rust-url`).
 * Validation requires any exported `sortidx` to have a valid `externdesc`
   (which disallows core sorts other than `core module`). When the optional
-  `externdesc` immediate is present, validation requires it to be equal to
-  the inferred `externdesc` of the `sortidx` (where equality judges a type and
-  the `typeidx` of an export of that type (via `eq` or `sub`) equivalent).
+  `externdesc` immediate is present, validation requires it to be a supertype
+  of the inferred `externdesc` of the `sortidx`.
 * The `name` fields of `externname` must be unique among imports and exports,
   respectively. The `URL` fields of `externname` (that are present) must
   independently unique among imports and exports, respectively.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1313,9 +1313,10 @@ exported).
 Validation of `export` requires that all transitive uses of resource types in
 the types of exported functions or values refer to resources that were either
 imported or exported (concretely, via the type index introduced by an `import`
-or `export`). The optional `<externdesc>?` in `export` can be used to ascribe
-an equivalent-but-different type to an exported definition, allowing a private
-type definition to be replaced with a public (exported) type definition.
+or `export`). The optional `<externdesc>?` in `export` can be used to
+explicitly ascribe a type to an export which is validated to be a supertype of
+the definition's type, thereby allowing a private (non-exported) type
+definition to be replaced with a public (exported) type definition.
 
 For example, in the following component:
 ```wasm


### PR DESCRIPTION
Everywhere else in Component Model validation checks subtyping, not "equality", so it makes sense for the export type ascription to use that condition as well.