### PR TITLE
Require type exports to always ascribe a type

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -347,9 +347,11 @@ Notes:
 * Validation requires that all resource types transitively used in the type of an
   export are introduced by a preceding `importdecl` or `exportdecl`.
 * Validation requires any exported `sortidx` to have a valid `externdesc`
-  (which disallows core sorts other than `core module`). When the optional
-  `externdesc` immediate is present, validation requires it to be a supertype
-  of the inferred `externdesc` of the `sortidx`.
+  (which disallows core sorts other than `core module`).
+* When an export's optional `externdesc` immediate is present, validation
+  requires it to be a supertype of the inferred `externdesc` of the `sortidx`.
+* Resource type exports must have an explicit ascribed `externdesc` (indicating
+  `(sub resource)` or `(eq <typeidx>)`).
 * The `name` fields of `exportname` and `importname` must be unique among all
   imports and exports in the containing component definition, component type or
   instance type. (An import and export cannot use the same `name`.)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -931,46 +931,28 @@ bind a fresh abstract type. For example, in the following component:
 all four types aliases in the outer component are unequal, reflecting the fact
 that each instance of `$C` generates two fresh resource types.
 
-If a single resource type definition is exported more than once, the exports
-after the first are equality-bound to the first export. For example, the
-following component:
+When a component exports a type, the component must explicitly specify how the
+type should appear to the outside world by explicitly ascribing a `typebound`.
+For example, in the following component:
 ```wasm
 (component
   (type $r (resource (rep i32)))
-  (export "r1" (type $r))
-  (export "r2" (type $r))
+  (export $r1 "r1" (type $r) (type (sub resource)))
+  (export     "r2" (type $r) (type (eq $r1)))
+  (export     "r3" (type $r) (type (sub resource)))
 )
 ```
-is assigned the following `componenttype`:
+the inferred `componenttype` is:
 ```wasm
 (component
   (export $r1 "r1" (type (sub resource)))
-  (export "r2" (type (eq $r1)))
+  (export     "r2" (type (eq $r1)))
+  (export     "r3" (type (sub resource)))
 )
 ```
-Thus, from an external perspective, `r1` and `r2` are two labels for the same
-type.
-
-If a component wants to hide this fact and force clients to assume `r1` and
-`r2` are distinct types (thereby allowing the implementation to actually use
-separate types in the future without breaking clients), an explicit type can be
-ascribed to the export that replaces the `eq` bound with a less-precise `sub`
-bound.
-```wasm
-(component
-  (type $r (resource (rep i32)))
-  (export "r1" (type $r)
-  (export "r2" (type $r) (type (sub resource)))
-)
-```
-This component is assigned the following `componenttype`:
-```wasm
-(component
-  (export "r1" (type (sub resource)))
-  (export "r2" (type (sub resource)))
-)
-```
-The assignment of this type to the above component mirrors the *introduction*
+This type exposes to clients of this component that only `r1` and `r2` are
+equal even though all three exports are of the same internal type definition.
+The assignment of these types to the above component mirrors the *introduction*
 rule of [existential types]  (∃T).
 
 When supplying a resource type (imported *or* defined) to a type import via


### PR DESCRIPTION
This is a tweak recommended by @pl-semiotics earlier as part of formalizing the semantics of resource types.  It's technically a breaking change, but not in the grammar, just the validation rules for resource-type-exports, which, iirc, was only implemented recently and so this might not break anyone in practice (but let me know if otherwise).

So, the basic motivation for the change is that, from first principles, for the following component implementation:
```wasm
(component
  (import "T" (type $T (sub resource)))
  (type $U (resource (rep i32)))
  (export "T1" (type $T))
  (export "T2" (type $T))
  (export "U1" (type $U))
  (export "U2" (type $U))
)
```
It's tricky to know what the implied component type is.  I believe the explainer currently says it's:
```wasm
(component
  (import "T" (type $T (sub resource)))
  (export "T1" (type (eq $T)))
  (export "T2" (type (eq $T)))
  (export $U1 "U1" (type (sub resource)))
  (export "U2" (type (eq $U1)))
)
```
but you might instead expect:
```wasm
(component
  (import "T" (type $T (sub resource)))
  (export "T1" (type (eq $T)))
  (export "T2" (type (eq $T)))
  (export "U1" (type (sub resource)))
  (export "U2" (type (sub resource)))
)
```
or, for uniformity:
```wasm
(component
  (import "T" (type (sub resource)))
  (export "T1" (type (sub resource)))
  (export "T2" (type (sub resource)))
  (export "U1" (type (sub resource)))
  (export "U2" (type (sub resource)))
)
```
All three of these component types can be assigned to the component using the optional *type ascription* immediate of exports, so this is only a question of what the default/inferred type is.  After some discussion of what, in principle, the right default inferred type should be, it started to become clear that it's rather ambiguous and maybe we should sidestep the issue altogether and just say that type exports must always ascribe a type.  A small practical benefit is that this removes a bit of inference logic (that needs to ask "is this already exported?" etc).

@alexcrichton WDYT?