### PR TITLE
Add missing paren in explainer example

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -363,17 +363,17 @@ With what's defined so far, we're able to link modules with arbitrary renamings:
   )
   (core instance $a (instantiate $A))
   (core instance $b1 (instantiate $B
-    (with "a" (instance $a))                     ;; no renaming
+    (with "a" (instance $a))                      ;; no renaming
   ))
-  (core func $a_two (alias core export $a "two") ;; ≡ (alias core export $a "two" (core func $a_two))
+  (core func $a_two (alias core export $a "two")) ;; ≡ (alias core export $a "two" (core func $a_two))
   (core instance $b2 (instantiate $B
     (with "a" (instance
-      (export "one" (func $a_two))               ;; renaming, using out-of-line alias
+      (export "one" (func $a_two))                ;; renaming, using out-of-line alias
     ))
   ))
   (core instance $b3 (instantiate $B
     (with "a" (instance
-      (export "one" (func $a "three"))           ;; renaming, using <inlinealias>
+      (export "one" (func $a "three"))            ;; renaming, using <inlinealias>
     ))
   ))
 )


### PR DESCRIPTION
There is a missing paren in the alias example in the explainer. This adds that paren and adjusts the comments so that they remain on the same level. 