### PR TITLE
switch to a single handle type (for now)

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -114,9 +114,9 @@ Notes:
   import or export, respectively, in the same scope (component, component type
   or instance type).
 * Validation of `[constructor]` names requires that the `func` returns a
-  `(result (own $R))`, where `$R` is the resource labeled `r`.
+  `(result (rc $R))`, where `$R` is the resource labeled `r`.
 * Validation of `[method]` names requires the first parameter of the function
-  to be `(param "self" (borrow $R))`, where `$R` is the resource labeled `r`.
+  to be `(param "self" (rc $R))`, where `$R` is the resource labeled `r`.
 * Validation of `[method]` and `[static]` names ensures that all field names
   are disjoint.
 
@@ -203,8 +203,7 @@ defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x6c t*:vec(<valtype>)                  => (union t*)
                 | 0x6b t:<valtype>                        => (option t)
                 | 0x6a t?:<valtype>? u?:<valtype>?        => (result t? (error u)?)
-                | 0x69 i:<typeidx>                        => (own i)
-                | 0x68 i:<typeidx>                        => (borrow i)
+                | 0x69 i:<typeidx>                        => (rc i)
 labelvaltype  ::= l:<label> t:<valtype>                   => l t
 case          ::= l:<label> t?:<valtype>? r?:<u32>?       => (case l t? (refines case-label[r])?)
 <T>?          ::= 0x00                                    =>
@@ -240,12 +239,7 @@ Notes:
   with type opcodes starting at SLEB128(-1) (`0x7f`) and going down,
   reserving the nonnegative SLEB128s for type indices.
 * Validation of `valtype` requires the `typeidx` to refer to a `defvaltype`.
-* Validation of `own` and `borrow` requires the `typeidx` to refer to a
-  resource type.
-* Validation only allows `borrow` to be used inside the `param` of a `functype`.
-  (This is likely to change in a future PR, converting `functype` into a
-  compound type constructor analogous to `moduletype` and `componenttype` and
-  using scoping to enforce this constraint instead.)
+* Validation of `rc` requires that `typeidx` refer to a resource type.
 * Validation of `resourcetype` requires the destructor (if present) to have
   type `[i32] -> []`.
 * Validation of `instancedecl` (currently) only allows the `type` and
@@ -281,7 +275,7 @@ Notes:
 canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift f opts type-index-space[ft])
            | 0x01 0x00 f:<funcidx> opts:<opts>                   => (canon lower f opts (core func))
            | 0x02 t:<typeidx>                                    => (canon resource.new t (core func))
-           | 0x03 t:<valtype>                                    => (canon resource.drop t (core func))
+           | 0x03 t:<typeidx>                                    => (canon resource.drop t (core func))
            | 0x04 t:<typeidx>                                    => (canon resource.rep t (core func))
 opts     ::= opt*:vec(<canonopt>)                                => opt*
 canonopt ::= 0x00                                                => string-encoding=utf8

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -982,8 +982,6 @@ def lower_handle(cx, res, ht):
   assert(isinstance(res, Resource))
   return cx.inst.handles.add(ht.rt, HandleElem(res))
 ```
-The `add` method (defined above) performs deduplication and reference-counting
-of the resource.
 
 
 ### Flattening

--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -17,7 +17,7 @@ But roughly speaking:
 | `option`                  | `T <: (option T)` |
 | `expected`                | `T <: (expected T _)` |
 | `union`                   | `T <: (union ... T ...)` |
-| `own`, `borrow`           | none (although resource subtyping may be introduced in the future which would imply handle subtyping) |
+| `rc`                      | none (although resource subtyping may be introduced in the future which would imply handle subtyping) |
 | `func`                    | parameter names must match in order; contravariant parameter subtyping; superfluous parameters can be ignored in the subtype; `option` parameters can be ignored in the supertype; covariant result subtyping |
 | `component`               | all imports in the subtype must be present in the supertype with matching types; all exports in the supertype must be present in the subtype; the `URL` is treated as the complete name, when present, ignoring the `name` field |
 


### PR DESCRIPTION
The current explainer has two handle types (`own` and `borrow`).  Unfortunately, to describe realistic interfaces (such as WASI HTTP), additional handle types are needed (for `own` to actually mean (transitive) exclusive ownership).  I was working on this in the [child-handles](https://github.com/WebAssembly/component-model/tree/child-handles) branch before realizing the need for more varieties and thus a potentially better, more-general, more-orthogonal design (currently sketched in the [generalize-handles](https://github.com/WebAssembly/component-model/tree/generalize-handles)) branch.  In the meantime, we need to make progress on Preview 2, so for now (and perhaps until after Preview 2), I think it'd be a good idea to have a single handle type that represents *non-exclusive, reference-counted* ownership, since this is able to express any interface honestly (albeit sometimes imprecisely and suboptimally).  In the future, when we add back more-precise handle types (capturing ownership, exclusivity and scope in the call contract), this non-exclusive, reference-counted handle would continue to exist as one of the options, so Wit and components written using it would continue to be valid.

There is the question of what to call this reference-counted handle type (in Wat and Wit).  `shared` or `ref` would make sense, but these names are already in use by core wasm and so it's probably a good idea to avoid creating confusion.  The best I could think of (that isn't super long) is `rc` (standing for "reference counted"), so that's what in the PR, but happy to hear better options.  E.g., in Wit, this would look like `rc<file>` (where `file` is a resource type).  This reserves use of the resource-type's name (without qualifier) for the unique/linear handle case, which seems like the right default option to suggest to interface authors.

A new issue that needs to be addressed for `rc` (and non-exclusive handles in general) is how to handle identity (e.g., when two `rc` handles to the same resource are given to a component).  Guest programs may need to ask whether two handles point to the same resource and/or use a resource as a key in a hash-table.  This can be solved in an ad hoc way on a per-interface basis (e.g., adding explicit `eq` and `hash-code`/`id` methods to resources), but (1) this is opaque to bindings generation, (2) `hash-code`/`id` raise various virtualization hazards, (3) it requires the interface author to anticipate usage patterns.  Instead, this PR proposes that the Canonical ABI lowering automatically de-duplicates multiple `rc` handles pointing to the same resource, ultimately giving them the same `i32` handle index, thus allowing the `i32` index to serve as the (component-local) identity of the resource for use in bindings generators.