### PR TITLE
Update Type Checking compound component example

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -755,9 +755,9 @@ example, in the following compound component:
   (component $B
     (type $ListString3 (list string))
     (type $ListListString3 (list $ListString3))
-    (type $ListString4 (alias outer $A $ListString))
+    (alias outer $A $ListString1 (type $ListString4))
     (type $ListListString4 (list $ListString4))
-    (type $ListListString5 (alias outer $A $ListString2))
+    (alias outer $A $ListListString2 (type $ListString5))
   )
 )
 ```


### PR DESCRIPTION
This commit updates the example given in the `Type Checking` section.

The motivation for this update is that the current example does not seem to be correct:
```console
$ echo '(component $A
  (type $ListString1 (list string))
  (type $ListListString1 (list $ListString1))
  (type $ListListString2 (list $ListString1))
  (component $B
    (type $ListString3 (list string))
    (type $ListListString3 (list $ListString3))
    (type $ListString4 (alias outer $A $ListString))
    (type $ListListString4 (list $ListString4))
    (type $ListListString5 (alias outer $A $ListString2))
  )
)' | wasm-tools parse -t
error: unexpected token, expected one of: `func`, `component`, `instance`, `resource`, `record`, `variant`, `list`, `tuple`, `flags`, `enum`, `union`, `option`, `result`, `own`, `borrow`
     --> <stdin>:8:25
      |
    8 |     (type $ListString4 (alias outer $A $ListString))
      |
```

With the updates in this commit the output will be:
```console
$ echo '(component $A
  (type $ListString1 (list string))
  (type $ListListString1 (list $ListString1))
  (type $ListListString2 (list $ListString1))
  (component $B
    (type $ListString3 (list string))
    (type $ListListString3 (list $ListString3))
    (alias outer $A $ListString1 (type $ListString4))
    (type $ListListString4 (list $ListString4))
    (alias outer $A $ListListString2 (type $ListString5))
  )
)' | wasm-tools parse -t
(component $A
  (type $ListString1 (;0;) (list string))
  (type $ListListString1 (;1;) (list $ListString1))
  (type $ListListString2 (;2;) (list $ListString1))
  (component $B (;0;)
    (type $ListString3 (;0;) (list string))
    (type $ListListString3 (;1;) (list $ListString3))
    (alias outer $A $ListString1 (type $ListString4 (;2;)))
    (type $ListListString4 (;3;) (list $ListString4))
    (alias outer $A $ListListString2 (type $ListString5 (;4;)))
  )
)
```
I think this is correct but hopefully others can correct me if I'm wrong.