### PR TITLE
Move structured import/export name information into the import/export string

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -310,10 +310,8 @@ in the explainer.)
 ```ebnf
 import      ::= en:<importname'> ed:<externdesc>                     => (import in ed)
 export      ::= en:<exportname'> si:<sortidx> ed?:<externdesc>?      => (export en si ed?)
-importname' ::= <junk> len:<u32> in:<importname>                     => in  (if len = |in|)
-exportname' ::= <junk> len:<u32> en:<exportname>                     => en  (if len = |en|)
-junk        ::= 0x00
-              | 0x01
+importname' ::= 0x00 len:<u32> in:<importname>                       => in  (if len = |in|)
+exportname' ::= 0x00 len:<u32> en:<exportname>                       => en  (if len = |en|)
 ```
 
 Notes:
@@ -343,8 +341,6 @@ Notes:
 * `<valid semver>` is as defined by [https://semver.org](https://semver.org/)
 * `<integrity-metadata>` is as defined by the
   [SRI](https://www.w3.org/TR/SRI/#dfn-integrity-metadata) spec.
-* The `junk` byte is leftover from a previous iteration and will be removed at
-  the next breaking binary format change.
 
 ## Name Section
 

--- a/design/mvp/examples/LinkTimeVirtualization.md
+++ b/design/mvp/examples/LinkTimeVirtualization.md
@@ -17,7 +17,7 @@ without regard to `parent.wasm`:
 ```wasm
 ;; child.wat
 (component
-  (import (interface "wasi:filesystem/types") (instance
+  (import "wasi:filesystem/types" (instance
     (export "read" (func ...))
     (export "write" (func ...))
   ))
@@ -31,7 +31,7 @@ out and reused as a separate component:
 ```wasm
 ;; virtualize.wat
 (component
-  (import (interface "wasi:filesystem/types") (instance $fs
+  (import "wasi:filesystem/types" (instance $fs
     (export "read" (func ...))
     (export "write" (func ...))
   ))
@@ -49,7 +49,7 @@ We now write the parent component by composing `child.wasm` with
 ```wasm
 ;; parent.wat
 (component
-  (import (interface "wasi:filesystem/types") (instance $real-fs ...))
+  (import "wasi:filesystem/types" (instance $real-fs ...))
   (import "./virtualize.wasm" (component $Virtualize ...))
   (import "./child.wasm" (component $Child ...))
   (instance $virtual-fs (instantiate (component $Virtualize)
@@ -66,7 +66,7 @@ definitions in place of imports:
 ```wasm
 ;; parent.wat
 (component
-  (import (interface "wasi:filesystem/types") (instance $real-fs ...))
+  (import "wasi:filesystem/types" (instance $real-fs ...))
   (component $Virtualize ... copied inline ...)
   (component $Child ... copied inline ...)
   (instance $virtual-fs (instantiate (component $Virtualize)


### PR DESCRIPTION
This PR fleshes out the idea in #253 to move the structured information of imports/exports into the import/export name string, maintaining the same validation structure, but now inside a single quoted strong.  The motivation for this change is to have a simple canonical string for all import/export names that contains all the structured information, without requiring host and toolchain implementations to define their own ad hoc string-serialization conventions.  The rationale here is basically the same as the earlier design choice to put method/constructor/etc annotations inside the name strings, with the net effect of making the way externally-meaningful name information is represented in components somewhat more regular.

Some specific details:
* This PR is intended to be backwards-compatible at the binary format level, assuming that the 5 new "implementation import" cases added by #222 haven't been implemented or used yet.  This binary compatibility is achieved by allowing a now-"junk" byte that was previously used to discriminate `(interface ...)` imports.
* The PR moves the existing kebab-name/label grammar to the "Imports and Exports" section so that the whole group can be defined in one block and also use a lexical grammar that's more explicit about whitespace and metacharacters.  This ended up surfacing a spec-bug in which labels weren't being quoted.
* As there are now a fair number of "<___name>"s in the grammar, it seemed odd to have `<name>` refer to the kebab-name case.  Moreover, `<name>` wasn't really a "kebab-name" anyway, since it also contains method/constructor/static annotations (with embedded square brackets and periods).  Thus, this PR proposes to rename this production to `<plainname>`, attempting to distinguish plain names from all the other kinds of names that carry more semantic information, but happy to hear other thoughts on how to call this.
* Embedded URLs and registry names are deliminted by angle-brackets (not parens, as discussed in #253), mostly because (1) parens are allowed in URLs, (2) double-quotes require extra escaping in WAT, which seems like it'll be annoying, (3) other than double-quotes, angle-brackets are the [RFC-recommended](https://www.rfc-editor.org/rfc/rfc3986#appendix-C) way to delimit URLs.  The other implementation imports follow the same scheme as URLs just for symmetry.

Copying from this PR, an example showing the new import/export names is:
```wasm
(component
  (import "custom-hook" (func (param string) (result string)))
  (import "wasi:http/handler" (instance
    (export "request" (type $request (sub resource)))
    (export "response" (type $response (sub resource)))
    (export "handle" (func (param (own $request)) (result (own $response))))
  ))
  (import "url=<https://mycdn.com/my-component.wasm>" (component ...))
  (import "relative-url=<./other-component.wasm>,integrity=<sha256-X9ArH3k...>" (component ...))
  (import "locked-dep=<my-registry:sqlite@1.2.3>,integrity=<sha256-H8BRh8j...>" (component ...))
  (import "unlocked-dep=<my-registry:imagemagick@{>=1.0.0}>" (instance ...))
  (import "integrity=<sha256-Y3BsI4l...>" (component ...))
  ... impl
  (export "wasi:http/handler" (instance $http_handler_impl))
  (export "get-JSON" (func $get_json_impl (result string)))
)
```