### PR TITLE
fix type checking WAT examples

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1043,7 +1043,7 @@ bound.
 ```wasm
 (component
   (type $r (resource (rep i32)))
-  (export "r1" (type $r)
+  (export "r1" (type $r))
   (export "r2" (type $r) (type (sub resource)))
 )
 ```

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -824,11 +824,11 @@ example, in the following compound component:
   (type $ListListString1 (list $ListString1))
   (type $ListListString2 (list $ListString1))
   (component $B
-    (type $ListString3 (list string))
-    (type $ListListString3 (list $ListString3))
-    (type $ListString4 (alias outer $A $ListString))
-    (type $ListListString4 (list $ListString4))
-    (type $ListListString5 (alias outer $A $ListString2))
+    (type $ListString2 (list string))
+    (type $ListListString3 (list $ListString2))
+    (type $ListString3 (alias outer $A $ListString1))
+    (type $ListListString4 (list $ListString3))
+    (type $ListListString5 (alias outer $A $ListListString1))
   )
 )
 ```


### PR DESCRIPTION
While studying the explainer and working on #336 , I found out that the example type checking WAT is not valid.
I've quickly tested this by modifying a test case in Wasmtime with the following WAT (it appears that inverted alias form as defined in https://github.com/WebAssembly/component-model/blob/1a3e3cfe68e1ecc0567059cd218296af2e34e977/design/mvp/Explainer.md?plain=1#L390-L397 is not supported by whatever is parsing WAT in Wasmtime)

```wat
(component $A
    (type $ListString1 (list string))
    (type $ListListString1 (list $ListString1))
    (type $ListListString2 (list $ListString1))
    (component $B
      (type $ListString3 (list string))
      (type $ListListString3 (list $ListString3))
      (alias outer $A $ListString (type $ListString4))
      (type $ListListString4 (list $ListString4))
      (alias outer $A $ListString2 (type $ListListString5))
    )
)
```

Which failed with:
```
Error: unknown type: failed to find name `$ListString`
     --> <anon>:10:39
      |
   10 |                       (alias outer $A $ListString (type $ListString4))
```
as expected

Proposed version:
```wat
(component $A
  (type $ListString1 (list string))
  (type $ListListString1 (list $ListString1))
  (type $ListListString2 (list $ListString1))
  (component $B
    (type $ListString2 (list string))
    (type $ListListString3 (list $ListString2))
    (alias outer $A $ListString1 (type $ListString3))
    (type $ListListString4 (list $ListString3))
    (alias outer $A $ListListString2 (type $ListListString5))
  )
)
```