### PR TITLE
Restrict namespace and package names to lowercase words

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1431,21 +1431,25 @@ plainname     ::= <label>
                 | '[constructor]' <label>
                 | '[method]' <label> '.' <label>
                 | '[static]' <label> '.' <label>
-label         ::= <word>
-                | <label> '-' <word>
+label         ::= <fragment>
+                | <label> '-' <fragment>
+fragment      ::= <word>
+                | <acronym>
 word          ::= [a-z] [0-9a-z]*
-                | [A-Z] [0-9A-Z]*
+acronym       ::= [A-Z] [0-9A-Z]*
 interfacename ::= <namespace> <label> <projection> <version>?
                 | <namespace>+ <label> <projection>+ <version>? 🪺
-namespace     ::= <label> ':'
+namespace     ::= <words> ':'
+words         ::= <word>
+                | <words> '-' <word>
 projection    ::= '/' <label>
 version       ::= '@' <valid semver>
 depname       ::= 'unlocked-dep=<' <pkgnamequery> '>'
                 | 'locked-dep=<' <pkgname> '>' ( ',' <hashname> )?
 pkgnamequery  ::= <pkgpath> <verrange>?
 pkgname       ::= <pkgpath> <version>?
-pkgpath       ::= <namespace> <label>
-                | <namespace>+ <label> <projection>* 🪺
+pkgpath       ::= <namespace> <words>
+                | <namespace>+ <words> <projection>* 🪺
 verrange      ::= '@*'
                 | '@{' <verlower> '}'
                 | '@{' <verupper> '}'


### PR DESCRIPTION
This PR implements the restriction discussed in #299.  While (with #337) case-insensitive uniqueness does allow a registry of components or WIT packages to lowercase everything without collision, enforcing case-insensitive uniqueness (on publication) may end up requiring non-trivial extra work (e.g., maintaining a whole side index) if the registry is implemented on top of an existing infrastructure (say, an OCI registry).  This also avoids some corner cases that will likely turn into incompatibilities in core infrastructure.