### PR TITLE
Handle class was renamed to HandleElem but not all references were updated

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -219,7 +219,7 @@ definitions via the `cx` parameter of type `CallContext`:
 class CallContext:
   opts: CanonicalOptions
   inst: ComponentInstance
-  lenders: [Handle]
+  lenders: [HandleElem]
   borrow_count: int
 
   def __init__(self, opts, inst):

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -279,7 +279,7 @@ def num_i32_flags(labels):
 class CallContext:
   opts: CanonicalOptions
   inst: ComponentInstance
-  lenders: [Handle]
+  lenders: [HandleElem]
   borrow_count: int
 
   def __init__(self, opts, inst):


### PR DESCRIPTION
I think commit 05cef2e changed the Handle class to HandleElem but not all references were updated. 

I noticed that even with this change, the CI still passed. Is there enough code coverage to ensure this would have been caught?