### PR TITLE
Fix lifting an own handle from a borrow handle

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -641,6 +641,7 @@ component.
 ```python
 def lift_own(cx, i, t):
   h = cx.inst.handles.remove(t.rt, i)
+  trap_if(not h.own)
   return h.rep
 ```
 The abstract lifted value for handle types is currently just the internal

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -544,6 +544,7 @@ def unpack_flags_from_int(i, labels):
 
 def lift_own(cx, i, t):
   h = cx.inst.handles.remove(t.rt, i)
+  trap_if(not h.own)
   return h.rep
 
 def lift_borrow(cx, i, t):


### PR DESCRIPTION
This fixes what I believe is a mistake in the `CanonicalABI.md` explainer currently where a lifting an owned resource handle from the table can succeed if the entry in the table was actually a borrowed handle. This inserts a check to ensure that the handle is an `own` handle before completing the lifting operation.