### PR TITLE
Move definition of `Flags`

### DIFF
--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -129,10 +129,6 @@ class Tuple(ValType):
   ts: [ValType]
 
 @dataclass
-class Flags(ValType):
-  labels: [str]
-
-@dataclass
 class Case:
   label: str
   t: Optional[ValType]
@@ -158,6 +154,10 @@ class Option(ValType):
 class Result(ValType):
   ok: Optional[ValType]
   error: Optional[ValType]
+
+@dataclass
+class Flags(ValType):
+  labels: [str]
 
 @dataclass
 class ResourceType(Type):


### PR DESCRIPTION
This makes the ordering of definitions and match branches more consistent.