### PR TITLE
Tweak syntax for how component-level export identifiers are bound

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -620,7 +620,7 @@ would generate this component:
   ))
   (alias export $shared "metadata" (type $metadata_from_shared))
   (import "host" (instance $host
-    (export $metadata_in_host "metadata" (type (eq $metadata_from_shared)))
+    (export "metadata" (type $metadata_in_host (eq $metadata_from_shared)))
     (export "get" (func (result $metadata_in_host)))
   ))
 )
@@ -1414,7 +1414,7 @@ can be packaged into a component as:
 (component
   (type (export "types") (component
     (export "local:demo/types" (instance
-      (export $file "file" (type (sub resource)))
+      (export "file" (type $file (sub resource)))
       (export "[method]file.read" (func
         (param "self" (borrow $file)) (param "off" u32) (param "n" u32)
         (result (list u8))


### PR DESCRIPTION
A good observation in #276 is that the way we bind new `$identifiers` in component-level `export` definitions is a bit irregular, being the only place in WAT where we bind an identifier without the identifier being right after the `<sort>` of the identifier (e.g., in `(import "f" (func $f))` or `(alias $c "e" (type $t))`).  As proposed in this PR, instead of binding a new identifier `$t'` like so:
```wat
(type $t (resource (rep i32)))
(export $t' "t" (type $t))
```
we would instead write:
```wat
(type $t (resource (rep i32)))
(export "t" (type $t) (type $t'))
```
and this would dovetail nicely with the type ascription, so that when you wanted to both bind an identifier and explicitly declare a type, you could write:
```wat
(type $t (resource (rep i32)))
(export "t" (type $t) (type $t' (sub resource)))
```
This PR doesn't affect the AST, semantics or binary format, just how identifier-binding works in the text format, but it is a breaking change.  Thus, if we did go forward with this change, we'd probably want to support both the current and new style for a long time.

I don't think there is a big rush to make this change, though; I think it's mostly just a good cleanup to make before everything is finalized.