### PR TITLE
Allow imports to name implementations

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -335,11 +335,12 @@ exportname  ::= 0x00 n:<name>                                        => n
 importname  ::= en:<exportname>                                      => en
               | 0x02 n:<name> s:<string> i?:<integrity'>?            => n (url s i?)
               | 0x03 n:<name> s:<string> i?:<integrity'>?            => n (relative-url s i?)
-              | 0x04 ri:<regid'> i?:<integrity'>?                    => (locked-dep ri i?)
-              | 0x05 ris:<regidset'>                                 => (unlocked-dep ris)
+              | 0x04 n:<name> i:<integrity'>                         => n i
+              | 0x05 ri:<regid'> i?:<integrity'>?                    => (locked-dep ri i?)
+              | 0x06 ris:<regidset'>                                 => (unlocked-dep ris)
 regid'      ::= len:<u32> ri:<regid>                                 => "ri" (if len = |ri|)
 regidset'   ::= len:<u32> ris:<regidset>                             => "ris" (if len = |ris|)
-integrity'  ::= len:<u32> im:<integrity-metadata>                    => "im" (if len = |im|)
+integrity'  ::= len:<u32> im:<integrity-metadata>                    => (integrity "im") (if len = |im|)
 ```
 
 Notes:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1891,6 +1891,7 @@ and will be added over the coming months to complete the MVP proposal:
 [`wizer`]: https://github.com/bytecodealliance/wizer
 [`warg`]: https://warg.io
 [SemVerRange]: https://semver.npmjs.com/
+[OCI Registry]: https://github.com/opencontainers/distribution-spec
 
 [Scoping and Layering]: https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8
 [Future and Stream Types]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1395,10 +1395,9 @@ The `valid semver` production is as defined by the [Semantic Versioning 2.0]
 spec and is meant to be interpreted according to that specification. The
 `verrange` production embeds a minimal subset of the syntax for version ranges
 found in common package managers like `npm` and `cargo` and is meant to be
-interpreted with the same [semantics][SemVerRange]. (Mostly this is
-interpretation is the obvious lexicographic ordering, but note the particular
-behavior of pre-release tags.)
-
+interpreted with the same [semantics][SemVerRange]. (Mostly this
+interpretation is the usual SemVer-spec-defined ordering, but note the
+particular behavior of pre-release tags.)
 
 For the 3 cases where an `importname` contains a kebab-`name`, that `name` is
 required to be unique within the component's imports so that it can be used as

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1313,9 +1313,9 @@ importname ::= <exportname>
              | <name> (relative-url <string> <integrity>?)
              | (locked-dep "<regid>" <integrity>?)
              | (unlocked-dep "<regidset>")
-regname    ::= <namespace>+<label><export>*
+regname    ::= <namespace>+<label><projection>*
 namespace  ::= <label>:
-export     ::= /<label>
+projection ::= /<label>
 regid      ::= <regname><version>?
 regidset   ::= <regname><verrange>?
 version    ::= @<valid semver>

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1328,9 +1328,6 @@ verlower   ::= >=<valid semver>
 verupper   ::= <<valid semver>
 integrity  ::= (integrity "<integrity-metadata>")
 ```
-(The `valid semver` production is as defined by the [Semantic Versioning 2.0]
-spec.)
-
 Components provide six options for naming imports:
 * a **naked kebab-name** that leaves it up to the developer to "read the docs"
   or otherwise figure out what to supply for the import;
@@ -1393,6 +1390,15 @@ can be interpreted by developer tooling as "registries":
 * a fixed set of host-provided functionality (see also the [built-in modules] proposal)
 * a programmatically-created tree data structure (such as the `importObject`
   parameter of [`WebAssembly.instantiate()`])
+
+The `valid semver` production is as defined by the [Semantic Versioning 2.0]
+spec and is meant to be interpreted according to that specification. The
+`verrange` production embeds a minimal subset of the syntax for version ranges
+found in common package managers like `npm` and `cargo` and is meant to be
+interpreted with the same [semantics][SemVerRange]. (Mostly this is
+interpretation is the obvious lexicographic ordering, but note the particular
+behavior of pre-release tags.)
+
 
 For the 3 cases where an `importname` contains a kebab-`name`, that `name` is
 required to be unique within the component's imports so that it can be used as
@@ -1878,6 +1884,7 @@ and will be added over the coming months to complete the MVP proposal:
 
 [`wizer`]: https://github.com/bytecodealliance/wizer
 [`warg`]: https://warg.io
+[SemVerRange]: https://semver.npmjs.com/
 
 [Scoping and Layering]: https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8
 [Future and Stream Types]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1323,7 +1323,7 @@ verrange   ::= <version>
              | @*
              | @{<verlower>}
              | @{<verupper>}
-             | @{<verlower>,<verupper>}
+             | @{<verlower> <verupper>}
 verlower   ::= >=<valid semver>
 verupper   ::= <<valid semver>
 integrity  ::= (integrity "<integrity-metadata>")


### PR DESCRIPTION
This PR extends the binary/text grammar of import names to allow imports to name not just interfaces, but also *implementations*.  There are a number of ways to refer to an implementation (absolute URL, relative URL, precisely-versioned hierarchical name, version-ranged hierarchical name), so to keep things explicit (and avoid ad hoc string analysis) and support good bindings generation in the relevant cases, these cases are enumerated explicitly.  (In the future, other cases could be added to `importname` as they present themselves.)  Putting this semantic intent directly in the component binary allows it to be reliably interpreted by a variety of tools and runtimes, allowing better tooling interoperability than if a separate file or custom section was used.

This PR doesn't add the new import name cases to Wit yet because there are some interesting related workflow questions that I expect influence how this looks in Wit, suggesting this be a follow-up, once we agree on the target grammar/information.  Also, the expectation is that, for the most part, folks won't need to write this in Wit, these implementation imports will be added late by the toolchain based on build-config files or import maps.

Unfortunately, there doesn't seem to be an "obvious" production we can simply reuse for describing version ranges, so, with a lot of help and ideas from @lann, a basic syntax is proposed built on semver that hopefully looks intuitive enough, but feedback welcome on this of course.