### PR TITLE
Tighten validation to require uniqueness between import and export kebab-names

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -343,9 +343,12 @@ Notes:
   (which disallows core sorts other than `core module`). When the optional
   `externdesc` immediate is present, validation requires it to be a supertype
   of the inferred `externdesc` of the `sortidx`.
-* The `name` fields of `externname` must be unique among imports and exports,
-  respectively. The `URL` fields of `externname` (that are present) must
-  independently unique among imports and exports, respectively.
+* The `name` fields of `externname` must be unique among all imports and exports
+  in the containing component definition, component type or instance type. (An
+  import and export cannot use the same `name`.)
+* The `id` fields of `externname` (that are present) must independently be
+  unique among imports and exports, respectively. (An import and export *may*
+  have the same `id`.)
 * URLs are compared for equality by plain byte identity.
 
 ## Name Section

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1348,9 +1348,13 @@ subdivision of external names allows component producers to represent a variety
 of intentions for how a component is to be instantiated and executed so that a
 variety of hosts can portably execute the component.
 
-The `name` field of `externname` is required to be unique. Thus, a single
-`name` has been used in the preceding definitions of `with` and `alias` to
-uniquely identify imports and exports.
+The `name` field of `externname` is required to be unique between all the imports
+and exports of a component definition, component type or instance type. Thus, a
+single `name` can be used to unambiguously select any import or export. Based on
+this, `with` and `alias` can use a `name` (not `externname`) to select an
+import or export. The uniqueness between imports and exports ensures that Wit
+and language bindings don't have to worry about separately namespacing imports
+and exports.
 
 In guest source-code bindings, the `name` is meant to be translated to
 source-language identifiers (applying case-conversion, as described


### PR DESCRIPTION
Recently, I've seen a few cases where the possibility of overlap between the kebab-names of imports and exports has led to additional complexity that seems unnecessary given that the whole point of kebab-names is to provide a nice local developer-friendly names that can be renamed in cases of collision without impacting meaning (which is where the `(id <URL>)` subfield come in instead).  Thus, this PR suggests tightening the validation rules for component-level `externname`s to rule out these cases of overlap.  E.g., with this change, the names of imports and exports in a Wit `world` can share a single namespace.