### PR TITLE
Use 'package name' more consistently in docs

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1364,11 +1364,11 @@ interfacename ::= <namespace> <label> <projection> <version>?
 namespace     ::= <label> ':'
 projection    ::= '/' <label>
 version       ::= '@' <valid semver>
-depname       ::= 'unlocked-dep=<' <pkgidset> '>'
-                | 'locked-dep=<' <pkgid> '>' ( ',' <hashname> )?
-pkgidset      ::= <pkgname> <verrange>?
-pkgid         ::= <pkgname> <version>?
-pkgname       ::= <namespace> <label>
+depname       ::= 'unlocked-dep=<' <pkgnamequery> '>'
+                | 'locked-dep=<' <pkgname> '>' ( ',' <hashname> )?
+pkgnamequery  ::= <pkgpath> <verrange>?
+pkgname       ::= <pkgpath> <version>?
+pkgpath       ::= <namespace> <label>
                 | <namespace>+ <label> <projection>* 🪺
 verrange      ::= '@*'
                 | '@{' <verlower> '}'

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -27,22 +27,22 @@ package suitable for distribution.
 [IDL]: https://en.wikipedia.org/wiki/Interface_description_language
 [components]: https://github.com/webassembly/component-model
 
-## Package identifiers
+## Package Names
 
-All WIT packages are assigned an "ID". IDs look like `foo:bar@1.0.0` and have
-three components:
+All WIT packages are assigned a *package name*. Package names look like
+`foo:bar@1.0.0` and have three fields:
 
-* A namespace, for example `foo` in `foo:bar`. This namespace is intended to
-  disambiguate between registries, top-level organizations, etc. For example
-  WASI interfaces use the `wasi` namespace.
+* A *namespace field*, for example `foo` in `foo:bar`. This namespace is
+  intended to disambiguate between registries, top-level organizations, etc.
+  For example WASI interfaces use the `wasi` namespace.
 
-* A package name, for example `clocks` in `wasi:clocks`. A package name groups
+* A *package field*, for example `clocks` in `wasi:clocks`. A "package" groups
   together a set of interfaces and worlds that would otherwise be named with a
   common prefix.
 
-* An optional version, specified as [full semver](https://semver.org/).
+* An optional *version field*, specified as [full semver](https://semver.org/).
 
-Package identifiers are specified at the top of a WIT file via a `package`
+Package names are specified at the top of a WIT file via a `package`
 declaration:
 
 ```wit
@@ -56,11 +56,14 @@ package wasi:clocks@1.2.0;
 ```
 
 WIT packages can be defined in a collection of files and at least one of them
-must specify a `package` identifier. Multiple files can specify a `package` and
-they must all agree on what the identifier is.
+must specify a package name. Multiple files can specify a `package` and
+they must all agree on what the package name is.
 
-Package identifiers are used to generate IDs in the component model binary
-format for [`interface`s][interfaces] and [`world`s][worlds].
+Package names are used to generate the [names of imports and exports]
+in the Component Model's representation of [`interface`s][interfaces] and
+[`world`s][worlds] as described [below](#package-format).
+
+[names of imports and exports]: Explainer.md#import-and-export-definitions
 
 ## WIT Interfaces
 [interfaces]: #wit-interfaces


### PR DESCRIPTION
This PR updates the terminology to match #263 (no change in behavior).

Prior to #263, there was a sortof haphazard mix of "name" and "id" used in the context of imports/exports referring to interfaces and implementations, which created some ambiguity because there was also this totally independent pre-existing use of the term "identifier" in both WAT and WIT.  #263 tried to remove this inconsistency and simply call everything an "X name" if it was used inside an `importname` or `exportname` (so: "plain name", "interface name", etc), which was more obvious to do once everything was inside the "name" string.  This PR ties up some loose ends that folks in SIG-Registry pointed out today.  This isn't the only possible regular terminology, though; happy to discuss alternatives.