### PR TITLE
Unlocked deps

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -663,7 +663,7 @@ world w2 {
 
 ## Unlocked Dependency Imports
 
-When working with a registry, the keyword `unlocked-dep` is available to specify version requirements as ranges.
+When working with a registry, the keyword `unlocked-dep` is available to specify dependencies with package name and version requirements.  For example:
 
 ```wit
 world w {

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -661,7 +661,7 @@ world w2 {
 > configure that a `use`'d interface is a particular import or a particular
 > export.
 
-## Unlocked Imports (semver)
+## Unlocked Dependency Imports
 
 When working with a registry, the keyword `unlocked-dep` is available to specify version requirements as ranges.
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -674,8 +674,7 @@ world w {
 The binary format has a corresponding [import definition](Explainer.md#import-and-export-definitions) and this WIT syntax informs
 bindgen tooling that it should be used.
 
-The key idea here is to be able to specify a dependency on a _component_, rather than on a wit interface.  Sometimes, as a component author, the goal is to have a dynamic import, where at a time after development is done, one of many implementations of a wit interface is specified, so that in essence your dependency makes your component configurable.  This workflow is well documented across a variety of tools.  Unlocked imports, on the other hand, are available for
-specifying a dependency on a specific implementation of an interface, with a semver range
+The point of `unlocked-dep` is to specify a dependency on a _component implementation_ (or a semver *range* of implementations), rather than on an abstract WIT interface (with an unspecified implementation).
 
 ### Example Unlocked Workflow
 Each language has its own toolchain for creating wasm components that should feel familiar to users of that language.  As an example, somebody authoring a rust component would add the component they're interested in to their `Cargo.toml`.


### PR DESCRIPTION
This PR servers as an initial description of what the desired behavior of an `unlocked-dep` would include.  As exemplified in the PR, most language toolchains would probably use it in combination with [nested interfaces](https://github.com/WebAssembly/component-model/pull/372), which is currently in the process of being implemented.

The primary motivation behind this syntax is enabling a way for registry tooling concerned with package resolution to resolve implementations of components (rather than wit).  This should hopefully enable workflows where users can depend on specific components, rather than interfaces whose implementations need to be specified at a later time.