### PR TITLE
Point users towards the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Component Model design and specification
 
+This repository is where the component model is being standardized. For a more user-focussed explanation, take a look at the **[Component Model Documentation]**.
+
 This repository describes the high-level [goals], [use cases], [design choices]
-and [FAQ] of the component model as well as a more-detailed [explainer], [IDL],
+and [FAQ] of the component model as well as a more-detailed [assembly-level explainer], [IDL],
 [binary format] and [ABI] covering the initial Minimum Viable Product (MVP)
 release.
 
@@ -21,12 +23,12 @@ All Component Model work is done as part of the [W3C WebAssembly Community Group
 To contribute to any of these repositories, see the Community Group's
 [Contributing Guidelines].
 
-
+[Component Model Documentation]: https://component-model.bytecodealliance.org/
 [goals]: design/high-level/Goals.md
 [use cases]: design/high-level/UseCases.md
 [design choices]: design/high-level/Choices.md
 [FAQ]: design/high-level/FAQ.md
-[explainer]: design/mvp/Explainer.md
+[assembly-level explainer]: design/mvp/Explainer.md
 [IDL]: design/mvp/WIT.md
 [binary format]: design/mvp/Binary.md
 [ABI]: design/mvp/CanonicalABI.md

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -2,7 +2,7 @@
 
 This explainer walks through the assembly-level definition of a
 [component](../high-level) and the proposed embedding of components into
-native JavaScript runtimes.
+native JavaScript runtimes. For a more user-focussed explanation, take a look at the **[Component Model Documentation](https://component-model.bytecodealliance.org/)**.
 
 * [Grammar](#grammar)
   * [Component definitions](#component-definitions)


### PR DESCRIPTION
The repository and the explainer are the second and forth result on Google when searching for "wasm component model". Since a lot of users actually want a high-level explanation instead of the design spec, we should point users to the docs instead.

~greetings from Componentize The World, btw!