### PR TITLE
Remove named multi-return from function types (for now at least)

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -204,7 +204,7 @@ resourcetype  ::= 0x3f 0x7f f?:<funcidx>?                 => (resource (rep i32)
 functype      ::= 0x40 ps:<paramlist> rs:<resultlist>     => (func ps rs)
 paramlist     ::= lt*:vec(<labelvaltype>)                 => (param lt)*
 resultlist    ::= 0x00 t:<valtype>                        => (result t)
-                | 0x01 lt*:vec(<labelvaltype>)            => (result lt)*
+                | 0x01 0x00                               =>
 componenttype ::= 0x41 cd*:vec(<componentdecl>)           => (component cd*)
 instancetype  ::= 0x42 id*:vec(<instancedecl>)            => (instance id*)
 componentdecl ::= 0x03 id:<importdecl>                    => id

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -552,10 +552,7 @@ defvaltype    ::= bool
 valtype       ::= <typeidx>
                 | <defvaltype>
 resourcetype  ::= (resource (rep i32) (dtor async? <funcidx> (callback <funcidx>)?)?)
-functype      ::= (func <paramlist> <resultlist>)
-paramlist     ::= (param "<label>" <valtype>)*
-resultlist    ::= (result "<label>" <valtype>)*
-                | (result <valtype>)
+functype      ::= (func (param "<label>" <valtype>)* (result <valtype>)?)
 componenttype ::= (component <componentdecl>*)
 instancetype  ::= (instance <instancedecl>*)
 componentdecl ::= <importdecl>
@@ -690,13 +687,8 @@ The remaining 4 type constructors in `deftype` use `valtype` to describe
 shared-nothing functions, resources, components, and component instances:
 
 The `func` type constructor describes a component-level function definition
-that takes and returns a list of `valtype`. In contrast to [`core:functype`],
-the parameters and results of `functype` can have associated names which
-validation requires to be unique. To improve the ergonomics and performance of
-the common case of single-value-returning functions, function types may
-additionally have a single unnamed return type. For this special case, bindings
-generators are naturally encouraged to return the single value directly without
-wrapping it in any containing record/object/struct.
+that takes a list of uniquely-named `valtype` parameters and optionally returns
+a `valtype`.
 
 The `resource` type constructor creates a fresh type for each instance of the
 containing component (with "freshness" and its interaction with general

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1122,7 +1122,6 @@ param-list ::= '(' named-type-list ')'
 
 result-list ::= ϵ
               | '->' ty
-              | '->' '(' named-type-list ')'
 
 named-type-list ::= ϵ
                   | named-type ( ',' named-type )*


### PR DESCRIPTION
Currently function types are slightly asymmetric with results having an extra single-unnamed-result option.  As #356 points out, we could make params and results fully symmetric by saying that both could either be a list of all-named- or all-unnamed types.  I think that topic requires some more discussion to motivate and understand the implications for bindings generators in various languages.

In the meantime, though, I don't think anyone uses or even knows about named multi-return -- the much more common thing to do is to return a `tuple` or `record` (almost always wrapped in a `result`).  I think this means we can expect to see
an ad hoc mix of multi-return and `tuple`/`record` in practice which seems like needless inconsistency (and wasted time arguing over what if any convention there should be).  It also seems like this path will be either unimplemented or untested in current bindings generators, which bodes poorly if anyone ever does decide to use this feature.

Thus, this PR proposes that, at least until we decide to go for full symmetry, we lean into the asymmetry (which is already present) and disable this additional case of named multi-return that (afaik) noone is using.  If however anyone is using and appreciating named multi-return, I'd be very interested to hear about it!  (I'll leave this PR open for a while to collect feedback.)