### PR TITLE
Add @feature and @since gates to WIT

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -945,14 +945,21 @@ nesting both namespaces and packages, which would then generalize the syntax of
 
 ## Item: `world`
 
-Worlds define a [componenttype](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#type-definitions) as a collection of imports and exports.
+Worlds define a [`componenttype`] as a collection of imports and exports, all
+of which can be gated.
 
 Concretely, the structure of a world is:
 
 ```ebnf
 world-item ::= gate 'world' id '{' world-items* '}'
 
-world-items ::= export-item | import-item | use-item | typedef-item | include-item
+world-items ::= gate world-definition
+
+world-definition ::= export-item
+                   | import-item
+                   | use-item
+                   | typedef-item
+                   | include-item
 
 export-item ::= 'export' id ':' extern-type
               | 'export' use-path ';'
@@ -966,6 +973,8 @@ Note that worlds can import types and define their own types to be exported
 from the root of a component and used within functions imported and exported.
 The `interface` item here additionally defines the grammar for IDs used to refer
 to `interface` items.
+
+[`componenttype`]: Explainer.md#type-definitions
 
 ## Item: `include`
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -865,10 +865,10 @@ interface foo {
   @since(version = "0.2.1")
   b: func();
 
-  @since(version = "0.2.2", feature = "fancy-foo")
+  @since(version = "0.2.2", feature = fancy-foo)
   c: func();
 
-  @unstable(feature = "fancier-foo")
+  @unstable(feature = fancier-foo)
   d: func();
 }
 ```
@@ -902,7 +902,7 @@ Specifically, the syntax for feature gates is:
 gate ::= unstable-gate
        | since-gate
 unstable-gate ::= '@unstable' '(' feature-field ')'
-feature-field ::= 'feature' '=' '"' id '"'
+feature-field ::= 'feature' '=' id
 since-gate ::= '@since' '(' 'version' '=' '"' <valid semver> '"' ( ',' feature-field )? ')'
 ```
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -862,10 +862,10 @@ For example, the following interface has 4 items, 3 of which are gated:
 interface foo {
   a: func();
 
-  @since(version = "0.2.1")
+  @since(version = 0.2.1)
   b: func();
 
-  @since(version = "0.2.2", feature = fancy-foo)
+  @since(version = 0.2.2, feature = fancy-foo)
   c: func();
 
   @unstable(feature = fancier-foo)
@@ -903,14 +903,14 @@ gate ::= unstable-gate
        | since-gate
 unstable-gate ::= '@unstable' '(' feature-field ')'
 feature-field ::= 'feature' '=' id
-since-gate ::= '@since' '(' 'version' '=' '"' <valid semver> '"' ( ',' feature-field )? ')'
+since-gate ::= '@since' '(' 'version' '=' <valid semver> ( ',' feature-field )? ')'
 ```
 
 As part of WIT validation, any item that refers to another gated item must also
 be compatibly gated. For example, this is an error:
 ```wit
 interface i {
-  @since("1.0.1")
+  @since(version = 1.0.1)
   type t1 = u32;
 
   type t2 = t1; // error
@@ -919,11 +919,11 @@ interface i {
 Additionally, if an item is *contained* by a gated item, it must also be
 compatibly gated. For example, this is an error:
 ```wit
-@since("1.0.2")
+@since(version = 1.0.2)
 interface i {
   foo: func();  // error: no gate
 
-  @since("1.0.1")
+  @since(version = 1.0.1)
   bar: func();  // also error: weaker gate
 }
 ```
@@ -1730,7 +1730,7 @@ package ns:p@1.1.0;
 interface i {
   f: func();
 
-  @since(version = "1.1.0")
+  @since(version = 1.1.0)
   g: func();
 }
 ```

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -905,8 +905,28 @@ unstable-gate ::= '@unstable' '(' feature-field ')'
 feature-field ::= 'feature' '=' id
 since-gate ::= '@since' '(' 'version' '=' '"' <valid semver> '"' ( ',' feature-field )? ')'
 ```
+
 As part of WIT validation, any item that refers to another gated item must also
-be gated.
+be compatibly gated. For example, this is an error:
+```wit
+interface i {
+  @since("1.0.1")
+  type t1 = u32;
+
+  type t2 = t1; // error
+}
+```
+Additionally, if an item is *contained* by a gated item, it must also be
+compatibly gated. For example, this is an error:
+```wit
+@since("1.0.2")
+interface i {
+  foo: func();  // error: no gate
+
+  @since("1.0.1")
+  bar: func();  // also error: weaker gate
+}
+```
 
 ## Package declaration
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -989,8 +989,7 @@ include-names-item ::= id 'as' id
 ## Item: `interface`
 
 Interfaces can be defined in a `wit` file. Interfaces have a name and a
-sequence of items and functions, all of which can be gated on an `id` or a
-semantic version.
+sequence of items and functions, all of which can be gated.
 
 Specifically interfaces have the structure:
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -905,6 +905,8 @@ unstable-gate ::= '@unstable' '(' feature-field ')'
 feature-field ::= 'feature' '=' id
 since-gate ::= '@since' '(' 'version' '=' '"' <valid semver> '"' ( ',' feature-field )? ')'
 ```
+As part of WIT validation, any item that refers to another gated item must also
+be gated.
 
 ## Package declaration
 
@@ -1710,11 +1712,6 @@ interface i {
 
   @since(version = "1.1.0")
   g: func();
-
-  @since(version = "1.1.0")
-  type t1 = u32;
-
-  type t2 = t1
 }
 ```
 is encoded as the following component when the target version is `1.0.0`:
@@ -1727,7 +1724,6 @@ is encoded as the following component when the target version is `1.0.0`:
   ))
 )
 ```
-Note that `t2` is transitively disabled since it relied on the gated `t1`.
 If the target version was instead `1.1.0`, the same WIT document would be
 encoded as:
 ```wat
@@ -1736,8 +1732,6 @@ encoded as:
     (export "ns:p/i@1.1.0" (instance
       (export "f" (func))
       (export "g" (func))
-      (export $t1 "t1" (type (eq u32)))
-      (export "t2" (type (eq $t1)))
     ))
   ))
 )

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1689,10 +1689,15 @@ For example, the following WIT document:
 package ns:p@1.1.0;
 
 interface i {
-  f: func()
+  f: func();
 
   @since(version = "1.1.0")
-  g: func()
+  g: func();
+
+  @since(version = "1.1.0")
+  type t1 = u32;
+
+  type t2 = t1
 }
 ```
 is encoded as the following component when the target version is `1.0.0`:
@@ -1705,6 +1710,7 @@ is encoded as the following component when the target version is `1.0.0`:
   ))
 )
 ```
+Note that `t2` is transitively disabled since it relied on the gated `t1`.
 If the target version was instead `1.1.0`, the same WIT document would be
 encoded as:
 ```wat
@@ -1713,6 +1719,8 @@ encoded as:
     (export "ns:p/i@1.1.0" (instance
       (export "f" (func))
       (export "g" (func))
+      (export $t1 "t1" (type (eq u32)))
+      (export "t2" (type (eq $t1)))
     ))
   ))
 )


### PR DESCRIPTION
Based on a number of other folks' ideas and feedback (esp. @yoshuawuyts, @ricochet, @alexcrichton), this proposal adds purely-WIT-level "gates" in order to reduce the churn necessary to make minor version releases (in preparation for WASI 0.2.1).

The motivation for adding these gates is that, without them, when adding a new function or type to an interface as part of a minor release, the transition is fairly toilsome and may require multiple copies of WIT documents be maintained (e.g., a "stable" snapshot, a "candidate" snapshot, and an "actively-developed" draft).  By definition, minor updates must be purely additive, so the idea is to "compress" these snapshots into a single document, by syntactically annotating the new feature with what minor version they were introduced in.  Importantly, these gates do not show up in a component or runtime; they are erased as part of the process of building a component (selecting the target version and experimental features to enable).

(At some point, we may add function-level subtyping, at which point minor updates won't just add new functions, but also modify existing function types and so we'll need to nuance gating.  But I think that should be possible and until then we don't have to worry about it.)

The PR explains the new WIT syntax and give some examples.