### PR TITLE
Add an `include` keyword

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -954,7 +954,7 @@ include-item ::= 'include' use-path
                | 'include' use-path 'with' '{' include-names-list '}'
 
 include-names-list ::= include-names-item
-                 | include-names-item ',' include-names-item?
+                     | include-names-list ',' include-names-item
 
 include-names-item ::= id 'as' id
 ```

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -287,7 +287,7 @@ The `include` statement also works with [WIT package](#wit-packages-and-use) def
 interface b { ... }
 
 // a.wit
-interface a {}
+interface a { ... }
 
 world my-world-a {
     import a

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -338,10 +338,7 @@ world union-my-world-b {
 
 ### Name Conflicts and `with`
 
-When two or more included Worlds have the same name for an import or export, the name is considered to be in conflict. The conflict needs to be explicitly resolved by the world author using the `with` keyword. `with` allows the world author to rename the import or export to a different name.
-
-Notice that when import or export names are IDs and since IDs are unique, there is no need to resolve name conflicts. Thus the `with` syntax is invalid when used with `include <ID>`. Only when import or export names are kebab names, name conflicts need to be resolved.
-
+When two or more included Worlds have the same name for an import or export that does *not* have an ID, automatic de-duplication cannot be used (because the two same-named imports/exports might have different meanings in the different worlds) and thus the conflict has to be resolved manually using the `with` keyword:
 The following example shows how to resolve name conflicts where `union-my-world-a` and `union-my-world-b` are equivalent:
 
 ```wit

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -283,10 +283,9 @@ world union-my-world {
 The `include` statement also works with [WIT package](#wit-packages-and-use) defined below with the same semantics. For example, the following World `union-my-world-a` is equivalent to `union-my-world-b`:
 
 ```wit
-// b.wit
-interface b { ... }
+package local:demo
 
-// a.wit
+interface b { ... }
 interface a { ... }
 
 world my-world-a {
@@ -295,9 +294,6 @@ world my-world-a {
     import wasi:io/c
     export d: interface { ... }
 }
-
-// union.wit
-package local:demo
 
 world union-my-world-a {
     include my-world-a
@@ -344,7 +340,7 @@ world union-my-world-b {
 
 When two or more included Worlds have the same name for an import or export, the name is considered to be in conflict. The conflict needs to be explicitly resolved by the world author using the `with` keyword. `with` allows the world author to rename the import or export to a different name.
 
-Notice that when import or export names are IDs and since IDs are unique, there is no need to resolve name conflicts. Thus the `with` syntax is a no-op in this case. Only when import or export names are kebab names, name conflicts need to be resolved.
+Notice that when import or export names are IDs and since IDs are unique, there is no need to resolve name conflicts. Thus the `with` syntax is invalid when used with `include <ID>`. Only when import or export names are kebab names, name conflicts need to be resolved.
 
 The following example shows how to resolve name conflicts where `union-my-world-a` and `union-my-world-b` are equivalent:
 
@@ -365,9 +361,9 @@ world union-my-world-b {
 }
 ```
 
-The following example shows that `with` is a no-op when the import or export name is an ID:
+The following example shows an invalid example that `with` is used when the import or export name is an ID:
 
-```wit
+```wi
 package local:demo
 
 world my-world-a {
@@ -383,11 +379,6 @@ world my-world-b {
 world union-my-world-a {
     include my-world-a with { a1 as a3 }
     include my-world-b with { a1 as a2 }
-}
-
-world union-my-world-a {    
-  import a1
-  import b1
 }
 ```
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -358,26 +358,21 @@ world union-my-world-b {
 }
 ```
 
-The following example shows an invalid example that `with` is used when the import or export name is an ID:
-
-```wi
+`with` cannot be used to rename IDs, however, so the following world would be invalid:
+```wit
 package local:demo
 
-world my-world-a {
-    import a1
-    import b1
+interface a {
+    foo: func()
 }
 
-world my-world-b {
-    import a1
-    import b1
+world world-using-a {
+    import a
 }
 
-world union-my-world-a {
-    include my-world-a with { a1 as a3 }
-    include my-world-b with { a1 as a2 }
+world invalid-union-world {
+    include my-using-a with { a as b }  // invalid: 'a', which is short for 'local:demo/a', is an ID
 }
-```
 
 ### A Note on SubTyping
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -312,32 +312,9 @@ world union-my-world-b {
 }
 ```
 
-### Name Conflicts
+### De-duplication of IDs
 
-When two or more included Worlds have the same name for an import or export, the name is considered to be in conflict. The conflict needs to be explicitly resolved by the world author using the `with` keyword. `with` allows the world author to rename the import or export to a different name.
-
-The following example shows how to resolve name conflicts where `union-my-world-a` and `union-my-world-b` are equivalent:
-
-```wit
-package local:demo
-
-world world-one { import a: func() }
-world world-two { import a: func() }
-
-world union-my-world-a { 
-    include foo
-    include bar with { a as b }
-}
-
-world union-my-world-b {
-  import a: func()
-  import b: func()
-}
-```
-
-### De-duplication
-
-If two worlds shared the same set of imports and exports, then the union of the two worlds will only contain one copy of the set of shared imports and exports. For example, the following two worlds `union-my-world-a` and `union-my-world-b` are equivalent:
+If two worlds shared the same set of import and export IDs, then the union of the two worlds will only contain one copy of this set. For example, the following two worlds `union-my-world-a` and `union-my-world-b` are equivalent:
 
 ```wit
 package local:demo
@@ -360,6 +337,57 @@ world union-my-world-a {
 world union-my-world-b {
     import a1
     import b1
+}
+```
+
+### Name Conflicts and `with`
+
+When two or more included Worlds have the same name for an import or export, the name is considered to be in conflict. The conflict needs to be explicitly resolved by the world author using the `with` keyword. `with` allows the world author to rename the import or export to a different name.
+
+Notice that when import or export names are IDs and since IDs are unique, there is no need to resolve name conflicts. Thus the `with` syntax is a no-op in this case. Only when import or export names are kebab names, name conflicts need to be resolved.
+
+The following example shows how to resolve name conflicts where `union-my-world-a` and `union-my-world-b` are equivalent:
+
+```wit
+package local:demo
+
+world world-one { import a: func() }
+world world-two { import a: func() }
+
+world union-my-world-a { 
+    include foo
+    include bar with { a as b }
+}
+
+world union-my-world-b {
+  import a: func()
+  import b: func()
+}
+```
+
+The following example shows that `with` is a no-op when the import or export name is an ID:
+
+```wit
+package local:demo
+
+world my-world-a {
+    import a1
+    import b1
+}
+
+world my-world-b {
+    import a1
+    import b1
+}
+
+world union-my-world-a {
+    include my-world-a with { a1 as a3 }
+    include my-world-b with { a1 as a2 }
+}
+
+world union-my-world-a {    
+  import a1
+  import b1
 }
 ```
 
@@ -917,8 +945,8 @@ to `interface` items.
 A `include` statement enables the union of the current world with another world. The structure of an `include` statement is:
 
 ```wit
-include pkg.my-world-1 with { a as a1, b as b1 }
-include self.my-world-2
+include wasi:io/my-world-1 with { a as a1, b as b1 }
+include my-world-2
 ```
 
 ```ebnf

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -363,9 +363,9 @@ world my-world-1 {
 
 // my-world-2.wit
 world my-world-2 {
-    import a2: pkg.a
-    import b2: pkg.b
-    export c2: pkg.c
+    import a1: pkg.a
+    import b1: pkg.b
+    export c1: pkg.c
 }
 
 // union.wit
@@ -381,7 +381,29 @@ world union-my-world-4 {
 }
 ```
 
-As you can see, the names of the imports and exports in "union-my-world-4" are picking up the names from the first included world. This is because the second included world has structurally the same imports and exports and are deduplicated.
+Notice that if the two included worlds have different names for the same import or export, then it will be considered as an error, even if the interfaces are strcuturally the same. For example, the following worlds `my-world-1` and `my-world-2` are not structurally equivalent, but the `include` statement will report an error:
+
+```wit
+// my-world-1.wit
+world my-world-1 {
+    import a1: pkg.a
+    import b1: pkg.b
+    export c1: pkg.c
+}
+
+// my-world-2.wit
+world my-world-2 {
+    import a2: pkg.a
+    import b2: pkg.b
+    export c2: pkg.c
+}
+
+// union.wit
+world union-my-world-3 {
+    include pkg.my-world-1
+    include pkg.my-world-2
+}
+```
 
 ### De-duplication with `with`
 
@@ -420,9 +442,9 @@ world union-my-world-6 {
 
 ### A Note on SubTyping
 
-As of now, host bindings are required to implicitly interpret all exports as optional to make a component targeting an included World a subtype of the union World. This [comment](https://github.com/WebAssembly/component-model/issues/169#issuecomment-1446776193) describes the reasoning behind this decision.
-
 In the future, when `optional` export is supported, the world author may explicitly mark exports as optional to make a component targeting an included World a subtype of the union World.
+
+For now, we are not following the subtyping rules for the `include` statement. That is, the `include` statement does not imply any subtyping relationship between the included worlds and the union world.
 
 ## WIT Packages and `use`
 [use]: #wit-packages-and-use

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -914,7 +914,7 @@ to `interface` items.
 
 ## Item: `include`
 
-A `include` statement enables union the current world with another world. The structure of an `include` statement is:
+A `include` statement enables the union of the current world with another world. The structure of an `include` statement is:
 
 ```wit
 include pkg.my-world-1 with { a as a1, b as b1 }

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -238,8 +238,7 @@ explicitly imported or exported twice.
 
 ### Union of Worlds with `include`
 
-A World can be created by taking the union of two or more worlds. This operation allows
-world builders to form larger worlds from smaller worlds.
+A World can be created by taking the union of two or more worlds. This operation allows world builders to form larger worlds from smaller worlds.
 
 Below is a simple example of a world that includes two other worlds.
 
@@ -263,9 +262,7 @@ world union-my-world {
 }
 ```
 
-The `include` statement is used to include the imports and exports of another World to the
-current World. It says that the new World should be able to run all components that target
-the included worlds and more.
+The `include` statement is used to include the imports and exports of another World to the current World. It says that the new World should be able to run all components that target the included worlds and more.
 
 The `union-my-world` World defined above is equivalent to the following World:
 
@@ -321,15 +318,15 @@ The following example shows how to resolve name conflicts where `union-my-world-
 ```wit
 // my-world-1.wit
 world my-world-1 {
-    import a: self.a
-    import b: self.b
+    import a: self.a1
+    import b: self.b1
     export d: self.d
 }
 
 // my-world-2.wit
 world my-world-2 {
-    import a: self.a
-    import b: self.b
+    import a: self.a2
+    import b: self.b2
     export c: self.c
 }
 
@@ -341,39 +338,34 @@ world union-my-world-1 {
 
 world union-my-world-2 {
     // resolve conflicts
-    import a1: pkg.my-world-1.a
-    import b1: pkg.my-world-1.b
+    import a1: pkg.my-world-1.a1
+    import b1: pkg.my-world-1.b1
     export d: pkg.my-world-1.d
 
-    import a: pkg.my-world-2.a
-    import b: pkg.my-world-2.b
+    import a: pkg.my-world-2.a2
+    import b: pkg.my-world-2.b2
     export c: pkg.my-world-2.c
 }
 ```
 
-### De-duplication (In the future)
+### De-duplication
 
-As of now, the `include` statement requires the world author to explicitly rename the imports and exports that have the same name.
-
-In the future, we may allow to de-duplicate the imports and exports of the included worlds if the yare structurally equivalent following the [Subtyping](Subtyping.md) rules. For example, the following world `union-my-world-3` is equivalent to `union-my-world-4`:
+If two interfaces have the same structure, then these two interfaces are considered to be structurally equivalent. The `include` statement can
+deduplicate the imports and exports of the included worlds if the they are structurally equivalent following the [Subtyping](Subtyping.md) rules. For example, the following world `union-my-world-3` is equivalent to `union-my-world-4`:
 
 ```wit
-// a.wit
-// b.wit
-// c.wit
-
 // my-world-1.wit
 world my-world-1 {
-    import a: pkg.a
-    import b: pkg.b
-    export c: pkg.c
+    import a1: pkg.a
+    import b1: pkg.b
+    export c1: pkg.c
 }
 
 // my-world-2.wit
 world my-world-2 {
-    import a: pkg.a
-    import b: pkg.b
-    export c: pkg.c
+    import a2: pkg.a
+    import b2: pkg.b
+    export c2: pkg.c
 }
 
 // union.wit
@@ -383,10 +375,47 @@ world union-my-world-3 {
 }
 
 world union-my-world-4 {
-    import a: pkg.a
-    import b: pkg.b
+    import a1: pkg.a
+    import b1: pkg.b
+    export c1: pkg.c
+}
+```
+
+As you can see, the names of the imports and exports in "union-my-world-4" are picking up the names from the first included world. This is because the second included world has structurally the same imports and exports and are deduplicated.
+
+### De-duplication with `with`
+
+When two worlds have both name conflicts and structurally equivalent imports and exports, the semantics of `include` will do deduplication first and then resolve the name conflicts with `with` statements. For example, the following world `union-my-world-5` is equivalent to `union-my-world-6`:
+
+```wit
+
+// my-world-1.wit
+world my-world-1 {
+    import a1: pkg.a
+    import b1: pkg.b
     export c: pkg.c
 }
+
+// my-world-2.wit
+world my-world-2 {
+    import a1: pkg.a
+    import b1: pkg.b
+    export c: pkg.d
+}
+
+// union
+world union-my-world-5 {
+    include pkg.my-world-1 with { c as c1 }
+    include pkg.my-world-2
+}
+
+world union-my-world-6 {
+    import a1: pkg.a
+    import b1: pkg.b
+    export c1: pkg.c
+    export c: pkg.d
+}
+
 ```
 
 ### A Note on SubTyping

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -281,10 +281,10 @@ The `include` statement also works with [WIT package](#wit-packages-and-use) def
 
 ```wit
 // b.wit
-interface b { ... }
+default interface b { ... }
 
 // a.wit
-interface a { ... }
+default interface a { ... }
 
 world my-world-1 {
     import a: self.a 
@@ -296,7 +296,7 @@ world my-world-1 {
 // union.wit
 
 world union-my-world-1 {
-    include pkg.my-world-1
+    include pkg.a.my-world-1
 }
 
 world union-my-world-2 {

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -699,6 +699,7 @@ keyword ::= 'use'
           | 'import'
           | 'export'
           | 'package'
+          | 'include'
 ```
 
 ### Integers
@@ -766,7 +767,7 @@ Concretely, the structure of a world is:
 ```ebnf
 world-item ::= 'world' id '{' world-items* '}'
 
-world-items ::= export-item | import-item | use-item | typedef-item
+world-items ::= export-item | import-item | use-item | typedef-item | include-item
 
 export-item ::= 'export' id ':' extern-type
               | 'export' interface
@@ -780,6 +781,25 @@ Note that worlds can import types and define their own types to be exported
 from the root of a component and used within functions imported and exported.
 The `interface` item here additionally defines the grammar for IDs used to refer
 to `interface` items.
+
+## Item: `include`
+
+A `include` statement enables union the current world with another world. The structure of an `include` statement is:
+
+```wit
+include pkg.my-world-1 with { a as a1, b as b1 }
+include self.my-world-2
+```
+
+```ebnf
+include-item ::= 'include' use-path
+               | 'include' use-path 'with' '{' include-names-list '}'
+
+include-names-list ::= include-names-item
+                 | include-names-item ',' include-names-item?
+
+include-names-item ::= id 'as' id
+```
 
 ## Item: `interface`
 


### PR DESCRIPTION
As proposed by #169 , this PR adds an `include` keyword to the WIT.md. It also sorts the keyword list alphabetically. 