### PR TITLE
Add type definition for `rectype`

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -136,18 +136,19 @@ Notes:
 
 (See [Type Definitions](Explainer.md#type-definitions) in the explainer.)
 ```ebnf
-core:type        ::= dt:<core:deftype>                  => (type dt)        (GC proposal)
-core:deftype     ::= rt:<core:rectype>                  => rt               (WebAssembly 3.0)
-                   | mt:<core:moduletype>               => mt
-core:moduletype  ::= 0x50 md*:vec(<core:moduledecl>)    => (module md*)
-core:moduledecl  ::= 0x00 i:<core:import>               => i
-                   | 0x01 t:<core:type>                 => t
-                   | 0x02 a:<core:alias>                => a
-                   | 0x03 e:<core:exportdecl>           => e
-core:alias       ::= s:<core:sort> t:<core:aliastarget> => (alias t (s))
-core:aliastarget ::= 0x01 ct:<u32> idx:<u32>            => outer ct idx
-core:importdecl  ::= i:<core:import>                    => i
-core:exportdecl  ::= n:<core:name> d:<core:importdesc>  => (export n d)
+core:type        ::= dt:<core:deftype>                                    => (type dt)        (GC proposal)
+core:deftype     ::= rt:<core:rectype>                                    => rt               (WebAssembly 3.0)
+                   | 0x00 0x50 x*:vec(<core:typeidx>) ct:<core:comptype>  => sub x* ct        (WebAssembly 3.0)
+                   | mt:<core:moduletype>                                 => mt
+core:moduletype  ::= 0x50 md*:vec(<core:moduledecl>)                      => (module md*)
+core:moduledecl  ::= 0x00 i:<core:import>                                 => i
+                   | 0x01 t:<core:type>                                   => t
+                   | 0x02 a:<core:alias>                                  => a
+                   | 0x03 e:<core:exportdecl>                             => e
+core:alias       ::= s:<core:sort> t:<core:aliastarget>                   => (alias t (s))
+core:aliastarget ::= 0x01 ct:<u32> idx:<u32>                              => outer ct idx
+core:importdecl  ::= i:<core:import>                                      => i
+core:exportdecl  ::= n:<core:name> d:<core:importdesc>                    => (export n d)
 ```
 Notes:
 * Reused Core binary rules: [`core:import`], [`core:importdesc`],

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -137,8 +137,7 @@ Notes:
 (See [Type Definitions](Explainer.md#type-definitions) in the explainer.)
 ```ebnf
 core:type        ::= dt:<core:deftype>                  => (type dt)        (GC proposal)
-core:deftype     ::= ft:<core:functype>                 => ft               (WebAssembly 1.0)
-                   | 0x00 rt:<core:rectype>             => rt               (WebAssembly 3.0)
+core:deftype     ::= rt:<core:rectype>                  => rt               (WebAssembly 3.0)
                    | mt:<core:moduletype>               => mt
 core:moduletype  ::= 0x50 md*:vec(<core:moduledecl>)    => (module md*)
 core:moduledecl  ::= 0x00 i:<core:import>               => i
@@ -152,14 +151,14 @@ core:exportdecl  ::= n:<core:name> d:<core:importdesc>  => (export n d)
 ```
 Notes:
 * Reused Core binary rules: [`core:import`], [`core:importdesc`],
-  [`core:functype`], [`core:rectype`]
-* The three branches of `core:deftype` have prefix bytes of 0x60
-  (`core:functype`), 0x50 (`core:moduletype`   ), and 0x00 (`core:rectype`). This
-  is because the component model and the GC specifications (i.e., source of
-  `core:rectype`) have evolved in parallel and independently. Ideally, in the
-  future, the `core:functype` production would be removed as it can be expressed
-  within `core:rectype`. Also, the prefix byte of `core:moduletype` (0x50) will
-  also likely change as well.
+  [`core:rectype`]
+* Unfortunately, the `core:deftype` rule results in an encoding ambiguity: the
+  `0x50` opcode is used by both `core:moduletype` and `core:subtype`, which can
+  be decoded as a top-level form of `core:rectype`. To resolve this, prior to
+  v1.0 of this specification, we require `core:subtype` to be prefixed by `0x00`
+  in this context (i.e., a `sub` as a component core type is `0x00 0x50`;
+  elsewhere, `0x50`). By the v1.0 release of this specification,
+  `core:moduletype` will receive a new, non-overlapping opcode.
 * Validation of `core:moduledecl` rejects `core:moduletype` definitions
   and `outer` aliases of `core:moduletype` definitions inside `type`
   declarators. Thus, as an invariant, when validating a `core:moduletype`, the

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -153,12 +153,13 @@ Notes:
 * Reused Core binary rules: [`core:import`], [`core:importdesc`],
   [`core:rectype`]
 * Unfortunately, the `core:deftype` rule results in an encoding ambiguity: the
-  `0x50` opcode is used by both `core:moduletype` and `core:subtype`, which can
-  be decoded as a top-level form of `core:rectype`. To resolve this, prior to
-  v1.0 of this specification, we require `core:subtype` to be prefixed by `0x00`
-  in this context (i.e., a `sub` as a component core type is `0x00 0x50`;
-  elsewhere, `0x50`). By the v1.0 release of this specification,
-  `core:moduletype` will receive a new, non-overlapping opcode.
+  `0x50` opcode is used by both `core:moduletype` and a non-final
+  `core:subtype`, which can be decoded as a top-level form of `core:rectype`. To
+  resolve this, prior to v1.0 of this specification, we require `core:subtype`
+  to be prefixed by `0x00` in this context (i.e., a non-final `sub` as a
+  component core type is `0x00 0x50`; elsewhere, `0x50`). By the v1.0 release of
+  this specification, `core:moduletype` will receive a new, non-overlapping
+  opcode.
 * Validation of `core:moduledecl` rejects `core:moduletype` definitions
   and `outer` aliases of `core:moduletype` definitions inside `type`
   declarators. Thus, as an invariant, when validating a `core:moduletype`, the

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -138,8 +138,7 @@ Notes:
 ```ebnf
 core:type        ::= dt:<core:deftype>                  => (type dt)        (GC proposal)
 core:deftype     ::= ft:<core:functype>                 => ft               (WebAssembly 1.0)
-                   | st:<core:structtype>               => st               (GC proposal)
-                   | at:<core:arraytype>                => at               (GC proposal)
+                   | 0x00 rt:<core:rectype>             => rt               (WebAssembly 3.0)
                    | mt:<core:moduletype>               => mt
 core:moduletype  ::= 0x50 md*:vec(<core:moduledecl>)    => (module md*)
 core:moduledecl  ::= 0x00 i:<core:import>               => i
@@ -152,7 +151,15 @@ core:importdecl  ::= i:<core:import>                    => i
 core:exportdecl  ::= n:<core:name> d:<core:importdesc>  => (export n d)
 ```
 Notes:
-* Reused Core binary rules: [`core:import`], [`core:importdesc`], [`core:functype`]
+* Reused Core binary rules: [`core:import`], [`core:importdesc`],
+  [`core:functype`], [`core:rectype`]
+* The three branches of `core:deftype` have prefix bytes of 0x60
+  (`core:functype`), 0x50 (`core:moduletype`   ), and 0x00 (`core:rectype`). This
+  is because the component model and the GC specifications (i.e., source of
+  `core:rectype`) have evolved in parallel and independently. Ideally, in the
+  future, the `core:functype` production would be removed as it can be expressed
+  within `core:rectype`. Also, the prefix byte of `core:moduletype` (0x50) will
+  also likely change as well.
 * Validation of `core:moduledecl` rejects `core:moduletype` definitions
   and `outer` aliases of `core:moduletype` definitions inside `type`
   declarators. Thus, as an invariant, when validating a `core:moduletype`, the
@@ -467,6 +474,7 @@ named once.
 [`core:import`]: https://webassembly.github.io/spec/core/binary/modules.html#binary-import
 [`core:importdesc`]: https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc
 [`core:functype`]: https://webassembly.github.io/spec/core/binary/types.html#binary-functype
+[`core:rectype]: https://webassembly.github.io/gc/core/binary/types.html#recursive-types
 
 [type-imports]: https://github.com/WebAssembly/proposal-type-imports/blob/master/proposals/type-imports/Overview.md
 [module-linking]: https://github.com/WebAssembly/module-linking/blob/main/proposals/module-linking/Explainer.md

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -136,7 +136,7 @@ Notes:
 
 (See [Type Definitions](Explainer.md#type-definitions) in the explainer.)
 ```ebnf
-core:type        ::= dt:<core:deftype>                                    => (type dt)        (GC proposal)
+core:type        ::= dt:<core:deftype>                                    => (type dt)
 core:deftype     ::= rt:<core:rectype>                                    => rt               (WebAssembly 3.0)
                    | 0x00 0x50 x*:vec(<core:typeidx>) ct:<core:comptype>  => sub x* ct        (WebAssembly 3.0)
                    | mt:<core:moduletype>                                 => mt


### PR DESCRIPTION
This changes the component model specification to reference a `rectype` in its type defintions. This makes sense since the [GC] proposal has graduated to become standard WebAssembly and the previous definitions refer to `arraytype` and `structtype` which are subsumed by `rectype`. Adding this also benefits the [shared-everything-threads] proposal, which uses `shared` bits on composite types.

In talking with @alexcrichton about this, the `functype` alternative is retained for now to allow backward compatibility for existing components (e.g., components using the `0x60` prefix to define a core `functype`). In the future, the `functype` alternative should be removed completely (since it is subsumed under `rectype`). Potentially the `0x00` prefix could be tweaked as well. In the meantime, this change allows more than one way to encode a `functype`.

[GC]: https://github.com/WebAssembly/gc
[shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads