### PR TITLE
Nested interfaces

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -662,8 +662,8 @@ world w2 {
 
 ## Nesting WIT interfaces
 [nest]: #nesting-wit-interfaces
-Interfaces can also export other interfaces via the `nest` keyword.
-With the `nest` keyword, one can reference other interfaces in the same package, foreign packages, or simply define anonymous interfaces inline.
+Interfaces can also contain other interfaces via the `nest` keyword.
+With the `nest` keyword, one can reference other interfaces in the same package, foreign packages, or define anonymous interfaces inline.
 
 ```wit
 package local:example;
@@ -673,7 +673,7 @@ interface foo {
 }
 
 interface top {
-  nest foo
+  nest foo;
   nest foreign:pkg/bar;
   baz: interface {
     ...
@@ -685,31 +685,45 @@ Each of these forms of nesting interfaces are encoded as:
 
 ```wasm
 (component
-  (type (;0;)
-    (instance
-      ... `types from foo`
-    )
-  )
-  (export "local:example/foo" (type 0))
-  (type (;1;) 
-    (instance
-      (alias outer 0 0 (type (;0;)))
-      (export "local:example/foo" (instance (type 0)))
-      (type (;1;) 
-        (instance 
-          ... `types from foreign:pkg/bar`
+  (type (;0;) 
+    (component 
+      (type (;0;)
+        (instance
+          ... `types from foo`
         )
       )
-      (export "foreign:pkg/bar" (instance (type 1)))
-      (type (;2;) 
-        (instance 
-          ... `types from baz`
-        )
-      )
-      (export "baz" (instance (type 2)))
+      (export "local:example/foo" (type 0))
     )
   )
-  (export "local:example/top (type 1))
+  (export (;1;) "foo" (type 0))
+  (type (;2;)
+    (component
+      (type (;0;) 
+        (instance
+          (type (;0;)
+            (instance
+              ... `types from foo`
+            )
+          )
+          (export "local:example/foo" (instance (type 0)))
+          (type (;1;) 
+            (instance 
+              ... `types from foreign:pkg/bar`
+            )
+          )
+          (export "foreign:pkg/bar" (instance (type 1)))
+          (type (;2;) 
+            (instance 
+              ... `types from baz`
+            )
+          )
+          (export "baz" (instance (type 2)))
+        )
+      )
+      (export "local:example/top (type 1))
+    )
+  )
+  (export (;3;) "top" (type 2))
 )
 ```
 
@@ -1159,6 +1173,7 @@ interface-items ::= gate interface-definition
 interface-definition ::= typedef-item
                        | use-item
                        | func-item
+                       | nest-item
 
 typedef-item ::= resource-item
                | variant-items
@@ -1181,6 +1196,9 @@ named-type-list ::= ϵ
                   | named-type ( ',' named-type )*
 
 named-type ::= id ':' ty
+
+nest-item ::= gate nest use-path ';'
+            | id: interface-item
 ```
 
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -116,7 +116,7 @@ would correspond to:
 )
 ```
 
-An `interface` can contain [`use`][use] statements, [type][types] definitions,
+An `interface` can contain [`use`][use] and [`nest`][nest] statements, [type][types] definitions,
 and [function][functions] definitions. For example:
 
 ```wit
@@ -136,7 +136,7 @@ interface types {
 }
 ```
 
-More information about [`use`][use] and [types] are described below, but this
+More information about [`use`][use], [`nest`][nest], and [types] are described below, but this
 is an example of a collection of items within an `interface`. All items defined
 in an `interface`, including [`use`][use] items, are considered as exports from
 the interface. This means that types can further be used from the interface by
@@ -659,6 +659,59 @@ world w2 {
 > this on a more fine-grained basis for exports, for example being able to
 > configure that a `use`'d interface is a particular import or a particular
 > export.
+
+## Nesting WIT interfaces
+[nest]: #nesting-wit-interfaces
+Interfaces can also export other interfaces via the `nest` keyword.
+With the `nest` keyword, one can reference other interfaces in the same package, foreign packages, or simply define anonymous interfaces inline.
+
+```wit
+package local:example;
+
+interface foo {
+  ...
+}
+
+interface top {
+  nest foo
+  nest foreign:pkg/bar;
+  baz: interface {
+    ...
+  }
+}
+```
+
+Each of these forms of nesting interfaces are encoded as:
+
+```wasm
+(component
+  (type (;0;)
+    (instance
+      ... `types from foo`
+    )
+  )
+  (export "local:example/foo" (type 0))
+  (type (;1;) 
+    (instance
+      (alias outer 0 0 (type (;0;)))
+      (export "local:example/foo" (instance (type 0)))
+      (type (;1;) 
+        (instance 
+          ... `types from foreign:pkg/bar`
+        )
+      )
+      (export "foreign:pkg/bar" (instance (type 1)))
+      (type (;2;) 
+        (instance 
+          ... `types from baz`
+        )
+      )
+      (export "baz" (instance (type 2)))
+    )
+  )
+  (export "local:example/top (type 1))
+)
+```
 
 ## WIT Functions
 [functions]: #wit-functions


### PR DESCRIPTION
Here is an outline for the various ways in which one could describe nested interfaces in wit.

For additional context re: motivation, see [this issue](https://github.com/WebAssembly/component-model/issues/301), though generally what this enables is the ability to target nested instances which are expressible in wat and binary formats, and not in wit.

An initial implementation that still needs some work can be found [here](https://github.com/bytecodealliance/wasm-tools/pull/1624), though at the moment, it would only add support for the case of nesting interfaces from foreign packages.

Perhaps this PR can also be a place to hash out a bit of what the implications would be from a guest lang bindgen perspective as well.