### PR TITLE
Propose `enum` be a subtype of `flags`.

### DIFF
--- a/design/mvp/Subtyping.md
+++ b/design/mvp/Subtyping.md
@@ -17,6 +17,7 @@ But roughly speaking:
 | `option`                  | `T <: (option T)` |
 | `expected`                | `T <: (expected T _)` |
 | `union`                   | `T <: (union ... T ...)` |
+| `enum`                    | an `enum` type is a subtype of a `flags` type if each case has a corresponding flag |
 | `own`, `borrow`           | none (although resource subtyping may be introduced in the future which would imply handle subtyping) |
 | `func`                    | parameter names must match in order; contravariant parameter subtyping; superfluous parameters can be ignored in the subtype; `option` parameters can be ignored in the supertype; covariant result subtyping |
 | `component`               | all imports in the subtype must be present in the supertype with matching types; all exports in the supertype must be present in the subtype |


### PR DESCRIPTION
I was exploring some hypothetical use cases where it'd be nice to migrate from an `enum`, "pick one of these", to a `flags`, "pick any number of these".

For example given these types:

```
enum berry-enum {
   blueberry,
   strawberry,
   raspberry,
}

flags berry-flags {
   blueberry,
   strawberry,
   raspberry,
}
```

The proposal is `berry-enum <: berry-flags`.

I know that the subtyping rules aren't currently a focus, and that they may change when the time does come to focus on them, but I wanted to add this idea to the list so that it's considered.