### PR TITLE
Add support for `@deprecated` gates to WIT

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -923,8 +923,9 @@ package-items ::= toplevel-use-item | interface-item | world-item
 ### Feature Gates
 
 Various WIT items can be "gated", to reflect the fact that the item is part of
-an unstable feature or that the item was added as part of a minor version
-update and shouldn't be used when targeting an earlier minor version.
+an unstable feature, that the item was added as part of a minor version
+update and shouldn't be used when targeting an earlier minor version, or that a
+feature has been deprecated and should no longer be used.
 
 For example, the following interface has 4 items, 3 of which are gated:
 ```wit
@@ -939,6 +940,9 @@ interface foo {
 
   @unstable(feature = fancier-foo)
   d: func();
+
+  @deprecated(version = 0.2.1)
+  e: func();
 }
 ```
 The `@since` gate indicates that `b` and `c` were added as part of the `0.2.1`
@@ -952,6 +956,12 @@ In contrast, the `@unstable` gate on `d` indicates that `d` is part of the
 change type or be removed at any time. An important expectation set by the
 `@unstable` gate is that toolchains will not expose `@unstable` features by
 default unless explicitly opted-into by the developer.
+
+Finally, the `@deprecated` gate on `e` indicates that `e` should no longer be
+used starting version `0.2.1`. `@deprecated` gates can carry an optional
+"message" field which can be used to elaborate why the feature should no longer
+be used and which feature to use instead. Both toolchains and host runtimes may
+warn users if they detect an `@deprecated` API is being used.
 
 Together, these gates support a development flow in which new features start
 with an `@unstable` gate while the details are still being hashed out. Then,
@@ -970,9 +980,15 @@ Specifically, the syntax for feature gates is:
 ```wit
 gate ::= unstable-gate
        | since-gate
+       | deprecated-gate
+
 unstable-gate ::= '@unstable' '(' feature-field ')'
+since-gate ::= '@since' '(' version-field ( ',' feature-field )? ')'
+deprecated-gate ::= '@deprecated' '(' version-field ( ',' message-field )? ')'
+
 feature-field ::= 'feature' '=' id
-since-gate ::= '@since' '(' 'version' '=' <valid semver> ( ',' feature-field )? ')'
+version-field ::= 'version' '=' <valid semver>
+message-field ::= 'message' '=' message
 ```
 
 As part of WIT validation, any item that refers to another gated item must also

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -958,10 +958,10 @@ change type or be removed at any time. An important expectation set by the
 default unless explicitly opted-into by the developer.
 
 Finally, the `@deprecated` gate on `e` indicates that `e` should no longer be
-used starting version `0.2.1`. `@deprecated` gates can carry an optional
-"message" field which can be used to elaborate why the feature should no longer
-be used and which feature to use instead. Both toolchains and host runtimes may
-warn users if they detect an `@deprecated` API is being used.
+used starting version `0.2.1`. Both toolchains and host runtimes may
+warn users if they detect an `@deprecated` API is being used. An `@deprecated`
+gate is required to always be paired up with an `@since` gate. It is
+semantically invalid to use `@deprecated` without also using `@since`.
 
 Together, these gates support a development flow in which new features start
 with an `@unstable` gate while the details are still being hashed out. Then,
@@ -985,7 +985,7 @@ gate-item ::= unstable-gate
 
 unstable-gate ::= '@unstable' '(' feature-field ')'
 since-gate ::= '@since' '(' version-field ( ',' feature-field )? ')'
-deprecated-gate ::= '@deprecated' '(' version-field ( ',' message-field )? ')'
+deprecated-gate ::= '@deprecated' '(' version-field ')'
 
 feature-field ::= 'feature' '=' id
 version-field ::= 'version' '=' <valid semver>

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -941,7 +941,8 @@ interface foo {
   @unstable(feature = fancier-foo)
   d: func();
 
-  @deprecated(version = 0.2.1)
+  @since(version = 0.2.0)
+  @deprecated(version = 0.2.2)
   e: func();
 }
 ```
@@ -958,7 +959,7 @@ change type or be removed at any time. An important expectation set by the
 default unless explicitly opted-into by the developer.
 
 Finally, the `@deprecated` gate on `e` indicates that `e` should no longer be
-used starting version `0.2.1`. Both toolchains and host runtimes may warn users
+used starting version `0.2.2`. Both toolchains and host runtimes may warn users
 if they detect an `@deprecated` API is being used. An `@deprecated` gate is
 required to always be paired up with either a `@since` or `@deprecated` gate.
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -988,8 +988,11 @@ deprecated-gate ::= '@deprecated' '(' version-field ( ',' message-field )? ')'
 
 feature-field ::= 'feature' '=' id
 version-field ::= 'version' '=' <valid semver>
-message-field ::= 'message' '=' message
+message-field ::= 'message' '=' <core:string>
 ```
+
+In this syntax `<core:string>` refers to core Wasm's [string
+value](https://webassembly.github.io/spec/core/text/values.html#text-string).
 
 As part of WIT validation, any item that refers to another gated item must also
 be compatibly gated. For example, this is an error:

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -978,9 +978,10 @@ enable the feature by default.
 
 Specifically, the syntax for feature gates is:
 ```wit
-gate ::= unstable-gate
-       | since-gate
-       | deprecated-gate
+gate ::= gate-item*
+gate-item ::= unstable-gate
+            | since-gate
+            | deprecated-gate
 
 unstable-gate ::= '@unstable' '(' feature-field ')'
 since-gate ::= '@since' '(' version-field ( ',' feature-field )? ')'

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -988,11 +988,7 @@ deprecated-gate ::= '@deprecated' '(' version-field ')'
 
 feature-field ::= 'feature' '=' id
 version-field ::= 'version' '=' <valid semver>
-message-field ::= 'message' '=' <core:string>
 ```
-
-In this syntax `<core:string>` refers to core Wasm's [string
-value](https://webassembly.github.io/spec/core/text/values.html#text-string).
 
 As part of WIT validation, any item that refers to another gated item must also
 be compatibly gated. For example, this is an error:

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -958,10 +958,9 @@ change type or be removed at any time. An important expectation set by the
 default unless explicitly opted-into by the developer.
 
 Finally, the `@deprecated` gate on `e` indicates that `e` should no longer be
-used starting version `0.2.1`. Both toolchains and host runtimes may
-warn users if they detect an `@deprecated` API is being used. An `@deprecated`
-gate is required to always be paired up with an `@since` gate. It is
-semantically invalid to use `@deprecated` without also using `@since`.
+used starting version `0.2.1`. Both toolchains and host runtimes may warn users
+if they detect an `@deprecated` API is being used. An `@deprecated` gate is
+required to always be paired up with either a `@since` or `@deprecated` gate.
 
 Together, these gates support a development flow in which new features start
 with an `@unstable` gate while the details are still being hashed out. Then,


### PR DESCRIPTION
Closes #374. Adds support for `@deprecated` gates to WIT. While the text in this PR is ready for review now, we should hold off on merging this until we have implementation feedback. Thanks!

r? @lukewagner 