### PR TITLE
Update WIT.md package ids to match #222

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -867,7 +867,7 @@ WIT files optionally start with a package declaration which defines the ID of
 the package.
 
 ```ebnf
-package-decl        ::= 'package' id ':' id ('@' valid-semver)?
+package-decl        ::= 'package' ( id ':' )+ id ( '/' id )* ('@' valid-semver)?
 ```
 
 The production `valid-semver` is as defined by
@@ -883,7 +883,7 @@ convenience:
 toplevel-use-item ::= 'use' use-path ('as' id)?
 
 use-path ::= id
-            | id ':' id '/' id ('@' valid-semver)?
+           | ( id ':' )+ id ( '/' id )+ ('@' valid-semver)?
 ```
 
 Here `use-path` is the ID used to refer to interfaces. The bare form `id`


### PR DESCRIPTION
#222 generalized registry identifier syntax to allow both nested namespaces (`a:b:c`) and nested packages (`a:b/c/d`), but didn't update WIT.md to match.  This PR generalizes WIT interface names accordingly.  It is still a TODO to expand WIT to allow expressing the new cases of implementation imports.