### PR TITLE
optimize resource/handle representation

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -968,10 +968,18 @@ def lower_own(cx, src, rt):
 
 def lower_borrow(cx, src, rt):
   assert(isinstance(src, Handle))
+  if cx.inst is rt.impl:
+    return src.rep
   cx.borrow_scope.add(src)
   h = BorrowHandle(src.rep, rt, 0, cx.borrow_scope)
   return cx.inst.handles.insert(h)
 ```
+The special case in `lower_borrow` is an optimization, recognizing that, when
+a borrowed handle is passed to the component that implemented the resource
+type, the only thing the borrowed handle is good for is calling
+`resource.rep`, so lowering might as well avoid the overhead of creating an
+intermediate borrow handle.
+
 Note that the `rt` value that is stored in the runtime `Handle` captures what
 is statically known about the handle right before losing this information in
 the homogeneous `HandleTable`. Moreoever, as described above, distinct type

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -241,21 +241,20 @@ canonical definition is defined to execute inside. The `may_enter` and
 `may_leave` fields are used to enforce the [component invariants]: `may_leave`
 indicates whether the instance may call out to an import and the `may_enter`
 state indicates whether the instance may be called from the outside world
-through an export. The `HandleTable` is defined next.
+through an export.
 ```python
 class ComponentInstance:
   may_leave: bool
   may_enter: bool
-  handles: HandleTable
+  handles: HandleTables
 
   def __init__(self):
     self.may_leave = True
     self.may_enter = True
-    self.handles = HandleTable()
+    self.handles = HandleTables()
 ```
-
-The `HandleTable` class is defined in terms of a collection of supporting
-runtime bookkeeping classes that we'll go through first.
+`HandleTables` is defined in terms of a collection of supporting runtime
+bookkeeping classes that we'll go through first.
 
 The `ResourceType` class represents a resource type that has been defined by
 the specific component instance pointed to by `impl` with a particular
@@ -275,7 +274,6 @@ handle refers to.
 @dataclass
 class Handle:
   rep: int
-  rt: ResourceType
   lend_count: int
 
 @dataclass
@@ -286,13 +284,10 @@ class OwnHandle(Handle):
 class BorrowHandle(Handle):
   scope: BorrowScope
 ```
-The `rt` field points to a runtime value representing the static
-[`resourcetype`](Explainer.md#type-definitions) of this handle and is used by
-dynamic type checking below. Lastly, the `lend_count` field maintains a count
-of the outstanding handles that were lent from this handle (by calls to
-`borrow`-taking functions). This count is used below to dynamically enforce the
-invariant that a handle cannot be dropped while it has currently lent out a
-`borrow`.
+The `lend_count` field maintains a count of the outstanding handles that were
+lent from this handle (by calls to `borrow`-taking functions). This count is
+used below to dynamically enforce the invariant that a handle cannot be
+dropped while it has currently lent out a `borrow`.
 
 The `BorrowScope` class represents the scope of a single runtime call of a
 component-level function during which zero or more handles are borrowed.
@@ -326,8 +321,9 @@ lent out a `BorrowHandle` and are to be restored when the call finishes and
 stored inline in the stack frame with a layout specialized to the function
 signature, thereby avoiding dynamic allocation of `lenders` in many cases.
 
-Based on these supporting runtime data structures, we can define the
-`HandleTable` in pieces, starting with its fields and the `insert` method:
+`HandleTable` (singular) encapsulates a single mutable, growable array
+of handles that all share the same `ResourceType`. Defining `HandleTable` in
+chunks, we start with the fields and `insert` method:
 ```python
 class HandleTable:
   array: [Optional[Handle]]
@@ -358,26 +354,18 @@ The `get` method is used by other `HandleTable` methods and canonical
 definitions below and uses dynamic guards to catch out-of-bounds and
 use-after-free:
 ```python
-  def get(self, i, rt):
+  def get(self, i):
     trap_if(i >= len(self.array))
     trap_if(self.array[i] is None)
-    trap_if(self.array[i].rt is not rt)
     return self.array[i]
 ```
-Additionally, the `get` method takes the runtime resource type tag and checks
-a tag match before returning the handle with this new-valid resource type. This
-check is a non-structural, pointer-equality-based test used to enforce the
-[type-checking rules](Explainer.md) of resource types at runtime. Importantly,
-this check keeps type imports abstract, considering each type import to have a
-unique `rt` value distinct from every other type import even if the two imports
-happen to be instantiated with the same resource type at runtime.
 
-Finally, the `remove` method is used to drop or transfer a handle out of the
-handle table. `remove` adds the removed handle to the `free` list for later
-recycling by `insert` (above).
+The last method of `HandleTable`, `remove`, is used to drop or transfer a
+handle out of the handle table. `remove` adds the removed handle to the `free`
+list for later recycling by `insert` (above).
 ```python
   def remove(self, i, t):
-    h = self.get(i, t.rt)
+    h = self.get(i)
     trap_if(h.lend_count != 0)
     match t:
       case Own(_):
@@ -397,6 +385,36 @@ resource and that there aren't any dangling borrows hanging around from the
 previous owner. The bookkeeping performed by `remove` for borrowed handles
 records the fulfillment of the obligation of the borrower to drop the handle
 before the end of the call.
+
+Finally, we can define `HandleTables` (plural) as simply a wrapper around
+a mutable mapping from `ResourceType` to `HandleTable`:
+```python
+class HandleTables:
+  rt_to_table: MutableMapping[ResourceType, HandleTable]
+
+  def __init__(self):
+    self.rt_to_table = dict()
+
+  def table(self, rt):
+    if id(rt) not in self.rt_to_table:
+      self.rt_to_table[id(rt)] = HandleTable()
+    return self.rt_to_table[id(rt)]
+
+  def insert(self, h, rt):
+    return self.table(rt).insert(h)
+  def get(self, i, rt):
+    return self.table(rt).get(i)
+  def remove(self, i, t):
+    return self.table(t.rt).remove(i, t)
+```
+While this Python code performs a dynamic hash-table lookup on each handle
+table access, as we'll see below, the `rt` parameter is always statically
+known such that a normal implementation can statically enumerate all
+`HandleTable` objects at compile time and then route the calls to `insert`,
+`get` and `remove` to the correct `HandleTable` at the callsite. The net
+result is that each component instance will contain one handle table per
+resource type used by the component, with each compiled adapter function
+accessing the correct handle table as-if it were a global variable.
 
 
 ### Loading
@@ -963,16 +981,16 @@ current component instance's `HandleTable`:
 ```python
 def lower_own(cx, src, rt):
   assert(isinstance(src, OwnHandle))
-  h = OwnHandle(src.rep, rt, 0)
-  return cx.inst.handles.insert(h)
+  h = OwnHandle(src.rep, 0)
+  return cx.inst.handles.insert(h, rt)
 
 def lower_borrow(cx, src, rt):
   assert(isinstance(src, Handle))
   if cx.inst is rt.impl:
     return src.rep
   cx.borrow_scope.add(src)
-  h = BorrowHandle(src.rep, rt, 0, cx.borrow_scope)
-  return cx.inst.handles.insert(h)
+  h = BorrowHandle(src.rep, 0, cx.borrow_scope)
+  return cx.inst.handles.insert(h, rt)
 ```
 The special case in `lower_borrow` is an optimization, recognizing that, when
 a borrowed handle is passed to the component that implemented the resource
@@ -1551,8 +1569,8 @@ Calling `$f` invokes the following function, which creates a resource object
 and inserts it into the current instance's handle table:
 ```python
 def canon_resource_new(inst, rt, rep):
-  h = OwnHandle(rep, rt, 0)
-  return inst.handles.insert(h)
+  h = OwnHandle(rep, 0)
+  return inst.handles.insert(h, rt)
 ```
 
 ### `canon resource.drop`

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -844,6 +844,8 @@ def lower_own(cx, src, rt):
 
 def lower_borrow(cx, src, rt):
   assert(isinstance(src, Handle))
+  if cx.inst is rt.impl:
+    return src.rep
   cx.borrow_scope.add(src)
   h = BorrowHandle(src.rep, rt, 0, cx.borrow_scope)
   return cx.inst.handles.insert(h)

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -396,7 +396,7 @@ def test_handles():
     assert(len(args) == 2)
     assert(args[0].rep == 42)
     assert(args[1].rep == 44)
-    return ([OwnHandle(45, rt, 0)], lambda:())
+    return ([OwnHandle(45, 0)], lambda:())
 
   def core_wasm(args):
     nonlocal dtor_value
@@ -419,36 +419,36 @@ def test_handles():
     dtor_value = None
     canon_resource_drop(inst, Own(rt), 0)
     assert(dtor_value == 42)
-    assert(len(inst.handles.array) == 4)
-    assert(inst.handles.array[0] is None)
-    assert(len(inst.handles.free) == 1)
+    assert(len(inst.handles.table(rt).array) == 4)
+    assert(inst.handles.table(rt).array[0] is None)
+    assert(len(inst.handles.table(rt).free) == 1)
 
     h = canon_resource_new(inst, rt, 46)
     assert(h == 0)
-    assert(len(inst.handles.array) == 4)
-    assert(inst.handles.array[0] is not None)
-    assert(len(inst.handles.free) == 0)
+    assert(len(inst.handles.table(rt).array) == 4)
+    assert(inst.handles.table(rt).array[0] is not None)
+    assert(len(inst.handles.table(rt).free) == 0)
 
     dtor_value = None
     canon_resource_drop(inst, Borrow(rt), 2)
     assert(dtor_value is None)
-    assert(len(inst.handles.array) == 4)
-    assert(inst.handles.array[2] is None)
-    assert(len(inst.handles.free) == 1)
+    assert(len(inst.handles.table(rt).array) == 4)
+    assert(inst.handles.table(rt).array[2] is None)
+    assert(len(inst.handles.table(rt).free) == 1)
 
     return [Value('i32', 0), Value('i32', 1), Value('i32', 3)]
 
   ft = FuncType([Own(rt),Own(rt),Borrow(rt),Borrow(rt2)],[Own(rt),Own(rt),Own(rt)])
-  args = [OwnHandle(42, rt, 0), OwnHandle(43, rt, 0), OwnHandle(44, rt, 0), OwnHandle(13, rt2, 0)]
+  args = [OwnHandle(42, 0), OwnHandle(43, 0), OwnHandle(44, 0), OwnHandle(13, 0)]
   got,post_return = canon_lift(opts, inst, core_wasm, ft, args)
 
   assert(len(got) == 3)
   assert(got[0].rep == 46)
   assert(got[1].rep == 43)
   assert(got[2].rep == 45)
-  assert(len(inst.handles.array) == 4)
-  assert(all(inst.handles.array[i] is None for i in range(3)))
-  assert(len(inst.handles.free) == 4)
+  assert(len(inst.handles.table(rt).array) == 4)
+  assert(all(inst.handles.table(rt).array[i] is None for i in range(3)))
+  assert(len(inst.handles.table(rt).free) == 4)
   definitions.MAX_FLAT_RESULTS = before
 
 test_handles()

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -383,21 +383,19 @@ def test_handles():
   def dtor(x):
     nonlocal dtor_value
     dtor_value = x
-  rt = ResourceType(dtor)
 
-  opts = mk_opts()
+  rt = ResourceType(ComponentInstance(), dtor)
+
   inst = ComponentInstance()
-  r1 = Resource(42, inst)
-  r2 = Resource(43, inst)
-  r3 = Resource(44, inst)
+  opts = mk_opts()
 
   def host_import(args):
     nonlocal opts
     nonlocal inst
     assert(len(args) == 2)
-    assert(args[0].resource is r1)
-    assert(args[1].resource is r3)
-    return ([OwnHandle(Resource(45, inst), rt, 0)], lambda:())
+    assert(args[0].rep == 42)
+    assert(args[1].rep == 44)
+    return ([OwnHandle(45, rt, 0)], lambda:())
 
   def core_wasm(args):
     nonlocal dtor_value
@@ -439,13 +437,13 @@ def test_handles():
     return [Value('i32', 0), Value('i32', 1), Value('i32', 3)]
 
   ft = FuncType([Own(rt),Own(rt),Borrow(rt)],[Own(rt),Own(rt),Own(rt)])
-  args = [OwnHandle(r1, rt, 0), OwnHandle(r2, rt, 0), OwnHandle(r3, rt, 0)]
+  args = [OwnHandle(42, rt, 0), OwnHandle(43, rt, 0), OwnHandle(44, rt, 0)]
   got,post_return = canon_lift(opts, inst, core_wasm, ft, args)
 
   assert(len(got) == 3)
-  assert(got[0].resource.rep == 46)
-  assert(got[1].resource is r2)
-  assert(got[2].resource.rep == 45)
+  assert(got[0].rep == 46)
+  assert(got[1].rep == 43)
+  assert(got[2].rep == 45)
   assert(len(inst.handles.array) == 4)
   assert(all(inst.handles.array[i] is None for i in range(3)))
   assert(len(inst.handles.free) == 4)

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -384,9 +384,10 @@ def test_handles():
     nonlocal dtor_value
     dtor_value = x
 
-  rt = ResourceType(ComponentInstance(), dtor)
+  rt = ResourceType(ComponentInstance(), dtor) # usable in imports and exports
 
   inst = ComponentInstance()
+  rt2 = ResourceType(inst, dtor) # only usable in exports
   opts = mk_opts()
 
   def host_import(args):
@@ -400,10 +401,11 @@ def test_handles():
   def core_wasm(args):
     nonlocal dtor_value
 
-    assert(len(args) == 3)
+    assert(len(args) == 4)
     assert(args[0].t == 'i32' and args[0].v == 0)
     assert(args[1].t == 'i32' and args[1].v == 1)
     assert(args[2].t == 'i32' and args[2].v == 2)
+    assert(args[3].t == 'i32' and args[3].v == 13)
     assert(canon_resource_rep(inst, rt, 0) == 42)
     assert(canon_resource_rep(inst, rt, 1) == 43)
     assert(canon_resource_rep(inst, rt, 2) == 44)
@@ -436,8 +438,8 @@ def test_handles():
 
     return [Value('i32', 0), Value('i32', 1), Value('i32', 3)]
 
-  ft = FuncType([Own(rt),Own(rt),Borrow(rt)],[Own(rt),Own(rt),Own(rt)])
-  args = [OwnHandle(42, rt, 0), OwnHandle(43, rt, 0), OwnHandle(44, rt, 0)]
+  ft = FuncType([Own(rt),Own(rt),Borrow(rt),Borrow(rt2)],[Own(rt),Own(rt),Own(rt)])
+  args = [OwnHandle(42, rt, 0), OwnHandle(43, rt, 0), OwnHandle(44, rt, 0), OwnHandle(13, rt2, 0)]
   got,post_return = canon_lift(opts, inst, core_wasm, ft, args)
 
   assert(len(got) == 3)


### PR DESCRIPTION
The first commit in this PR does not change observable behavior but, noting that a resource's internal `(rep i32)` isn't currently mutable, inlines the `i32` value directly into the handle-table element (instead of going through an indirection), suggesting that implementations can easily to likewise.

The second commit restores an optimization in @alexcrichton's original resource/handle prototype in which, when passing a `(borrow $R)` to the component that implemented `$R`, you don't want to create a whole handle in the handle table just so the callee can call `resource.rep` on it -- you can simply pass the `rep` `i32` directly.

The last commit removes the dynamic type tag test when lifting a handle out of the heterogeneous `HandleTable` by instead having a homogeneous handle table per resource type (rather like asm.js typed function tables, if anyone remembers those).  Thus, all that's needed is a bounds check, and also the per-handle type tag can be removed.