### PR TITLE
Remove doc-comment from WIT.md

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -796,17 +796,6 @@ comment ::= '//' character-that-isnt-a-newline*
           | '/*' any-unicode-character* '*/'
 ```
 
-There is a special type of comment called `documentation comment`. A
-`doc-comment` is either a line comment preceded with `///` which ends at the next
-newline (`\n`) character or it's a block comment which starts with `/**` and ends
-with `*/`. Note that block comments are allowed to be nested and their delimiters
-must be balanced
-
-```ebnf
-doc-comment ::= '///' character-that-isnt-a-newline*
-          | '/**' any-unicode-character* '*/'
-```
-
 ### Operators
 
 There are some common operators in the lexical structure of `wit` used for


### PR DESCRIPTION
As discussed in #273, this PR just removes the `doc-comment` production from WIT.md.  (In case you were wondering, I didn't forget to remove uses of `doc-comment`; it just wasn't referenced anywhere that I could see.)