### PR TITLE
Use little-endian byte ordering for internal conversions.

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -500,10 +500,10 @@ def decode_i64_as_float(i):
   return canonicalize_nan64(core_f64_reinterpret_i64(i))
 
 def core_f32_reinterpret_i32(i):
-  return struct.unpack('!f', struct.pack('!I', i))[0] # f32.reinterpret_i32
+  return struct.unpack('<f', struct.pack('<I', i))[0] # f32.reinterpret_i32
 
 def core_f64_reinterpret_i64(i):
-  return struct.unpack('!d', struct.pack('!Q', i))[0] # f64.reinterpret_i64
+  return struct.unpack('<d', struct.pack('<Q', i))[0] # f64.reinterpret_i64
 ```
 
 An `i32` is converted to a `char` (a [Unicode Scalar Value]) by dynamically
@@ -760,10 +760,10 @@ def encode_float_as_i64(f):
   return core_i64_reinterpret_f64(maybe_scramble_nan64(f))
 
 def core_i32_reinterpret_f32(f):
-  return struct.unpack('!I', struct.pack('!f', f))[0] # i32.reinterpret_f32
+  return struct.unpack('<I', struct.pack('<f', f))[0] # i32.reinterpret_f32
 
 def core_i64_reinterpret_f64(f):
-  return struct.unpack('!Q', struct.pack('!d', f))[0] # i64.reinterpret_f64
+  return struct.unpack('<Q', struct.pack('<d', f))[0] # i64.reinterpret_f64
 ```
 
 The integral value of a `char` (a [Unicode Scalar Value]) is a valid unsigned

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -435,10 +435,10 @@ def decode_i64_as_float(i):
   return canonicalize_nan64(core_f64_reinterpret_i64(i))
 
 def core_f32_reinterpret_i32(i):
-  return struct.unpack('!f', struct.pack('!I', i))[0] # f32.reinterpret_i32
+  return struct.unpack('<f', struct.pack('<I', i))[0] # f32.reinterpret_i32
 
 def core_f64_reinterpret_i64(i):
-  return struct.unpack('!d', struct.pack('!Q', i))[0] # f64.reinterpret_i64
+  return struct.unpack('<d', struct.pack('<Q', i))[0] # f64.reinterpret_i64
 
 def convert_i32_to_char(cx, i):
   trap_if(i >= 0x110000)
@@ -611,10 +611,10 @@ def encode_float_as_i64(f):
   return core_i64_reinterpret_f64(maybe_scramble_nan64(f))
 
 def core_i32_reinterpret_f32(f):
-  return struct.unpack('!I', struct.pack('!f', f))[0] # i32.reinterpret_f32
+  return struct.unpack('<I', struct.pack('<f', f))[0] # i32.reinterpret_f32
 
 def core_i64_reinterpret_f64(f):
-  return struct.unpack('!Q', struct.pack('!d', f))[0] # i64.reinterpret_f64
+  return struct.unpack('<Q', struct.pack('<d', f))[0] # i64.reinterpret_f64
 
 def char_to_i32(c):
   i = ord(c)


### PR DESCRIPTION
When implementing reinterpret-cast functions, use `python.struct`'s `<` (little-endian) instead of `!` (network byte order).

This has no effective semantic change, because the conversions are just converting between i32/f32 and i64/f64 and are always done in pairs, so it's only required that the decoding match the encoding. However, using little-endian more clearly describes the behavior as corresponding to a Wasm store followed by a Wasm load, which would both be little-endian.

In theory this could become significant in the future if we add SIMD values where endianness conversions are partitioned by SIMD lanes, or other complex types.