### PR TITLE
Tweak CABI string conversion behavior

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -905,18 +905,20 @@ def store_string_to_utf8(cx, src, src_code_units, worst_case_size):
   assert(src_code_units <= MAX_STRING_BYTE_LENGTH)
   ptr = cx.opts.realloc(0, 0, 1, src_code_units)
   trap_if(ptr + src_code_units > len(cx.opts.memory))
-  encoded = src.encode('utf-8')
-  assert(src_code_units <= len(encoded))
-  cx.opts.memory[ptr : ptr+src_code_units] = encoded[0 : src_code_units]
-  if src_code_units < len(encoded):
-    trap_if(worst_case_size > MAX_STRING_BYTE_LENGTH)
-    ptr = cx.opts.realloc(ptr, src_code_units, 1, worst_case_size)
-    trap_if(ptr + worst_case_size > len(cx.opts.memory))
-    cx.opts.memory[ptr+src_code_units : ptr+len(encoded)] = encoded[src_code_units : ]
-    if worst_case_size > len(encoded):
-      ptr = cx.opts.realloc(ptr, worst_case_size, 1, len(encoded))
-      trap_if(ptr + len(encoded) > len(cx.opts.memory))
-  return (ptr, len(encoded))
+  for i,code_point in enumerate(src):
+    if ord(code_point) < 2**7:
+      cx.opts.memory[ptr + i] = ord(code_point)
+    else:
+      trap_if(worst_case_size > MAX_STRING_BYTE_LENGTH)
+      ptr = cx.opts.realloc(ptr, src_code_units, 1, worst_case_size)
+      trap_if(ptr + worst_case_size > len(cx.opts.memory))
+      encoded = src.encode('utf-8')
+      cx.opts.memory[ptr+i : ptr+len(encoded)] = encoded[i : ]
+      if worst_case_size > len(encoded):
+        ptr = cx.opts.realloc(ptr, worst_case_size, 1, len(encoded))
+        trap_if(ptr + len(encoded) > len(cx.opts.memory))
+      return (ptr, len(encoded))
+  return (ptr, src_code_units)
 ```
 
 Converting from UTF-8 to UTF-16 performs an initial worst-case size allocation


### PR DESCRIPTION
As surfaced in [jco/#443](https://github.com/bytecodealliance/jco/issues/443), the current string conversion logic in `store_string_to_utf8` doesn't quite match what an implementation naturally wants to do.  In particular, while the CABI does specify starting with an optimistic allocation that assumes all code points fit into a single byte, the fallback (that reallocs to the worst-case size and does the general transcode) doesn't happen as soon as the first non-fitting code point is discovered; it happens later once the initial allocation is full.  This PR tweaks the logic to instead do the realloc immediately when the non-fitting code point is discovered.

Technically, this could be considered a breaking change (since it observably changes when exactly the realloc happens), but it would be surprising if any code depended upon this behavior (at this early stage, without massive usage).  Thus, I think we can just make the change.

CC @alexcrichton @guybedford @dbaeumer