### PR TITLE
Don't force deterministic NaN canonicalization

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -536,7 +536,7 @@ sets of abstract values:
 | `bool`                    | `true` and `false` |
 | `s8`, `s16`, `s32`, `s64` | integers in the range [-2<sup>N-1</sup>, 2<sup>N-1</sup>-1] |
 | `u8`, `u16`, `u32`, `u64` | integers in the range [0, 2<sup>N</sup>-1] |
-| `float32`, `float64`      | [IEEE754] floating-pointer numbers with a single, canonical "Not a Number" ([NaN]) value |
+| `float32`, `float64`      | [IEEE754] floating-point numbers |
 | `char`                    | [Unicode Scalar Values] |
 | `record`                  | heterogeneous [tuples] of named values |
 | `variant`                 | heterogeneous [tagged unions] of named values |
@@ -550,15 +550,6 @@ and lowering definitions*, which are introduced [below](#canonical-definitions).
 For example, while abstract `variant`s contain a list of `case`s labelled by
 name, canonical lifting and lowering map each case to an `i32` value starting
 at `0`.
-
-The `float32` and `float64` values have their NaNs canonicalized to a single
-value so that:
-1. consumers of NaN values are free to use the rest of the NaN payload for
-   optimization purposes (like [NaN boxing]) without needing to worry about
-   whether the NaN payload bits were significant; and
-2. producers of NaN values across component boundaries do not develop brittle
-   assumptions that NaN payload bits are preserved by the other side (since
-   they often aren't).
 
 The `own` and `borrow` value types are both *handle types*. Handles logically
 contain the opaque address of a resource and avoid copying the resource when
@@ -1655,7 +1646,7 @@ At a high level, the additional coercions would be:
 | `u8`, `u16`, `u32` | as a Number value | `ToUint8`, `ToUint16`, `ToUint32` |
 | `s64` | as a BigInt value | `ToBigInt64` |
 | `u64` | as a BigInt value | `ToBigUint64` |
-| `float32`, `float64` | as a Number, mapping the canonical NaN to [JS NaN] | `ToNumber` mapping [JS NaN] to the canonical NaN |
+| `float32`, `float64` | as a Number value | `ToNumber` |
 | `char` | same as [`USVString`] | same as [`USVString`], throw if the USV length is not 1 |
 | `record` | TBD: maybe a [JS Record]? | same as [`dictionary`] |
 | `variant` | see below | see below |
@@ -1837,7 +1828,6 @@ and will be added over the coming months to complete the MVP proposal:
 [`enum`]: https://webidl.spec.whatwg.org/#es-enumeration
 [`T?`]: https://webidl.spec.whatwg.org/#es-nullable-type
 [`Get`]: https://tc39.es/ecma262/#sec-get-o-p
-[JS NaN]: https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type
 [Import Reflection]: https://github.com/tc39-transfer/proposal-import-reflection
 [Module Record]: https://tc39.es/ecma262/#sec-abstract-module-records
 [Module Specifier]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-ModuleSpecifier
@@ -1853,8 +1843,6 @@ and will be added over the coming months to complete the MVP proposal:
 [Closure]: https://en.wikipedia.org/wiki/Closure_(computer_programming)
 [Empty Type]: https://en.wikipedia.org/w/index.php?title=Empty_type
 [IEEE754]: https://en.wikipedia.org/wiki/IEEE_754
-[NaN]: https://en.wikipedia.org/wiki/NaN
-[NaN Boxing]: https://wingolog.org/archives/2011/05/18/value-representation-in-javascript-implementations
 [Unicode Scalar Values]: https://unicode.org/glossary/#unicode_scalar_value
 [Tuples]: https://en.wikipedia.org/wiki/Tuple
 [Tagged Unions]: https://en.wikipedia.org/wiki/Tagged_union

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 import math
 import struct
+import random
 from dataclasses import dataclass
 from typing import Optional
 from typing import Callable
@@ -392,8 +393,8 @@ def load(cx, ptr, t):
     case S16()          : return load_int(cx, ptr, 2, signed=True)
     case S32()          : return load_int(cx, ptr, 4, signed=True)
     case S64()          : return load_int(cx, ptr, 8, signed=True)
-    case Float32()      : return canonicalize32(reinterpret_i32_as_float(load_int(cx, ptr, 4)))
-    case Float64()      : return canonicalize64(reinterpret_i64_as_float(load_int(cx, ptr, 8)))
+    case Float32()      : return maybe_scramble_nan32(reinterpret_i32_as_float(load_int(cx, ptr, 4)))
+    case Float64()      : return maybe_scramble_nan64(reinterpret_i64_as_float(load_int(cx, ptr, 8)))
     case Char()         : return convert_i32_to_char(cx, load_int(cx, ptr, 4))
     case String()       : return load_string(cx, ptr)
     case List(t)        : return load_list(cx, ptr, t)
@@ -410,24 +411,41 @@ def convert_int_to_bool(i):
   assert(i >= 0)
   return bool(i)
 
+DETERMINISTIC_PROFILE = False # or True
+THE_HOST_WANTS_TO = True # or False
+CANONICAL_FLOAT32_NAN = 0x7fc00000
+CANONICAL_FLOAT64_NAN = 0x7ff8000000000000
+
+def maybe_scramble_nan32(f):
+  if math.isnan(f):
+    if DETERMINISTIC_PROFILE:
+      f = reinterpret_i32_as_float(CANONICAL_FLOAT32_NAN)
+    elif THE_HOST_WANTS_TO:
+      f = reinterpret_i32_as_float(random_nan_bits(32, 8))
+    assert(math.isnan(f))
+  return f
+
+def maybe_scramble_nan64(f):
+  if math.isnan(f):
+    if DETERMINISTIC_PROFILE:
+      f = reinterpret_i64_as_float(CANONICAL_FLOAT64_NAN)
+    elif THE_HOST_WANTS_TO:
+      f = reinterpret_i64_as_float(random_nan_bits(64, 11))
+    assert(math.isnan(f))
+  return f
+
 def reinterpret_i32_as_float(i):
   return struct.unpack('!f', struct.pack('!I', i))[0] # f32.reinterpret_i32
 
 def reinterpret_i64_as_float(i):
   return struct.unpack('!d', struct.pack('!Q', i))[0] # f64.reinterpret_i64
 
-CANONICAL_FLOAT32_NAN = 0x7fc00000
-CANONICAL_FLOAT64_NAN = 0x7ff8000000000000
-
-def canonicalize32(f):
-  if math.isnan(f):
-    return reinterpret_i32_as_float(CANONICAL_FLOAT32_NAN)
-  return f
-
-def canonicalize64(f):
-  if math.isnan(f):
-    return reinterpret_i64_as_float(CANONICAL_FLOAT64_NAN)
-  return f
+def random_nan_bits(total_bits, exponent_bits):
+  fraction_bits = total_bits - exponent_bits - 1
+  bits = random.getrandbits(total_bits)
+  bits |= ((1 << exponent_bits) - 1) << fraction_bits
+  bits |= 1 << random.randrange(fraction_bits - 1)
+  return bits
 
 def convert_i32_to_char(cx, i):
   trap_if(i >= 0x110000)
@@ -554,8 +572,8 @@ def store(cx, v, t, ptr):
     case S16()          : store_int(cx, v, ptr, 2, signed=True)
     case S32()          : store_int(cx, v, ptr, 4, signed=True)
     case S64()          : store_int(cx, v, ptr, 8, signed=True)
-    case Float32()      : store_int(cx, reinterpret_float_as_i32(canonicalize32(v)), ptr, 4)
-    case Float64()      : store_int(cx, reinterpret_float_as_i64(canonicalize64(v)), ptr, 8)
+    case Float32()      : store_int(cx, reinterpret_float_as_i32(maybe_scramble_nan32(v)), ptr, 4)
+    case Float64()      : store_int(cx, reinterpret_float_as_i64(maybe_scramble_nan64(v)), ptr, 8)
     case Char()         : store_int(cx, char_to_i32(v), ptr, 4)
     case String()       : store_string(cx, v, ptr)
     case List(t)        : store_list(cx, v, ptr, t)
@@ -874,8 +892,8 @@ def lift_flat(cx, vi, t):
     case S16()          : return lift_flat_signed(vi, 32, 16)
     case S32()          : return lift_flat_signed(vi, 32, 32)
     case S64()          : return lift_flat_signed(vi, 64, 64)
-    case Float32()      : return canonicalize32(vi.next('f32'))
-    case Float64()      : return canonicalize64(vi.next('f64'))
+    case Float32()      : return maybe_scramble_nan32(vi.next('f32'))
+    case Float64()      : return maybe_scramble_nan64(vi.next('f64'))
     case Char()         : return convert_i32_to_char(cx, vi.next('i32'))
     case String()       : return lift_flat_string(cx, vi)
     case List(t)        : return lift_flat_list(cx, vi, t)
@@ -963,8 +981,8 @@ def lower_flat(cx, v, t):
     case S16()          : return lower_flat_signed(v, 32)
     case S32()          : return lower_flat_signed(v, 32)
     case S64()          : return lower_flat_signed(v, 64)
-    case Float32()      : return [Value('f32', canonicalize32(v))]
-    case Float64()      : return [Value('f64', canonicalize64(v))]
+    case Float32()      : return [Value('f32', maybe_scramble_nan32(v))]
+    case Float64()      : return [Value('f64', maybe_scramble_nan64(v))]
     case Char()         : return [Value('i32', char_to_i32(v))]
     case String()       : return lower_flat_string(cx, v)
     case List(t)        : return lower_flat_list(cx, v, t)

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -154,18 +154,32 @@ test_pairs(Char(), [(0xE000,'\uE000'), (0x10FFFF,'\U0010FFFF'), (0x110000,None),
 test_pairs(Enum(['a','b']), [(0,{'a':None}), (1,{'b':None}), (2,None)])
 
 def test_nan32(inbits, outbits):
-  f = lift_flat(mk_cx(), ValueIter([Value('f32', reinterpret_i32_as_float(inbits))]), Float32())
-  assert(reinterpret_float_as_i32(f) == outbits)
+  origf = reinterpret_i32_as_float(inbits)
+  f = lift_flat(mk_cx(), ValueIter([Value('f32', origf)]), Float32())
+  if DETERMINISTIC_PROFILE:
+    assert(reinterpret_float_as_i32(f) == outbits)
+  else:
+    assert(not math.isnan(origf) or math.isnan(f))
   cx = mk_cx(int.to_bytes(inbits, 4, 'little'))
   f = load(cx, 0, Float32())
-  assert(reinterpret_float_as_i32(f) == outbits)
+  if DETERMINISTIC_PROFILE:
+    assert(reinterpret_float_as_i32(f) == outbits)
+  else:
+    assert(not math.isnan(origf) or math.isnan(f))
 
 def test_nan64(inbits, outbits):
-  f = lift_flat(mk_cx(), ValueIter([Value('f64', reinterpret_i64_as_float(inbits))]), Float64())
-  assert(reinterpret_float_as_i64(f) == outbits)
+  origf = reinterpret_i64_as_float(inbits)
+  f = lift_flat(mk_cx(), ValueIter([Value('f64', origf)]), Float64())
+  if DETERMINISTIC_PROFILE:
+    assert(reinterpret_float_as_i64(f) == outbits)
+  else:
+    assert(not math.isnan(origf) or math.isnan(f))
   cx = mk_cx(int.to_bytes(inbits, 8, 'little'))
   f = load(cx, 0, Float64())
-  assert(reinterpret_float_as_i64(f) == outbits)
+  if DETERMINISTIC_PROFILE:
+    assert(reinterpret_float_as_i64(f) == outbits)
+  else:
+    assert(not math.isnan(origf) or math.isnan(f))
 
 test_nan32(0x7fc00000, CANONICAL_FLOAT32_NAN)
 test_nan32(0x7fc00001, CANONICAL_FLOAT32_NAN)


### PR DESCRIPTION
After revisiting this design choice in #247, this PR changes the Canonical ABI to not force canonicalization of NaNs, so that hosts can just use the raw `f32`/`f64` bit-patterns.  Because some languages and host implementation techniques (especially JS, both as host and as guest) will inevitably end up doing some amount of NaN-canonicalization, this PR explicitly includes this allowed non-determinism in the Canonical ABI lifting and lowering routines.