### PR TITLE
Simplify and tighten up reentrance/backpressure rules for async

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -221,6 +221,11 @@ call the `task.backpressure` built-in to set a "backpressure" flag that causes
 subsequent export calls to immediately return in the [starting](#starting)
 state without calling the component's Core WebAssembly code.
 
+Once backpressure is enabled, the current task can [wait](#waiting) for
+existing tasks to finish and release their associated resources. Thus, a task
+can [wait](#waiting) with or without backpressure, depending on whether it
+wants to accept new accept new export calls while waiting or not.
+
 See the [`canon_task_backpressure`] function and [`Task.enter`] method in the
 Canonical ABI explainer for the setting and implementation of backpressure.
 
@@ -233,9 +238,9 @@ arguments and must instead call an imported [`task.start`] built-in to lower
 and receive its arguments.
 
 The main reason to have `task.start` is so that an overloaded component can
-[wait](#waiting) and/or exert [backpressure](#backpressure) before accepting
-the arguments to an export call. See the [`canon_task_start`] function in the
-Canonical ABI explainer for more details.
+enable [backpressure](#backpressure) and then [wait](#waiting) for existing
+tasks to finish before the receiving the arguments to the current task. See the
+[`canon_task_start`] function in the Canonical ABI explainer for more details.
 
 Before a task has called `task.start`, it is considered in the "starting"
 state. After calling `task.start`, the task is in a "started" state.

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -275,11 +275,12 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
            | 0x05 ft:<typeidx>                                   => (canon thread.spawn ft (core func))
            | 0x06                                                => (canon thread.hw_concurrency (core func))
-           | 0x08 ft:<core:typeidx>                              => (canon task.start ft (core func))
-           | 0x09 ft:<core:typeidx>                              => (canon task.return ft (core func))
-           | 0x0a                                                => (canon task.wait (core func))
-           | 0x0b                                                => (canon task.poll (core func))
-           | 0x0c                                                => (canon task.yield (core func))
+           | 0x08                                                => (canon task.backpressure (core func))
+           | 0x09 ft:<core:typeidx>                              => (canon task.start ft (core func))
+           | 0x0a ft:<core:typeidx>                              => (canon task.return ft (core func))
+           | 0x0b                                                => (canon task.wait (core func))
+           | 0x0c                                                => (canon task.poll (core func))
+           | 0x0d                                                => (canon task.yield (core func))
 opts     ::= opt*:vec(<canonopt>)                                => opt*
 canonopt ::= 0x00                                                => string-encoding=utf8
            | 0x01                                                => string-encoding=utf16

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1313,6 +1313,7 @@ canon ::= ...
         | (canon resource.new <typeidx> (core func <id>?))
         | (canon resource.drop <typeidx> async? (core func <id>?))
         | (canon resource.rep <typeidx> (core func <id>?))
+        | (canon task.backpressure (core func <id>?)) 🔀
         | (canon task.start <core:typeidx> (core func <id>?)) 🔀
         | (canon task.return <core:typeidx> (core func <id>?)) 🔀
         | (canon task.wait (core func <id>?)) 🔀
@@ -1374,15 +1375,19 @@ transferring ownership of the newly-created resource to the export's caller.
 See the [async explainer](Async.md) for high-level context and terminology
 and the [Canonical ABI explainer] for detailed runtime semantics.
 
+The `task.backpressure` built-in has type `[i32] -> []` and allows the
+async-lifted callee to toggle a per-component-instance flag that, when set,
+prevents new incoming export calls to the component (until the flag is unset).
+This allows the component to exert [backpressure](Async.md#backpressure).
+
 The `task.start` built-in returns the arguments to the currently-executing
 task. This built-in must be called from an `async`-lifted export exactly once
-per export activation. Delaying the call to `task.start` allows the async
-callee to exert *backpressure* on the caller. The `canon task.start` definition
-takes the type index of a core function type and produces a core function with
-exactly that type. When called, the declared core function type is checked
-to match the lowered function type of a component-level function returning the
-parameter types of the current task. (See also [Starting](Async.md#starting) in
-the async explainer and [`canon_task_start`] in the Canonical ABI explainer.)
+per export activation. The `canon task.start` definition takes the type index
+of a core function type and produces a core function with exactly that type.
+When called, the declared core function type is checked to match the lowered
+function type of a component-level function returning the parameter types of
+the current task. (See also [Starting](Async.md#starting) in the async
+explainer and [`canon_task_start`] in the Canonical ABI explainer.)
 
 The `task.return` built-in takes as parameters the result values of the
 currently-executing task. This built-in must be called from an `async`-lifted


### PR DESCRIPTION
I realized that the current CABI logic underspecifies a few cases and that would seem to allow, in some cases, async calls to block in cases where they intuitively shouldn't.  The two commits in this PR fix this by specifying how async-lowered calls work in a lot more detail (without a lot more code; I found some latent simplifications at part of this) and removing the hand-wavey-ness (particularly around `asyncio.create_task`).

The first commit also makes one semantic change: instead of async tasks implicitly signalling backpressure by `task.wait`ing before `task.start`ing the call, the first commit instead introduces an explicit `task.backpressure` built-in that can be called any time by guest code to toggle a bool on the `ComponentInstance` for whether to exert backpressure or not.  This both simplifies the logic quite a bit and provides more expressivity to the guest code (e.g., you might only realize at the end of a task that you're nearing OOM and need backpressure, and this change lets you do that).  This commit also makes guest-signaled backpressure apply to *all* export calls (not just async-lifted ones) since, if you're explicitly signalling backpressure due to nearing OOM, sync calls are also a problem.

cc @dicej