### PR TITLE
Make multiple exports of the same type definition equal by default

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -930,10 +930,9 @@ bind a fresh abstract type. For example, in the following component:
 all four types aliases in the outer component are unequal, reflecting the fact
 that each instance of `$C` generates two fresh resource types.
 
-If a single resource type definition is exported twice, clients must *still*
-treat each export as abstract and thus unequal; the fact that the underlying
-concrete type is the same is kept an encapsulated implementation detail. For
-example, the following component:
+If a single resource type definition is exported greater than once, the exports
+after the first are equality-bound to the first export. For example, the
+following component:
 ```wasm
 (component
   (type $r (resource (rep i32)))
@@ -944,32 +943,34 @@ example, the following component:
 is assigned the following `componenttype`:
 ```wasm
 (component
-  (export "r1" (type (sub resource)))
-  (export "r2" (type (sub resource)))
-)
-```
-Thus, from an external perspective, `r1` and `r2` are completely distinct. The
-assignment of this type to the above component mirrors the *introduction* rule
-of [existential types]  (∃T).
-
-If a component *wants* to publicly export a single private resource type twice
-with the second export equal to the first, it can do so by having the second
-export refer to the type index introduced by the first export. For example, the
-following component:
-```wasm
-(component
-  (type $r (resource (rep i32)))
-  (export $r1 "r1" (type $r))
-  (export "r2" (type $r1))
-)
-```
-is assigned the following `componenttype`:
-```wasm
-(component
   (export $r1 "r1" (type (sub resource)))
   (export "r2" (type (eq $r1)))
 )
 ```
+Thus, from an external perspective, `r1` and `r2` are two labels for the same
+type.
+
+If a component wants to hide this fact and force clients to assume `r1` and
+`r2` are distinct types (thereby allowing the implementation to actually use
+separate types in the future without breaking clients), an explicit type can be
+ascribed to the export that replaces the `eq` bound with a less-precise `sub`
+bound.
+```wasm
+(component
+  (type $r (resource (rep i32)))
+  (export "r1" (type $r)
+  (export "r2" (type $r) (type (sub resource)))
+)
+```
+This component is assigned the following `componenttype`:
+```wasm
+(component
+  (export "r1" (type (sub resource)))
+  (export "r2" (type (sub resource)))
+)
+```
+The assignment of this type to the above component mirrors the *introduction*
+rule of [existential types]  (∃T).
 
 When supplying a resource type (imported *or* defined) to a type import via
 `instantiate`, type checking performs a substitution, replacing all uses of the


### PR DESCRIPTION
This changes the rules for multiple exports of the same resource type definition to match what is suggested in #178.