### PR TITLE
Rename `float32`/`float64` to `f32`/`f64`.

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -176,8 +176,8 @@ primvaltype   ::= 0x7f                                    => bool
                 | 0x79                                    => u32
                 | 0x78                                    => s64
                 | 0x77                                    => u64
-                | 0x76                                    => float32
-                | 0x75                                    => float64
+                | 0x76                                    => f32
+                | 0x75                                    => f64
                 | 0x74                                    => char
                 | 0x73                                    => string
 defvaltype    ::= pvt:<primvaltype>                       => pvt

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -96,8 +96,8 @@ def alignment(t):
     case S16() | U16()      : return 2
     case S32() | U32()      : return 4
     case S64() | U64()      : return 8
-    case Float32()          : return 4
-    case Float64()          : return 8
+    case F32()              : return 4
+    case F64()              : return 8
     case Char()             : return 4
     case String() | List(_) : return 4
     case Record(fields)     : return alignment_record(fields)
@@ -169,8 +169,8 @@ def size(t):
     case S16() | U16()      : return 2
     case S32() | U32()      : return 4
     case S64() | U64()      : return 8
-    case Float32()          : return 4
-    case Float64()          : return 8
+    case F32()              : return 4
+    case F64()              : return 8
     case Char()             : return 4
     case String() | List(_) : return 8
     case Record(fields)     : return size_record(fields)
@@ -441,8 +441,8 @@ def load(cx, ptr, t):
     case S16()          : return load_int(cx, ptr, 2, signed=True)
     case S32()          : return load_int(cx, ptr, 4, signed=True)
     case S64()          : return load_int(cx, ptr, 8, signed=True)
-    case Float32()      : return decode_i32_as_float(load_int(cx, ptr, 4))
-    case Float64()      : return decode_i64_as_float(load_int(cx, ptr, 8))
+    case F32()          : return decode_i32_as_float(load_int(cx, ptr, 4))
+    case F64()          : return decode_i64_as_float(load_int(cx, ptr, 8))
     case Char()         : return convert_i32_to_char(cx, load_int(cx, ptr, 4))
     case String()       : return load_string(cx, ptr)
     case List(t)        : return load_list(cx, ptr, t)
@@ -693,8 +693,8 @@ def store(cx, v, t, ptr):
     case S16()          : store_int(cx, v, ptr, 2, signed=True)
     case S32()          : store_int(cx, v, ptr, 4, signed=True)
     case S64()          : store_int(cx, v, ptr, 8, signed=True)
-    case Float32()      : store_int(cx, encode_float_as_i32(v), ptr, 4)
-    case Float64()      : store_int(cx, encode_float_as_i64(v), ptr, 8)
+    case F32()          : store_int(cx, encode_float_as_i32(v), ptr, 4)
+    case F64()          : store_int(cx, encode_float_as_i64(v), ptr, 8)
     case Char()         : store_int(cx, char_to_i32(v), ptr, 4)
     case String()       : store_string(cx, v, ptr)
     case List(t)        : store_list(cx, v, ptr, t)
@@ -1134,8 +1134,8 @@ def flatten_type(t):
     case U8() | U16() | U32() : return ['i32']
     case S8() | S16() | S32() : return ['i32']
     case S64() | U64()        : return ['i64']
-    case Float32()            : return ['f32']
-    case Float64()            : return ['f64']
+    case F32()                : return ['f32']
+    case F64()                : return ['f64']
     case Char()               : return ['i32']
     case String() | List(_)   : return ['i32', 'i32']
     case Record(fields)       : return flatten_record(fields)
@@ -1213,8 +1213,8 @@ def lift_flat(cx, vi, t):
     case S16()          : return lift_flat_signed(vi, 32, 16)
     case S32()          : return lift_flat_signed(vi, 32, 32)
     case S64()          : return lift_flat_signed(vi, 64, 64)
-    case Float32()      : return canonicalize_nan32(vi.next('f32'))
-    case Float64()      : return canonicalize_nan64(vi.next('f64'))
+    case F32()          : return canonicalize_nan32(vi.next('f32'))
+    case F64()          : return canonicalize_nan64(vi.next('f64'))
     case Char()         : return convert_i32_to_char(cx, vi.next('i32'))
     case String()       : return lift_flat_string(cx, vi)
     case List(t)        : return lift_flat_list(cx, vi, t)
@@ -1337,8 +1337,8 @@ def lower_flat(cx, v, t):
     case S16()          : return lower_flat_signed(v, 32)
     case S32()          : return lower_flat_signed(v, 32)
     case S64()          : return lower_flat_signed(v, 64)
-    case Float32()      : return [Value('f32', maybe_scramble_nan32(v))]
-    case Float64()      : return [Value('f64', maybe_scramble_nan64(v))]
+    case F32()          : return [Value('f32', maybe_scramble_nan32(v))]
+    case F64()          : return [Value('f64', maybe_scramble_nan64(v))]
     case Char()         : return [Value('i32', char_to_i32(v))]
     case String()       : return lower_flat_string(cx, v)
     case List(t)        : return lower_flat_list(cx, v, t)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -530,7 +530,7 @@ deftype       ::= <defvaltype>
                 | <instancetype>
 defvaltype    ::= bool
                 | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64
-                | float32 | float64
+                | f32 | f64
                 | char | string
                 | (record (field "<label>" <valtype>)+)
                 | (variant (case <id>? "<label>" <valtype>?)+)
@@ -583,7 +583,7 @@ sets of abstract values:
 | `bool`                    | `true` and `false` |
 | `s8`, `s16`, `s32`, `s64` | integers in the range [-2<sup>N-1</sup>, 2<sup>N-1</sup>-1] |
 | `u8`, `u16`, `u32`, `u64` | integers in the range [0, 2<sup>N</sup>-1] |
-| `float32`, `float64`      | [IEEE754] floating-point numbers, with a single NaN value |
+| `f32`, `f64`              | [IEEE754] floating-point numbers, with a single NaN value |
 | `char`                    | [Unicode Scalar Values] |
 | `record`                  | heterogeneous [tuples] of named values |
 | `variant`                 | heterogeneous [tagged unions] of named values |
@@ -1755,7 +1755,7 @@ At a high level, the additional coercions would be:
 | `u8`, `u16`, `u32` | as a Number value | `ToUint8`, `ToUint16`, `ToUint32` |
 | `s64` | as a BigInt value | `ToBigInt64` |
 | `u64` | as a BigInt value | `ToBigUint64` |
-| `float32`, `float64` | as a Number value | `ToNumber` |
+| `f32`, `f64` | as a Number value | `ToNumber` |
 | `char` | same as [`USVString`] | same as [`USVString`], throw if the USV length is not 1 |
 | `record` | TBD: maybe a [JS Record]? | same as [`dictionary`] |
 | `variant` | see below | see below |

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -655,7 +655,7 @@ package local:demo;
 interface foo {
   a1: func();
   a2: func(x: u32);
-  a3: func(y: u64, z: float32);
+  a3: func(y: u64, z: f32);
 }
 ```
 
@@ -676,7 +676,7 @@ And functions can also return multiple types by naming them:
 package local:demo;
 
 interface foo {
-  a: func() -> (a: u32, b: float32);
+  a: func() -> (a: u32, b: f32);
 }
 ```
 
@@ -1209,7 +1209,7 @@ Specifically the following types are available:
 ```ebnf
 ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | 's8' | 's16' | 's32' | 's64'
-     | 'float32' | 'float64'
+     | 'f32' | 'f64'
      | 'char'
      | 'bool'
      | 'string'

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -106,8 +106,8 @@ class S32(ValType): pass
 class U32(ValType): pass
 class S64(ValType): pass
 class U64(ValType): pass
-class Float32(ValType): pass
-class Float64(ValType): pass
+class F32(ValType): pass
+class F64(ValType): pass
 class Char(ValType): pass
 class String(ValType): pass
 
@@ -182,8 +182,8 @@ def alignment(t):
     case S16() | U16()      : return 2
     case S32() | U32()      : return 4
     case S64() | U64()      : return 8
-    case Float32()          : return 4
-    case Float64()          : return 8
+    case F32()              : return 4
+    case F64()              : return 8
     case Char()             : return 4
     case String() | List(_) : return 4
     case Record(fields)     : return alignment_record(fields)
@@ -231,8 +231,8 @@ def size(t):
     case S16() | U16()      : return 2
     case S32() | U32()      : return 4
     case S64() | U64()      : return 8
-    case Float32()          : return 4
-    case Float64()          : return 8
+    case F32()              : return 4
+    case F64()              : return 8
     case Char()             : return 4
     case String() | List(_) : return 8
     case Record(fields)     : return size_record(fields)
@@ -394,8 +394,8 @@ def load(cx, ptr, t):
     case S16()          : return load_int(cx, ptr, 2, signed=True)
     case S32()          : return load_int(cx, ptr, 4, signed=True)
     case S64()          : return load_int(cx, ptr, 8, signed=True)
-    case Float32()      : return decode_i32_as_float(load_int(cx, ptr, 4))
-    case Float64()      : return decode_i64_as_float(load_int(cx, ptr, 8))
+    case F32()          : return decode_i32_as_float(load_int(cx, ptr, 4))
+    case F64()          : return decode_i64_as_float(load_int(cx, ptr, 8))
     case Char()         : return convert_i32_to_char(cx, load_int(cx, ptr, 4))
     case String()       : return load_string(cx, ptr)
     case List(t)        : return load_list(cx, ptr, t)
@@ -565,8 +565,8 @@ def store(cx, v, t, ptr):
     case S16()          : store_int(cx, v, ptr, 2, signed=True)
     case S32()          : store_int(cx, v, ptr, 4, signed=True)
     case S64()          : store_int(cx, v, ptr, 8, signed=True)
-    case Float32()      : store_int(cx, encode_float_as_i32(v), ptr, 4)
-    case Float64()      : store_int(cx, encode_float_as_i64(v), ptr, 8)
+    case F32()          : store_int(cx, encode_float_as_i32(v), ptr, 4)
+    case F64()          : store_int(cx, encode_float_as_i64(v), ptr, 8)
     case Char()         : store_int(cx, char_to_i32(v), ptr, 4)
     case String()       : store_string(cx, v, ptr)
     case List(t)        : store_list(cx, v, ptr, t)
@@ -857,8 +857,8 @@ def flatten_type(t):
     case U8() | U16() | U32() : return ['i32']
     case S8() | S16() | S32() : return ['i32']
     case S64() | U64()        : return ['i64']
-    case Float32()            : return ['f32']
-    case Float64()            : return ['f64']
+    case F32()                : return ['f32']
+    case F64()                : return ['f64']
     case Char()               : return ['i32']
     case String() | List(_)   : return ['i32', 'i32']
     case Record(fields)       : return flatten_record(fields)
@@ -916,8 +916,8 @@ def lift_flat(cx, vi, t):
     case S16()          : return lift_flat_signed(vi, 32, 16)
     case S32()          : return lift_flat_signed(vi, 32, 32)
     case S64()          : return lift_flat_signed(vi, 64, 64)
-    case Float32()      : return canonicalize_nan32(vi.next('f32'))
-    case Float64()      : return canonicalize_nan64(vi.next('f64'))
+    case F32()          : return canonicalize_nan32(vi.next('f32'))
+    case F64()          : return canonicalize_nan64(vi.next('f64'))
     case Char()         : return convert_i32_to_char(cx, vi.next('i32'))
     case String()       : return lift_flat_string(cx, vi)
     case List(t)        : return lift_flat_list(cx, vi, t)
@@ -1005,8 +1005,8 @@ def lower_flat(cx, v, t):
     case S16()          : return lower_flat_signed(v, 32)
     case S32()          : return lower_flat_signed(v, 32)
     case S64()          : return lower_flat_signed(v, 64)
-    case Float32()      : return [Value('f32', maybe_scramble_nan32(v))]
-    case Float64()      : return [Value('f64', maybe_scramble_nan64(v))]
+    case F32()          : return [Value('f32', maybe_scramble_nan32(v))]
+    case F64()          : return [Value('f64', maybe_scramble_nan64(v))]
     case Char()         : return [Value('i32', char_to_i32(v))]
     case String()       : return lower_flat_string(cx, v)
     case List(t)        : return lower_flat_list(cx, v, t)

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -109,12 +109,12 @@ test(t, [2], {'a':False,'b':True})
 test(t, [3], {'a':True,'b':True})
 test(t, [4], {'a':False,'b':False})
 test(Flags([str(i) for i in range(33)]), [0xffffffff,0x1], { str(i):True for i in range(33) })
-t = Variant([Case('x',U8()),Case('y',Float32()),Case('z',None)])
+t = Variant([Case('x',U8()),Case('y',F32()),Case('z',None)])
 test(t, [0,42], {'x': 42})
 test(t, [0,256], {'x': 0})
 test(t, [1,0x4048f5c3], {'y': 3.140000104904175})
 test(t, [2,0xffffffff], {'z': None})
-t = Option(Float32())
+t = Option(F32())
 test(t, [0,3.14], {'none':None})
 test(t, [1,3.14], {'some':3.14})
 t = Result(U8(),U32())
@@ -147,21 +147,21 @@ test_pairs(U32(), [((1<<31)-1,(1<<31)-1),(1<<31,1<<31),(((1<<32)-1),(1<<32)-1)])
 test_pairs(S32(), [((1<<31)-1,(1<<31)-1),(1<<31,-(1<<31)),((1<<32)-1,-1)])
 test_pairs(U64(), [((1<<63)-1,(1<<63)-1), (1<<63,1<<63), ((1<<64)-1,(1<<64)-1)])
 test_pairs(S64(), [((1<<63)-1,(1<<63)-1), (1<<63,-(1<<63)), ((1<<64)-1,-1)])
-test_pairs(Float32(), [(3.14,3.14)])
-test_pairs(Float64(), [(3.14,3.14)])
+test_pairs(F32(), [(3.14,3.14)])
+test_pairs(F64(), [(3.14,3.14)])
 test_pairs(Char(), [(0,'\x00'), (65,'A'), (0xD7FF,'\uD7FF'), (0xD800,None), (0xDFFF,None)])
 test_pairs(Char(), [(0xE000,'\uE000'), (0x10FFFF,'\U0010FFFF'), (0x110000,None), (0xFFFFFFFF,None)])
 test_pairs(Enum(['a','b']), [(0,{'a':None}), (1,{'b':None}), (2,None)])
 
 def test_nan32(inbits, outbits):
   origf = decode_i32_as_float(inbits)
-  f = lift_flat(mk_cx(), ValueIter([Value('f32', origf)]), Float32())
+  f = lift_flat(mk_cx(), ValueIter([Value('f32', origf)]), F32())
   if DETERMINISTIC_PROFILE:
     assert(encode_float_as_i32(f) == outbits)
   else:
     assert(not math.isnan(origf) or math.isnan(f))
   cx = mk_cx(int.to_bytes(inbits, 4, 'little'))
-  f = load(cx, 0, Float32())
+  f = load(cx, 0, F32())
   if DETERMINISTIC_PROFILE:
     assert(encode_float_as_i32(f) == outbits)
   else:
@@ -169,13 +169,13 @@ def test_nan32(inbits, outbits):
 
 def test_nan64(inbits, outbits):
   origf = decode_i64_as_float(inbits)
-  f = lift_flat(mk_cx(), ValueIter([Value('f64', origf)]), Float64())
+  f = lift_flat(mk_cx(), ValueIter([Value('f64', origf)]), F64())
   if DETERMINISTIC_PROFILE:
     assert(encode_float_as_i64(f) == outbits)
   else:
     assert(not math.isnan(origf) or math.isnan(f))
   cx = mk_cx(int.to_bytes(inbits, 8, 'little'))
-  f = load(cx, 0, Float64())
+  f = load(cx, 0, F64())
   if DETERMINISTIC_PROFILE:
     assert(encode_float_as_i64(f) == outbits)
   else:
@@ -322,12 +322,12 @@ def test_flatten(t, params, results):
   got = flatten_functype(t, 'lower')
   assert(got == expect)
 
-test_flatten(FuncType([U8(),Float32(),Float64()],[]), ['i32','f32','f64'], [])
-test_flatten(FuncType([U8(),Float32(),Float64()],[Float32()]), ['i32','f32','f64'], ['f32'])
-test_flatten(FuncType([U8(),Float32(),Float64()],[U8()]), ['i32','f32','f64'], ['i32'])
-test_flatten(FuncType([U8(),Float32(),Float64()],[Tuple([Float32()])]), ['i32','f32','f64'], ['f32'])
-test_flatten(FuncType([U8(),Float32(),Float64()],[Tuple([Float32(),Float32()])]), ['i32','f32','f64'], ['f32','f32'])
-test_flatten(FuncType([U8(),Float32(),Float64()],[Float32(),Float32()]), ['i32','f32','f64'], ['f32','f32'])
+test_flatten(FuncType([U8(),F32(),F64()],[]), ['i32','f32','f64'], [])
+test_flatten(FuncType([U8(),F32(),F64()],[F32()]), ['i32','f32','f64'], ['f32'])
+test_flatten(FuncType([U8(),F32(),F64()],[U8()]), ['i32','f32','f64'], ['i32'])
+test_flatten(FuncType([U8(),F32(),F64()],[Tuple([F32()])]), ['i32','f32','f64'], ['f32'])
+test_flatten(FuncType([U8(),F32(),F64()],[Tuple([F32(),F32()])]), ['i32','f32','f64'], ['f32','f32'])
+test_flatten(FuncType([U8(),F32(),F64()],[F32(),F32()]), ['i32','f32','f64'], ['f32','f32'])
 test_flatten(FuncType([U8() for _ in range(17)],[]), ['i32' for _ in range(17)], [])
 test_flatten(FuncType([U8() for _ in range(17)],[Tuple([U8(),U8()])]), ['i32' for _ in range(17)], ['i32','i32'])
 


### PR DESCRIPTION
The `float32` and `float64` types are being
[renamed to `f32` and `f64`]. All the main tools have been updated to accept both old and new names for now, so there's no urgency to change anything, but users who wish to can now start switching to the new `f32`/`f64` names.

[renamed to `f32` and `f64`]: https://github.com/WebAssembly/component-model/issues/277