### PR TITLE
Update core type explainer text to match implementation

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -160,9 +160,6 @@ Notes:
   initially-empty type index space.
 * `alias` declarators currently only allow `outer` `type` aliases but
   would add `export` aliases when core wasm adds type exports.
-* Validation of `outer` aliases cannot see beyond the enclosing core type index
-  space. Since core modules and core module types cannot nest in the MVP, this
-  means that the maximum `ct` in an MVP `alias` declarator is `1`.
 
 ```ebnf
 type          ::= dt:<deftype>                            => (type dt)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -493,17 +493,13 @@ implicitly-created `func` type referring to both.
 Lastly, the `core:alias` module declarator allows a module type definition to
 reuse (rather than redefine) type definitions in the enclosing component's core
 type index space via `outer` `type` alias. In the MVP, validation restricts
-`core:alias` module declarators to *only* allow `outer` `type` aliases but,
-in the future, more kinds of aliases would be meaningful and allowed.
+`core:alias` module declarators to *only* allow `outer` `type` aliases (into an
+enclosing component's or component-type's core type index space). In the
+future, more kinds of aliases would be meaningful and allowed.
 
 As an example, the following component defines two semantically-equivalent
 module types, where the former defines the function type via `type` declarator
-and the latter refers via `alias` declarator. Note that, since core type
-definitions are validated in a Core WebAssembly context that doesn't "know"
-anything about components, the module type `$C2` can't name `$C` directly in
-the text format but must instead use the appropriate [de Bruijn] index (`1`).
-In both cases, the defined/aliased function type is given index `0` since
-module types always start with an empty type index space.
+and the latter refers via `alias` declarator.
 ```wasm
 (component $C
   (core type $C1 (module
@@ -513,7 +509,7 @@ module types always start with an empty type index space.
   ))
   (core type $F (func (param i32) (result i32)))
   (core type $C2 (module
-    (alias outer 1 $F (type))
+    (alias outer $C $F (type))
     (import "a" "b" (func (type 0)))
     (export "c" (func (type 0)))
   ))


### PR DESCRIPTION
I noticed a small discrepancy between the explainer text for how core type definitions work with what's in Binary.md and what's implemented.  What's implemented is actually a bit nicer (symbolic identifiers work, which I just checked), so this PR (should) bring the Explainer up to date.