### PR TITLE
Reorganize the "Canonical Built-ins" section of Explainer.md.

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -550,9 +550,9 @@ comes after:
 [Lift and Lower Definitions]: Explainer.md#canonical-definitions
 [Lifted]: Explainer.md#canonical-definitions
 [Canonical Built-in]: Explainer.md#canonical-built-ins
-[`task.return`]: Explainer.md#-async-built-ins
-[`task.wait`]: Explainer.md#-async-built-ins
-[`thread.spawn`]: Explainer.md#-threading-built-ins
+[`task.return`]: Explainer.md#-taskreturn
+[`task.wait`]: Explainer.md#-taskwait
+[`thread.spawn`]: Explainer.md#-threadspawn
 [ESM-integration]: Explainer.md#ESM-integration
 
 [Canonical ABI Explainer]: CanonicalABI.md

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1644,16 +1644,26 @@ table, trapping if the subtask isn't done.
 
 ###### 🔀 `stream.new` and `future.new`
 
-| Synopsis                                   |                          |
-| ------------------------------------------ | ------------------------ |
-| Approximate WIT signature for `stream.new` | `func<T>() -> stream<T>` |
-| Approximate WIT signature for `future.new` | `func<T>() -> future<T>` |
-| Canonical ABI signature                    | `[] -> [i32]`            |
+| Synopsis                                   |                                   |
+| ------------------------------------------ | --------------------------------- |
+| Approximate WIT signature for `stream.new` | `func<T>() -> writable-stream<T>` |
+| Approximate WIT signature for `future.new` | `func<T>() -> writable-future<T>` |
+| Canonical ABI signature                    | `[] -> [i32]`                     |
 
 The `stream.new` and `future.new` built-ins return the
 [writable end](Async.md#streams-and-futures) of a new `stream<T>` or
 `future<T>`. (See
 [`canon_stream_new`] in the Canonical ABI explainer for details.)
+
+The types `readable-stream<T>` and `writable-stream<T>` are not WIT types; they
+are the conceptual lower-level types that describe how the canonical built-ins use
+the readable and writable ends of a `stream<T>`. `writable-stream<T>`s are obtained
+from `stream.new` and from lowering a `stream<T>` in a function return type, and
+`readable-stream<T>`s are obtained from lowering a `stream<T>` in a function
+parameter type.
+
+The same relationship exists among `readable-future<T>`, `writable-future<T>`,
+and the WIT `future<T>`.
 
 ###### 🔀 `stream.read`
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1600,7 +1600,7 @@ subtasks. (See also [Waiting](Async.md#waiting) in the async explainer and
 | Approximate WIT signature  | `func() -> option<event> `          |
 | Canonical ABI signature    | `[event_addr:i32] -> [is_some:i32]` |
 
-where `event`, `event-kind`, and `payload` are defined as in [🔀 `task.wait`].
+where `event`, `event-kind`, and `payload` are defined as in [`task.wait`](#-taskwait).
 
 The `task.poll` built-in returns either `none` if no event was immediately
 available, or `some` containing an event code and payload.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1437,6 +1437,8 @@ canon ::= ...
 The `resource.new` built-in creates a new
 resource (with resource type `T`) with `rep` as its
 representation, and returns a new handle pointing to the new resource.
+Validation only allows `resource.rep T` to be used within the component
+that defined `T`.
 
 In the Canonical ABI, `T.rep` is defined to be the `$rep` in the
 `(type $T (resource (rep $rep) ...))` type definition that defined `T`. While
@@ -1464,6 +1466,8 @@ When the `async` immediate is true:
 The `resource.drop` built-in drops a resource handle `t` (with resource type `T`).
 If the dropped handle owns the resource, the resource's
 `dtor` is called, if present.
+Validation only allows `resource.rep T` to be used within the component
+that defined `T`.
 
 When the `async` immediate is true, the returned value indicates whether
 the drop completed eagerly, or if not, identifies the in-progress drop.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1634,7 +1634,7 @@ ABI explainer.)
 
 | Synopsis                   |                       |
 | -------------------------- | --------------------- |
-| Approximate WIT signature  | `func(subtask: task)` |
+| Approximate WIT signature  | `func(subtask: subtask)` |
 | Canonical ABI signature    | `[i32] -> []`         |
 
 The `subtask.drop` built-in removes the indicated

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1798,17 +1798,19 @@ for details.)
 | Approximate WIT signature for `stream.close-writable` | `func<T>(out: writable-stream<T>, err: option<error-context>)` |
 | Approximate WIT signature for `future.close-readable` | `func<T>(in: readable-future<T>)` |
 | Approximate WIT signature for `future.close-writable` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
-| Canonical ABI signature for `*.close-readable`        | `[i32] -> []`                     |
-| Canonical ABI signature for `*.close-writable`        | `[i32, i32] -> []`                |
+| Canonical ABI signature for `*.close-readable`        | `[in:i32] -> []`                  |
+| Canonical ABI signature for `*.close-writable`        | `[out:i32, err:i32] -> []`        |
 
 The `{stream,future}.close-{readable,writable}` built-ins
 remove the indicated [stream or future](Async.md#streams-and-futures)
 from the current component instance's [waitables](Async.md#waiting) table,
 trapping if the stream or future has a mismatched direction or type or are in
 the middle of a `read` or `write`.
-(See also [the `close` built-ins] in the Canonical ABI explainer.)
 
-TODO: Describe how the `option<error-context>` is represented as i32 in the Canonical ABI.
+In the Canonical ABI, an `err` value of `0` represents `none`, and a non-zero
+value represents `some` of the index of an `error-context` in the instance's
+table.
+(See also [the `close` built-ins] in the Canonical ABI explainer.)
 
 ##### 🔀 Error Context built-ins
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1650,9 +1650,9 @@ The `stream.new` and `future.new` built-ins return the
 The types `readable-stream<T>` and `writable-stream<T>` are not WIT types; they
 are the conceptual lower-level types that describe how the canonical built-ins use
 the readable and writable ends of a `stream<T>`. `writable-stream<T>`s are obtained
-from `stream.new` and from lowering a `stream<T>` in a function return type, and
-`readable-stream<T>`s are obtained from lowering a `stream<T>` in a function
-parameter type.
+from `stream.new`.  A `readable-stream<T>` is created by calling `stream.new` to create a fresh "unpaired" `writable-stream<T>` and then lifting it as the `stream<T>` parameter of an import call
+or the `stream<T>` result of an export call.  This lifted `stream<T>` value is then lowered by the
+receiving component into a `readable-stream<T>` that is "paired" with the original `writable-stream<T>`.
 
 An analogous relationship exists among `readable-future<T>`, `writable-future<T>`,
 and the WIT `future<T>`.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1637,7 +1637,7 @@ enum stream-status {
    // The operation did not complete immediately, so callers must wait for
    // the operation to complete by using `task.wait` or by returning to the
    // event loop.
-   blocked,
+   blocked(task),
 
    // The stream is closed. For reading, the end of the stream has been
    // reached. For writing, the reader is no longer reading data.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1648,7 +1648,7 @@ The `stream.new` and `future.new` built-ins return the
 
 | Synopsis                   |                                                             |
 | -------------------------- | ----------------------------------------------------------- |
-| Approximate WIT signature  | `func<T>(stream: stream<T>, buffer: readable-buffer<T>) -> read-status`  |
+| Approximate WIT signature  | `func<T>(stream: readable-stream<T>, buffer: readable-buffer<T>) -> read-status`  |
 | Canonical ABI signature    | `[stream:i32 ptr:i32 num:i32] -> [i32]`                     |
 
 where `read-status` is defined in WIT as:
@@ -1686,7 +1686,7 @@ in linear memory and the size in elements of the buffer. (See
 
 | Synopsis                   |                                                             |
 | -------------------------- | ----------------------------------------------------------- |
-| Approximate WIT signature  | `func<T>(stream: stream<T>, buffer: writable-buffer<T>) -> write-status`  |
+| Approximate WIT signature  | `func<T>(stream: writable-stream<T>, buffer: writable-buffer<T>) -> write-status`  |
 | Canonical ABI signature    | `[stream:i32 ptr:i32 num:i32] -> [i32]`                     |
 
 where `write-status` is defined in WIT as:
@@ -1759,10 +1759,10 @@ in linear memory. (See
 
 | Synopsis                                            |                                            |
 | --------------------------------------------------- | ------------------------------------------ |
-| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: stream<T>) -> cancel-status`  |
-| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: stream<T>) -> cancel-status` |
-| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: future<T>) -> cancel-status`  |
-| Approximate WIT signature for `future.cancel-write` | `func<T>(out: future<T>) -> cancel-status` |
+| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: readable-stream<T>) -> cancel-status`  |
+| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: writable-stream<T>) -> cancel-status` |
+| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: readable-future<T>) -> cancel-status`  |
+| Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>) -> cancel-status` |
 | Canonical ABI signature                             | `[i32] -> [i32]`                           |
 
 ```wit
@@ -1803,10 +1803,10 @@ for details.)
 
 | Synopsis                                            |                           |
 | --------------------------------------------------- | ------------------------- |
-| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: stream<T>)`  |
-| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: stream<T>)` |
-| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: future<T>)`  |
-| Approximate WIT signature for `future.cancel-write` | `func<T>(out: future<T>)` |
+| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: readable-stream<T>)`  |
+| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: writable-stream<T>)` |
+| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: readable-future<T>)`  |
+| Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>)` |
 | Canonical ABI signature                             | `[i32] -> []`             |
 ``
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1436,7 +1436,10 @@ canon ::= ...
 
 The `resource.new` built-in creates a new
 resource (with resource type `T`) with `repr` as its
-representation and returning the `i32` index of a new handle pointing to this
+representation, and returns a new handle pointing to the new resource.
+
+In the Canonical ABI, `repr<T>` is a `u32`, and the new handle is returned
+returning the `i32` index of a new handle pointing to this
 resource.
 
 ###### `resource.drop`
@@ -1476,6 +1479,9 @@ The `resource.rep` built-in returns the
 representation of the resource (with resource type `T`) pointed to by the
 handle `t`. Validation only allows `resource.rep T` to be used within the component
 that defined `T`.
+
+In the Canonical ABI, `repr<T>` is a `u32`, and the handle argument is passed
+tshe `i32` index of the handle.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1434,16 +1434,15 @@ canon ::= ...
 | Approximate WIT signature  | `func<T>(rep: T.rep) -> T` |
 | Canonical ABI signature    | `[rep:i32] -> [i32]`       |
 
-The `resource.new` built-in creates a new
-resource (of resource type `T`) with `rep` as its
-representation, and returns a new handle pointing to the new resource.
-Validation only allows `resource.rep T` to be used within the component
-that defined `T`.
+The `resource.new` built-in creates a new resource (of resource type `T`) with
+`rep` as its representation, and returns a new handle pointing to the new
+resource. Validation only allows `resource.rep T` to be used within the
+component that defined `T`.
 
 In the Canonical ABI, `T.rep` is defined to be the `$rep` in the
 `(type $T (resource (rep $rep) ...))` type definition that defined `T`. While
-it's designed to allow different types in the future, it is currently hard-coded
-to always be `i32`.
+it's designed to allow different types in the future, it is currently
+hard-coded to always be `i32`.
 
 (See also [`canon_resource_new`] in the Canonical ABI explainer.)
 
@@ -1451,30 +1450,30 @@ to always be `i32`.
 
 When the `async` immediate is false:
 
-| Synopsis                   |                      |
-| -------------------------- | -------------------- |
-| Approximate WIT signature  | `func<T>(t: T)`      |
-| Canonical ABI signature    | `[t:i32] -> []`      |
+| Synopsis                   |                                    |
+| -------------------------- | ---------------------------------- |
+| Approximate WIT signature  | `func<T>(t: T)`                    |
+| Canonical ABI signature    | `[t:i32] -> []`                    |
 
 When the `async` immediate is true:
 
-| Synopsis                   |                                 |
-| -------------------------- | ------------------------------- |
+| Synopsis                   |                                    |
+| -------------------------- | ---------------------------------- |
 | Approximate WIT signature  | `func<T>(t: T) -> option<subtask>` |
-| Canonical ABI signature    | `[t:i32] -> [i32]`              |
+| Canonical ABI signature    | `[t:i32] -> [i32]`                 |
 
-The `resource.drop` built-in drops a resource handle `t` (with resource type `T`).
-If the dropped handle owns the resource, the resource's
-`dtor` is called, if present.
-Validation only allows `resource.rep T` to be used within the component
-that defined `T`.
+The `resource.drop` built-in drops a resource handle `t` (with resource type
+`T`). If the dropped handle owns the resource, the resource's `dtor` is called,
+if present. Validation only allows `resource.rep T` to be used within the
+component that defined `T`.
 
-When the `async` immediate is true, the returned value indicates whether
-the drop completed eagerly, or if not, identifies the in-progress drop.
+When the `async` immediate is true, the returned value indicates whether the
+drop completed eagerly, or if not, identifies the in-progress drop.
 
 In the Canonical ABI, the returned `i32` is either `0` (if the drop completed
-eagerly) or the index of the in-progress drop subtask (representing the in-progress `dtor` call).
-(See also [`canon_resource_drop`] in the Canonical ABI explainer.)
+eagerly) or the index of the in-progress drop subtask (representing the
+in-progress `dtor` call). (See also [`canon_resource_drop`] in the Canonical
+ABI explainer.)
 
 ###### `resource.rep`
 
@@ -1483,15 +1482,14 @@ eagerly) or the index of the in-progress drop subtask (representing the in-progr
 | Approximate WIT signature  | `func<T>(t: T) -> T.rep` |
 | Canonical ABI signature    | `[t:i32] -> [i32]`       |
 
-The `resource.rep` built-in returns the
-representation of the resource (with resource type `T`) pointed to by the
-handle `t`. Validation only allows `resource.rep T` to be used within the component
-that defined `T`.
+The `resource.rep` built-in returns the representation of the resource (with
+resource type `T`) pointed to by the handle `t`. Validation only allows
+`resource.rep T` to be used within the component that defined `T`.
 
 In the Canonical ABI, `T.rep` is defined to be the `$rep` in the
 `(type $T (resource (rep $rep) ...))` type definition that defined `T`. While
-it's designed to allow different types in the future, it is currently hard-coded
-to always be `i32`.
+it's designed to allow different types in the future, it is currently
+hard-coded to always be `i32`.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:
@@ -1525,8 +1523,8 @@ transferring ownership of the newly-created resource to the export's caller.
 
 ##### 🔀 Async built-ins
 
-See the [async explainer](Async.md) for high-level context and terminology
-and the [Canonical ABI explainer] for detailed runtime semantics.
+See the [async explainer](Async.md) for high-level context and terminology and
+the [Canonical ABI explainer] for detailed runtime semantics.
 
 ###### 🔀 `task.backpressure`
 
@@ -1535,11 +1533,11 @@ and the [Canonical ABI explainer] for detailed runtime semantics.
 | Approximate WIT signature  | `func(enable: bool)`  |
 | Canonical ABI signature    | `[enable:i32] -> []`  |
 
-The `task.backpressure` built-in allows the
-async-lifted callee to toggle a per-component-instance flag that, when set,
-prevents new incoming export calls to the component (until the flag is unset).
-This allows the component to exert [backpressure](Async.md#backpressure).
-(See also [`canon_task_backpressure`] in the Canonical ABI explainer.)
+The `task.backpressure` built-in allows the async-lifted callee to toggle a
+per-component-instance flag that, when set, prevents new incoming export calls
+to the component (until the flag is unset). This allows the component to exert
+[backpressure](Async.md#backpressure). (See also [`canon_task_backpressure`] in
+the Canonical ABI explainer.)
 
 ###### 🔀 `task.return`
 
@@ -1606,9 +1604,9 @@ The `task.poll` built-in returns either `none` if no event was immediately
 available, or `some` containing an event code and payload.
 
 In the Canonical ABI, the return value `is_some` holds a boolean value
-indicating whether an event was immediately available, and if so,
-the `event` value, containing the code and payloads are stored into the buffer pointed to by
-`event_addr`. (See also [`canon_task_poll`] n the Canonical ABI explainer.)
+indicating whether an event was immediately available, and if so, the `event`
+value, containing the code and payloads are stored into the buffer pointed to
+by `event_addr`. (See also [`canon_task_poll`] n the Canonical ABI explainer.)
 
 ###### 🔀 `task.yield`
 
@@ -1617,10 +1615,9 @@ the `event` value, containing the code and payloads are stored into the buffer p
 | Approximate WIT signature  | `func()`   |
 | Canonical ABI signature    | `[] -> []` |
 
-The `task.yield` built-in simply allows the runtime to
-switch to another task, allowing a long-running computation to cooperatively
-interleave with other tasks. (See also [`canon_task_yield`] in the Canonical
-ABI explainer.)
+The `task.yield` built-in simply allows the runtime to switch to another task,
+allowing a long-running computation to cooperatively interleave with other
+tasks. (See also [`canon_task_yield`] in the Canonical ABI explainer.)
 
 ###### 🔀 `subtask.drop`
 
@@ -1631,8 +1628,8 @@ ABI explainer.)
 
 The `subtask.drop` built-in removes the indicated
 [subtask](Async.md#subtask-and-supertask) from the current instance's subtask
-table, trapping if the subtask isn't done.
-(See [`canon_subtask_drop`] in the Canonical ABI explainer for details.)
+table, trapping if the subtask isn't done. (See [`canon_subtask_drop`] in the
+Canonical ABI explainer for details.)
 
 ###### 🔀 `stream.new` and `future.new`
 
@@ -1644,15 +1641,18 @@ table, trapping if the subtask isn't done.
 
 The `stream.new` and `future.new` built-ins return the
 [writable end](Async.md#streams-and-futures) of a new `stream<T>` or
-`future<T>`. (See
-[`canon_stream_new`] in the Canonical ABI explainer for details.)
+`future<T>`. (See [`canon_stream_new`] in the Canonical ABI explainer for
+details.)
 
 The types `readable-stream<T>` and `writable-stream<T>` are not WIT types; they
-are the conceptual lower-level types that describe how the canonical built-ins use
-the readable and writable ends of a `stream<T>`. `writable-stream<T>`s are obtained
-from `stream.new`.  A `readable-stream<T>` is created by calling `stream.new` to create a fresh "unpaired" `writable-stream<T>` and then lifting it as the `stream<T>` parameter of an import call
-or the `stream<T>` result of an export call.  This lifted `stream<T>` value is then lowered by the
-receiving component into a `readable-stream<T>` that is "paired" with the original `writable-stream<T>`.
+are the conceptual lower-level types that describe how the canonical built-ins
+use the readable and writable ends of a `stream<T>`. `writable-stream<T>`s are
+obtained from `stream.new`. A `readable-stream<T>` is created by calling
+`stream.new` to create a fresh "unpaired" `writable-stream<T>` and then lifting
+it as the `stream<T>` parameter of an import call or the `stream<T>` result of
+an export call. This lifted `stream<T>` value is then lowered by the receiving
+component into a `readable-stream<T>` that is "paired" with the original
+`writable-stream<T>`.
 
 An analogous relationship exists among `readable-future<T>`, `writable-future<T>`,
 and the WIT `future<T>`.
@@ -1698,20 +1698,18 @@ enum write-status {
 }
 ```
 
-The `stream.read` and `stream.write` built-ins
-take the matching [readable or writable end](Async.md#streams-and-futures)
-of a stream as the first parameter and a buffer for the `T` values to be read
-from or written to.
+The `stream.read` and `stream.write` built-ins take the matching
+[readable or writable end](Async.md#streams-and-futures) of a stream as the
+first parameter and a buffer for the `T` values to be read from or written to.
 The return value is either the number of elements (possibly zero) that have
-been eagerly read or written, a sentinel indicating
-that the operation did not complete yet (`blocked`), or a sentinel
-indicating that the stream is closed (`closed`). For reads, `closed` has an
-optional error context describing the error that caused to the
-stream to close.
+been eagerly read or written, a sentinel indicating that the operation did not
+complete yet (`blocked`), or a sentinel indicating that the stream is closed
+(`closed`). For reads, `closed` has an optional error context describing the
+error that caused to the stream to close.
 
-In the Canonical ABI, the buffer is passed as a pointer to a buffer
-in linear memory and the size in elements of the buffer. (See
-[`canon_stream_read`] in the Canonical ABI explainer for details.)
+In the Canonical ABI, the buffer is passed as a pointer to a buffer in linear
+memory and the size in elements of the buffer. (See [`canon_stream_read`] in
+the Canonical ABI explainer for details.)
 
 `read-status` and `write-status` are lowered in the Canonical ABI as:
  - The value `0xffff_ffff` represents `blocked`.
@@ -1725,31 +1723,29 @@ in linear memory and the size in elements of the buffer. (See
 
 ###### 🔀 `future.read` and `future.write`
 
-| Synopsis                                     |                                                                                     |
-| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Synopsis                                     |                                                                                   |
+| -------------------------------------------- | --------------------------------------------------------------------------------- |
 | Approximate WIT signature for `future.read`  | `func<T>(in: readable-future<T>, buffer: writable-buffer<T; 1>) -> read-status`   |
 | Approximate WIT signature for `future.write` | `func<T>(out: writable-future<T>, buffer: readable-buffer<T; 1>) -> write-status` |
-| Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                                     |
+| Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                                   |
 
 where `read-status` and `write-status` are defined as in
 [`stream.read` and `stream.write`](#-streamread-and-streamwrite).
 
-The `future.{read,write}` built-ins
-take the matching [readable or writable end](Async.md#streams-and-futures)
-of a future as the first parameter, and a buffer for a single `T` value to
-read into or write from. The return value is either `complete` if the future
-value was eagerly read or written, a sentinel indicating that the
-operation did not complete yet (`blocked`), or a sentinel indicating
-that the future is closed (`closed`).
+The `future.{read,write}` built-ins take the matching
+[readable or writable end](Async.md#streams-and-futures) of a future as the
+first parameter, and a buffer for a single `T` value to read into or write
+from. The return value is either `complete` if the future value was eagerly
+read or written, a sentinel indicating that the operation did not complete yet
+(`blocked`), or a sentinel indicating that the future is closed (`closed`).
 
 The number of elements returned when the value is `complete` is at most `1`.
 
 The `<T; 1>` in the buffer types indicates that these buffers may hold at most
 one `T` element.
 
-In the Canonical ABI, the buffer is passed as a pointer to a buffer
-in linear memory.
-(See [`canon_future_read`] in the Canonical ABI explainer for details.)
+In the Canonical ABI, the buffer is passed as a pointer to a buffer in linear
+memory. (See [`canon_future_read`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
 
@@ -1764,48 +1760,43 @@ in linear memory.
 where `read-status` and `write-status` are defined as in
 [`stream.read` and `stream.write`](#-streamread-and-streamwrite).
 
-The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
-built-ins
-take the matching [readable or writable end](Async.md#streams-and-futures)
-of a stream or future that has an outstanding `blocked` read or write. If
-cancellation finished eagerly, the return value is `complete`, and provides
-the number of elements read
-or written into the given buffer (`0` or `1` for a `future`). If cancellation
-blocks, the return value is `blocked` and the caller
-must `task.wait`. If the stream or future is closed, the return value is
-`closed`.
+The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and
+`future.cancel-write` built-ins take the matching
+[readable or writable end](Async.md#streams-and-futures) of a stream or future
+that has an outstanding `blocked` read or write. If cancellation finished
+eagerly, the return value is `complete`, and provides the number of elements
+read or written into the given buffer (`0` or `1` for a `future`). If
+cancellation blocks, the return value is `blocked` and the caller must
+`task.wait`. If the stream or future is closed, the return value is `closed`.
 
-For `futures.*`, the
-number of elements returned when the value is `complete` is at most `1`.
+For `futures.*`, the number of elements returned when the value is `complete`
+is at most `1`.
 
-In the Canonical ABI with the `callback` option, returning to the event
-loop is equivalent to a `task.wait`, and a
-`{STREAM,FUTURE}_{READ,WRITE}` event will be delivered to indicate the
-completion of the `read`
-or `write`. (See [`canon_stream_cancel_read`] in the Canonical ABI explainer
-for details.)
+In the Canonical ABI with the `callback` option, returning to the event loop is
+equivalent to a `task.wait`, and a `{STREAM,FUTURE}_{READ,WRITE}` event will be
+delivered to indicate the completion of the `read` or `write`. (See
+[`canon_stream_cancel_read`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `stream.close-readable`, `stream.close-writable`, `future.close-readable`, and `future.close-writable`
 
-| Synopsis                                              |                                   |
-| ----------------------------------------------------- | --------------------------------- |
-| Approximate WIT signature for `stream.close-readable` | `func<T>(in: readable-stream<T>)` |
+| Synopsis                                              |                                                                |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| Approximate WIT signature for `stream.close-readable` | `func<T>(in: readable-stream<T>)`                              |
 | Approximate WIT signature for `stream.close-writable` | `func<T>(out: writable-stream<T>, err: option<error-context>)` |
-| Approximate WIT signature for `future.close-readable` | `func<T>(in: readable-future<T>)` |
+| Approximate WIT signature for `future.close-readable` | `func<T>(in: readable-future<T>)`                              |
 | Approximate WIT signature for `future.close-writable` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
-| Canonical ABI signature for `*.close-readable`        | `[in:i32] -> []`                  |
-| Canonical ABI signature for `*.close-writable`        | `[out:i32 err:i32] -> []`         |
+| Canonical ABI signature for `*.close-readable`        | `[in:i32] -> []`                                               |
+| Canonical ABI signature for `*.close-writable`        | `[out:i32 err:i32] -> []`                                      |
 
-The `{stream,future}.close-{readable,writable}` built-ins
-remove the indicated [stream or future](Async.md#streams-and-futures)
-from the current component instance's [waitables](Async.md#waiting) table,
-trapping if the stream or future has a mismatched direction or type or are in
-the middle of a `read` or `write`.
+The `{stream,future}.close-{readable,writable}` built-ins remove the indicated
+[stream or future](Async.md#streams-and-futures) from the current component
+instance's [waitables](Async.md#waiting) table, trapping if the stream or
+future has a mismatched direction or type or are in the middle of a `read` or
+`write`.
 
 In the Canonical ABI, an `err` value of `0` represents `none`, and a non-zero
 value represents `some` of the index of an `error-context` in the instance's
-table.
-(See also [the `close` built-ins] in the Canonical ABI explainer.)
+table. (See also [the `close` built-ins] in the Canonical ABI explainer.)
 
 ##### 🔀 Error Context built-ins
 
@@ -1816,15 +1807,13 @@ table.
 | Approximate WIT signature        | `func(message: string) -> error-context` |
 | Canonical ABI signature          | `[ptr:i32 len:i32] -> [i32]`             |
 
-The `error-context.new` built-in
-returns a new `error-context` value.
-The given string is non-deterministically
-transformed to produce the `error-context`'s internal
-[debug message](#error-context-type).
+The `error-context.new` built-in returns a new `error-context` value. The given
+string is non-deterministically transformed to produce the `error-context`'s
+internal [debug message](#error-context-type).
 
-In the Canonical ABI, the returned value is an index into a per-component-instance
-table.
-(See also [`canon_error_context_new`] in the Canonical ABI explainer.)
+In the Canonical ABI, the returned value is an index into a
+per-component-instance table. (See also [`canon_error_context_new`] in the
+Canonical ABI explainer.)
 
 ###### `error-context.debug-message`
 
@@ -1833,15 +1822,13 @@ table.
 | Approximate WIT signature        | `func(errctx: error-context) -> string` |
 | Canonical ABI signature          | `[errctxi:i32 ptr:i32] -> []`           |
 
-The `error-context.debug-message` built-in
-returns the [debug message](#error-context-type)
-of the given `error-context`.
+The `error-context.debug-message` built-in returns the
+[debug message](#error-context-type) of the given `error-context`.
 
 In the Canonical ABI, it writes the debug message into `ptr` as an 8-byte
-(`ptr`, `length`) pair,
-according to the Canonical ABI for `string`, given the `<canonopt>*`
-immediates.
-(See also [`canon_error_context_debug_message`] in the Canonical ABI explainer.)
+(`ptr`, `length`) pair, according to the Canonical ABI for `string`, given the
+`<canonopt>*` immediates. (See also [`canon_error_context_debug_message`] in
+the Canonical ABI explainer.)
 
 ###### `error-context.drop`
 
@@ -1850,12 +1837,11 @@ immediates.
 | Approximate WIT signature        | `func(errctx: error-context)` |
 | Canonical ABI signature          | `[errctxi:i32] -> []`         |
 
-The `error-context.drop` built-in drops the
-given `error-context` value from the component instance.
+The `error-context.drop` built-in drops the given `error-context` value from
+the component instance.
 
 In the Canonical ABI, `errctxi` is an index into a per-component-instance
-table.
-(See also [`canon_error_context_drop`] in the Canonical ABI explainer.)
+table. (See also [`canon_error_context_drop`] in the Canonical ABI explainer.)
 
 ##### 🧵 Threading built-ins
 
@@ -1866,15 +1852,15 @@ Web/JS APIs.
 
 ###### 🧵 `thread.spawn`
 
-| Synopsis                   |                                                    |
-| -------------------------- | -------------------------------------------------- |
+| Synopsis                   |                                                           |
+| -------------------------- | --------------------------------------------------------- |
 | Approximate WIT signature  | `func<FuncT>(f: FuncT, c: FuncT.params[0]) -> bool`       |
 | Canonical ABI signature    | `[f:(ref null (func shared (param i32))) c:i32] -> [i32]` |
 
-The `thread.spawn` built-in
-spawns a new thread by invoking the shared function `f` while passing `c` to it,
-returning whether a thread was successfully spawned.  While it's designed to allow
-different types in the future, the type of `c` is currently hard-coded to always be `i32`.
+The `thread.spawn` built-in spawns a new thread by invoking the shared function
+`f` while passing `c` to it, returning whether a thread was successfully
+spawned. While it's designed to allow different types in the future, the type
+of `c` is currently hard-coded to always be `i32`.
 
 (See also [`canon_thread_spawn`] in the Canonical ABI explainer.)
 
@@ -1885,8 +1871,8 @@ different types in the future, the type of `c` is currently hard-coded to always
 | Approximate WIT signature  | `func() -> u32` |
 | Canonical ABI signature    | `[] -> [i32]`   |
 
-The `thread.hw_concurrency` built-in returns the
-number of threads that can be expected to execute concurrently.
+The `thread.hw_concurrency` built-in returns the number of threads that can be
+expected to execute concurrently.
 
 (See also [`canon_thread_hw_concurrency`] in the Canonical ABI explainer.)
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1671,7 +1671,7 @@ enum read-status {
    // The operation did not complete immediately, so callers must wait for
    // the operation to complete by using `task.wait` or by returning to the
    // event loop.
-   blocked(task),
+   blocked,
 
    // The end of the stream has been reached.
    closed(option<error-context>),

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1391,8 +1391,8 @@ broken using an auxiliary module performing `call_indirect`.
 In addition to the `lift` and `lower` canonical function definitions which
 adapt *existing* functions, there are also a set of canonical "built-ins" that
 define core functions out of nothing that can be imported by core modules to
-dynamically interact with Canonical ABI entities like resources (and, when
-async is added to the proposal, [tasks][Future and Stream Types] 🔀).
+dynamically interact with Canonical ABI entities like resources and
+[tasks][Future and Stream Types] 🔀.
 ```ebnf
 canon ::= ...
         | (canon resource.new <typeidx> (core func <id>?))

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1744,8 +1744,8 @@ that the future is closed (`closed`).
 
 The number of elements returned when the value is `complete` is at most `1`.
 
-The `..1` in the buffer types indicates that these buffers may hold at most
-one element.
+The `<T; 1>` in the buffer types indicates that these buffers may hold at most
+one `T` element.
 
 In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1703,7 +1703,15 @@ In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory and the size in elements of the buffer. (See
 [`canon_stream_read`] in the Canonical ABI explainer for details.)
 
-TODO: Describe how `read-status` is mapped to the `i32` return.
+`read-status` is lowered in the Canonical ABI as:
+ - The value `0xffff_ffff` represents `blocked`.
+ - Otherwise, if the bit `0x8000_0000` is set, the value represents `closed`,
+   with the bits `0x7fff_ffff` representing the index of the `error-context`
+   in the instance's `error-context` table.
+ - Otherwise, the value represents `complete` and contains the number of
+   element read.
+
+(See [`pack_async_copy_result`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `stream.write`
 
@@ -1741,7 +1749,16 @@ In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory and the size in elements of the buffer. (See
 [`canon_stream_write`] in the Canonical ABI explainer for details.)
 
-TODO: Describe how `write-status` is mapped to the `i32` return.
+`write-status` is lowered in the Canonical ABI as:
+ - The value `0xffff_ffff` represents `blocked`.
+   TODO: How is `task` encoded?
+ - Otherwise, if the bit `0x8000_0000` is set, the value represents `closed`,
+   with the bits `0x7fff_ffff` representing the index of the `error-context`
+   in the instance's `error-context` table.
+ - Otherwise, the value represents `complete` and contains the number of
+   element written.
+
+(See [`pack_async_copy_result`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `future.read` and `future.write`
 
@@ -1780,7 +1797,15 @@ In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory.
 (See [`canon_future_read`] in the Canonical ABI explainer for details.)
 
-TODO: Describe how `future-status` is mapped to the `i32` return.
+`future-status` is lowered in the Canonical ABI as:
+ - The value `0xffff_ffff` represents `blocked`.
+ - Otherwise, if the bit `0x8000_0000` is set, the value represents `closed`,
+   with the bits `0x7fff_ffff` representing the index of the `error-context`
+   in the instance's `error-context` table.
+ - Otherwise, the value represents `complete` and contains the value `1`.
+
+(See [`pack_async_copy_result`] in the Canonical ABI explainer for details.)
+
 TODO: Should `blocked` have a `task`?
 TODO: Should `closed` have an `error-context` for the `future.read` case?
 TODO: Should there be separate readable-one-buffer and writable-one-buffer types?
@@ -2763,6 +2788,7 @@ For some use-case-focused, worked examples, see:
 [`canon_error_context_drop`]: CanonicalABI.md#-canon-error-contextdrop
 [`canon_thread_spawn`]: CanonicalABI.md#-canon-theadspawn
 [`canon_thread_hw_concurrency`]: CanonicalABI.md#-canon-threadhw_concurrency
+[`pack_async_copy_result`]: CanonicalABI.md#-canon-streamfuturereadwrite
 [the `close` built-ins]: CanonicalABI.md#-canon-streamfutureclose-readablewritable
 [Shared-Nothing]: ../high-level/Choices.md
 [Use Cases]: ../high-level/UseCases.md

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1739,8 +1739,7 @@ in linear memory and the size in elements of the buffer. (See
 | Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                                     |
 
 where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`]. The number of elements
-returned when the value is `complete` is always `1`.
+and `write-status` is defined as in [`stream.write`].
 
 The `future.{read,write}` built-ins
 take the matching [readable or writable end](Async.md#streams-and-futures)
@@ -1749,6 +1748,11 @@ read into or write from. The return value is either `complete` if the future
 value was eagerly read or written, a sentinel indicating that the
 operation did not complete yet (`blocked`), or a sentinel indicating
 that the future is closed (`closed`).
+
+The number of elements returned when the value is `complete` is at most `1`.
+
+The `..1` in the buffer types indicates that these buffers may hold at most
+one element.
 
 In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1392,7 +1392,7 @@ In addition to the `lift` and `lower` canonical function definitions which
 adapt *existing* functions, there are also a set of canonical "built-ins" that
 define core functions out of nothing that can be imported by core modules to
 dynamically interact with Canonical ABI entities like resources (and, when
-async is added to the proposal, [tasks][Future and Stream Types]).
+async is added to the proposal, [tasks][Future and Stream Types] 🔀).
 ```ebnf
 canon ::= ...
         | (canon resource.new <typeidx> (core func <id>?))
@@ -1427,21 +1427,54 @@ canon ::= ...
 
 ##### Resource built-ins
 
-The `resource.new` built-in has type `[i32] -> [i32]` and creates a new
-resource (with resource type `typeidx`) with the given `i32` value as its
+###### `resource.new`
+
+| Synopsis                   |                               |
+| -------------------------- | ----------------------------- |
+| Conceptual signature       | `func<T>(repr: repr<T>) -> T` |
+| Canonical ABI signature    | `[repr:i32] -> [i32]`         |
+
+The `resource.new` built-in creates a new
+resource (with resource type `T`) with `repr` as its
 representation and returning the `i32` index of a new handle pointing to this
 resource.
 
-The `resource.drop` drops a resource handle (with resource type `typeidx`) at
-a given `i32` index. If the dropped handle owns the resource, the resource's
-`dtor` is called, if present. If `async` is not specified, the core function
-type of `resource.drop` is `[i32] -> []`. Otherwise, the core function type
-of `async` `drop` is `[i32] -> [i32]`, where the returned `i32` is either `0`
-(if the drop completed eagerly) or the index of the in-progress drop.
+###### `resource.drop`
 
-The `resource.rep` built-in has type `[i32] -> [i32]` and returns the `i32`
-representation of the resource (with resource type `typeidx`) pointed to by the
-handle at the given `i32` index.
+When the `async` immediate is false:
+
+| Synopsis                   |                      |
+| -------------------------- | -------------------- |
+| Conceptual signature       | `func<T>(t: T)`      |
+| Canonical ABI signature    | `[t:i32] -> []`      |
+
+When `async` immediate is true:
+
+| Synopsis                   |                                 |
+| -------------------------- | ------------------------------- |
+| Conceptual signature       | `func<T>(t: T) -> option<task>` |
+| Canonical ABI signature    | `[t:i32] -> [i32]`              |
+
+The `resource.drop` drops a resource handle `t` (with resource type `T`).
+If the dropped handle owns the resource, the resource's
+`dtor` is called, if present.
+
+When the `async` immediate is true, the returned value indicates whether
+the drop completed eagerly, or if not, identifies the in-progress drop.
+
+In the Canonical ABI, the returned `i32` is either `0` (if the drop completed
+eagerly) or the index of the in-progress drop.
+
+###### `resource.rep`
+
+| Synopsis                   |                            |
+| -------------------------- | -------------------------- |
+| Conceptual signature       | `func<T>(t: T) -> repr<T>` |
+| Canonical ABI signature    | `[t:i32] -> [i32]`         |
+
+The `resource.rep` built-in returns the
+representation of the resource (with resource type `T`) pointed to by the
+handle `t`.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:
@@ -1477,10 +1510,19 @@ transferring ownership of the newly-created resource to the export's caller.
 See the [async explainer](Async.md) for high-level context and terminology
 and the [Canonical ABI explainer] for detailed runtime semantics.
 
-The `task.backpressure` built-in has type `[i32] -> []` and allows the
+###### 🔀 `task.backpressure`
+
+| Synopsis                   |                       |
+| -------------------------- | --------------------- |
+| Conceptual signature       | `func(enable: bool)`  |
+| Canonical ABI signature    | `[enable:i32] -> []`  |
+
+The `task.backpressure` built-in allows the
 async-lifted callee to toggle a per-component-instance flag that, when set,
 prevents new incoming export calls to the component (until the flag is unset).
 This allows the component to exert [backpressure](Async.md#backpressure).
+
+###### 🔀 `task.return`
 
 The `task.return` built-in takes as parameters the result values of the
 currently-executing task. This built-in must be called exactly once per export
@@ -1491,79 +1533,272 @@ of a component-level function taking the result types of the current task. (See
 also [Returning](Async.md#returning) in the async explainer and
 [`canon_task_return`] in the Canonical ABI explainer.)
 
-The `task.wait` built-in has type `[i32] -> [i32]`, returning an event and
-storing the 4-byte payload of the event at the address passed as parameter.
+###### 🔀 `task.wait`
+
+| Synopsis                   |                                           |
+| -------------------------- | ----------------------------------------- |
+| Conceptual signature       | `func() -> [kind:event, payload:payload]` |
+| Canonical ABI signature    | `[payload_addr:i32] -> [kind:i32]`        |
+
+```wit
+enum event {
+  call-starting,
+  call-started,
+  call-returned,
+  call-done,
+  yielded,
+  stream-read,
+  stream-write,
+  future-read,
+  future-write,
+}
+```
+
+The `task.wait` built-in returns an event code and
+the payload of the event at the address passed as parameter.
+
+In the Canonical ABI, the returned payload is a 4-byte value and is stored
+at address `payload_addr`.
+
 `task.wait` can be called whether or not `async` was present, allowing any sort
 of code to synchronously wait for progress on any of the currently-executing
 subtasks. (See also [Waiting](Async.md#waiting) in the async explainer and
 [`canon_task_wait`] in the Canonical ABI explainer.)
 
-The `task.poll` built-in has type `[i32] -> [i32]`, returning whether or not
-an event was immediately available as a boolean and, if true, storing the
-event and its payload in the buffer pointed to by the `i32` parameter.
+###### 🔀 `task.poll`
+
+| Synopsis                   |                                                          |
+| -------------------------- | -------------------------------------------------------- |
+| Conceptual signature       | `func() -> [option<tuple<kind:event, payload:payload>>]` |
+| Canonical ABI signature    | `[tuple_addr:i32] -> [is_some:i32]`                      |
+
+The `task.poll` built-in returns either `none` if no event was immediately
+available, or `some` containing an event code and payload.
+
+In the Canonical ABI, the return value `is_some` holds a boolean value
+indicating whether an event was immediately available, and if so,
+the event code and payload are stored into the buffer pointed to by
+`tuple_addr`.
+
 (See also [`canon_task_poll`] in the Canonical ABI explainer.)
 
-The `task.yield` built-in has type `[] -> []` and simply allows the runtime to
+###### 🔀 `task.yield`
+
+| Synopsis                   |            |
+| -------------------------- | ---------- |
+| Conceptual signature       | `func()`   |
+| Canonical ABI signature    | `[] -> []` |
+
+The `task.yield` built-in simply allows the runtime to
 switch to another task, allowing a long-running computation to cooperatively
 interleave with other tasks. (See also [`canon_task_yield`] in the Canonical
 ABI explainer.)
 
-The `subtask.drop` built-in has type `[i32] -> []` and removes the indicated
+###### 🔀 `subtask.drop`
+
+| Synopsis                   |                       |
+| -------------------------- | --------------------- |
+| Conceptual signature       | `func(subtask: task)` |
+| Canonical ABI signature    | `[i32] -> []`         |
+
+The `subtask.drop` built-in removes the indicated
 [subtask](Async.md#subtask-and-supertask) from the current instance's subtask
 table, trapping if the subtask isn't done.
 
-The `{stream,future}.new` built-ins have type `[] -> [i32]` and return a new
-[writable end](Async.md#streams-and-futures) of a stream or future. (See
+###### 🔀 `stream.new` and `future.new`
+
+| Synopsis                              |                          |
+| ------------------------------------- | ------------------------ |
+| Conceptual signature for `stream.new` | `func<T>() -> stream<T>` |
+| Conceptual signature for `future.new` | `func<T>() -> future<T>` |
+| Canonical ABI signature               | `[] -> [i32]`            |
+
+The `stream.new` and `future.new` built-ins return the
+[writable end](Async.md#streams-and-futures) of a new `stream<T>` or
+`future<T>`. (See
 [`canon_stream_new`] in the Canonical ABI explainer for details.)
 
-The `stream.{read,write]` built-ins have type `[i32 i32 i32] -> [i32]` and
-take an index to the matching [readable or writable end](Async.md#streams-and-futures)
-of a stream as the first parameter, a pointer to linear memory buffer as the
-second parameter and the number of elements worth of available space in the
-buffer. The return value is either the non-zero number of elements that have
-been eagerly read or else a sentinel "`BLOCKED`" value. (See
+###### 🔀 `stream.read` and `stream.write`
+
+| Synopsis                   |                                                             |
+| -------------------------- | ----------------------------------------------------------- |
+| Conceptual signature       | `func<T>(stream: stream<T>, buffer: list-buffer<T>) -> stream-status`  |
+| Canonical ABI signature    | `[stream:i32 ptr:i32 num:i32] -> [i32]`                     |
+
+```wit
+enum stream-status {
+   // The operation completed and read or wrote this many elements.
+   // This value is always non-zero.
+   complete(u64),
+
+   // The operation did not complete immediately, so callers must wait for
+   // the operation to complete by using `task.wait` or by returning to the
+   // event loop.
+   blocked,
+
+   // The stream is closed. For reading, the end of the stream has been
+   // reached. For writing, the reader is no longer reading data.
+   closed,
+}
+```
+
+
+The `stream.{read,write]` built-ins
+take the matching [readable or writable end](Async.md#streams-and-futures)
+of a stream as the first parameter and a buffer for `T` values to read into
+or write from.
+The return value is either the non-zero number of elements that have
+been eagerly read or written, a sentinel indicating
+that the operation did not complete yet (`blocked`), or a sentinel
+indicating that the stream is closed (`closed`).
+
+In the Canonical ABI, the buffer is passed as a pointer to a buffer
+in linear memory and the size in elements of the buffer. (See
 [`canon_stream_read`] in the Canonical ABI explainer for details.)
 
-The `future.{read,write}` built-ins have type `[i32 i32] -> [i32]` and
-take an index to the matching [readable or writable end](Async.md#streams-and-futures)
-of a future as the first parameter and a pointer linear memory as the second
-parameter. The return value is either `1` if the future value was eagerly
-read from or written to the pointer or the sentinel "`BLOCKED`" value otherwise.
+###### 🔀 `future.read` and `future.write`
+
+| Synopsis                                |                                                         |
+| --------------------------------------- | ------------------------------------------------------- |
+| Conceptual signature for `future.read`  | `func<T>(in: future<T>, buffer: one-buffer<T>) -> future-status`  |
+| Conceptual signature for `future.write` | `func<T>(out: future<T>, buffer: one-buffer<T>) -> future-status` |
+| Canonical ABI signature                 | `[future:i32 ptr:i32] -> [i32]`                         |
+
+```wit
+enum future-status {
+   // The operation completed and read or wrote the value.
+   complete,
+
+   // The operation did not complete immediately, so callers must wait for
+   // the operation to complete by using `task.wait` or by returning to the
+   // event loop.
+   blocked,
+
+   // The stream is closed. For reading, the end of the stream has been
+   // reached. For writing, the reader is no longer reading data.
+   closed,
+}
+```
+
+The `future.{read,write}` built-ins
+take the matching [readable or writable end](Async.md#streams-and-futures)
+of a future as the first parameter, and a buffer for a single `T` value to
+read into or write from. The return value is either `complete` if the future
+value was eagerly read or written, a sentinel indicating that the
+operation did not complete yet (`blocked`), or a sentinel indicating
+that the future is closed (`closed`).
+
+In the Canonical ABI, the buffer is passed as a pointer to a buffer
+in linear memory. (See
 (See [`canon_future_read`] in the Canonical ABI explainer for details.)
 
-The `{stream,future}.cancel-{read,write}` built-ins have type `[i32] -> [i32]`
-and take an index to the matching [readable or writable end](Async.md#streams-and-futures)
-of a stream or future that has an outstanding "`BLOCKED`" read or write. If
-cancellation finished eagerly, the return value is the number of elements read
+###### 🔀 `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
+
+| Synopsis                                       |                                            |
+| ---------------------------------------------- | ------------------------------------------ |
+| Conceptual signature for `stream.cancel-read`  | `func<T>(in: stream<T>) -> cancel-status`  |
+| Conceptual signature for `stream.cancel-write` | `func<T>(out: stream<T>) -> cancel-status` |
+| Conceptual signature for `future.cancel-read`  | `func<T>(in: future<T>) -> cancel-status`  |
+| Conceptual signature for `future.cancel-write` | `func<T>(out: future<T>) -> cancel-status` |
+| Canonical ABI signature                        | `[i32] -> [i32]`                           |
+
+```wit
+enum cancel-status {
+   // The operation completed and read or wrote this many elements.
+   complete(u64),
+
+   // The operation did not complete immediately, so callers must wait for
+   // the operation to complete by using `task.wait` or by returning to the
+   // event loop.
+   blocked,
+
+   // The stream is closed. For reading, the end of the stream has been
+   // reached. For writing, the reader is no longer reading data.
+   closed,
+}
+```
+
+The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
+builtins
+take the matching [readable or writable end](Async.md#streams-and-futures)
+of a stream or future that has an outstanding `blocked` read or write. If
+cancellation finished eagerly, the return value is `complete`, and provides
+the number of elements read
 or written into the given buffer (`0` or `1` for a `future`). If cancellation
-blocks, the return value is the sentinel "`BLOCKED`" value and the caller must
-`task.wait` (or, if using `callback`, return to the event loop) to receive a
-`{STREAM,FUTURE}_{READ,WRITE}` event to indicate the completion of the `read`
+blocks, the return value is `blocked` and the caller
+must `task.wait`. If the stream or future is closed, the return value is
+`closed`.
+
+In the Canonical ABI with the `callback` option, returning to the event
+loop is equivalent to a `task.wait`, and a
+`{STREAM,FUTURE}_{READ,WRITE}` event will be delivered to indicate the
+completion of the `read`
 or `write`. (See [`canon_stream_cancel_read`] in the Canonical ABI explainer
 for details.)
 
-The `{stream,future}.close-{readable,writable}` built-ins have type
-`[i32] -> []` and removes the indicated [stream or future](Async.md#streams-and-futures)
+###### 🔀 `stream.close-readable`, `stream.close-writeable`, `future.close-readable`, and `future.close-writeable`
+
+| Synopsis                                       |                           |
+| ---------------------------------------------- | ------------------------- |
+| Conceptual signature for `stream.cancel-read`  | `func<T>(in: stream<T>)`  |
+| Conceptual signature for `stream.cancel-write` | `func<T>(out: stream<T>)` |
+| Conceptual signature for `future.cancel-read`  | `func<T>(in: future<T>)`  |
+| Conceptual signature for `future.cancel-write` | `func<T>(out: future<T>)` |
+| Canonical ABI signature                        | `[i32] -> []`             |
+``
+
+The `{stream,future}.close-{readable,writable}` built-ins
+remove the indicated [stream or future](Async.md#streams-and-futures)
 from the current component instance's [waitables](Async.md#waiting) table,
 trapping if the stream or future has a mismatched direction or type or are in
 the middle of a `read` or `write`.
 
 ##### 🔀 Error Context built-ins
 
-The `error-context.new` built-in has type `[ptr:i32 len:i32] -> [i32]` and
-returns the index of a new `error-context` value in a per-component-instance
-table. The given (`ptr`, `length`) pair are non-deterministically lifted and
+###### `error-context.new`
+
+| Synopsis                                       |                               |
+| ---------------------------------------------- | ----------------------------- |
+| Conceptual signature                           | `func(message: string) -> error-context` |
+| Canonical ABI signature                        | `[ptr:i32 len:i32] -> [i32]`  |
+
+The `error-context.new` built-in
+returns a new `error-context` value.
+The given string is non-deterministically
 transformed to produce the `error-context`'s internal
 [debug message](#error-context-type).
 
-The `error-context.debug-message` built-in has type
-`[errctxi:i32 ptr:i32] -> []` and writes the [debug message](#error-context-type)
-of the given `error-context` into `ptr` as an 8-byte (`ptr`, `length`) pair,
+In the Canonical ABI, the returned value is an index into a per-component-instance
+table.
+
+###### `error-context.debug-message`
+
+| Synopsis                                       |                                |
+| ---------------------------------------------- | ------------------------------ |
+| Conceptual signature                           | `func(errctx: error-context) -> string` |
+| Canonical ABI signature                        | `[errctxi:i32 ptr:i32] -> []`  |
+
+The `error-context.debug-message` built-in
+returns the [debug message](#error-context-type)
+of the given `error-context`.
+
+In the Canonical ABI, it writes the debug message into `ptr` as an 8-byte
+(`ptr`, `length`) pair,
 according to the Canonical ABI for `string`, given the `<canonopt>*`
 immediates.
 
-The `error-context.drop` built-in has type `[errctxi:i32] -> []` and drops the
-given `error-context` value from the component instance's table.
+###### `error-context.drop`
+
+| Synopsis                                       |                               |
+| ---------------------------------------------- | ----------------------------- |
+| Conceptual signature                           | `func(errctx: error-context)` |
+| Canonical ABI signature                        | `[errctxi:i32] -> []`         |
+
+The `error-context.drop` built-in d drops the
+given `error-context` value from the component instance.
+
+In the Canonical ABI, `errctxi` is an index into a per-component-instance
+table.
 
 ##### 🧵 Threading built-ins
 
@@ -1572,11 +1807,25 @@ thread management. These are specified as built-ins and not core WebAssembly
 instructions because browsers expect this functionality to come from existing
 Web/JS APIs.
 
-The `thread.spawn` built-in has type `[f:(ref null $f) c:i32] -> [i32]` and
+###### 🧵 `thread.spawn`
+
+| Synopsis                   |                                                    |
+| -------------------------- | -------------------------------------------------- |
+| Conceptual signature       | `func<FuncTy, ArgTy>(f: FuncTy, c: ArgTy) -> bool` |
+| Canonical ABI signature    | `[f:(ref null $f) c:i32] -> [i32]`                 |
+
+The `thread.spawn` built-in
 spawns a new thread by invoking the shared function `f` while passing `c` to it,
 returning whether a thread was successfully spawned.
 
-The `resource.hw_concurrency` built-in has type `[] -> [i32]` and returns the
+###### 🧵 `resource.hw_concurrency`
+
+| Synopsis                   |                 |
+| -------------------------- | --------------- |
+| Conceptual signature       | `func() -> u32` |
+| Canonical ABI signature    | `[] -> [i32]`   |
+
+The `resource.hw_concurrency` built-in returns the
 number of threads that can be expected to execute concurrently.
 
 See the [CanonicalABI.md](CanonicalABI.md#canonical-definitions) for detailed

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1537,8 +1537,8 @@ also [Returning](Async.md#returning) in the async explainer and
 
 | Synopsis                   |                                           |
 | -------------------------- | ----------------------------------------- |
-| Conceptual signature       | `func() -> [kind:event, payload:payload]` |
-| Canonical ABI signature    | `[payload_addr:i32] -> [kind:i32]`        |
+| Conceptual signature       | `func() -> record { kind: event, payload1: u32, payload2: u32 }` |
+| Canonical ABI signature    | `[payloads_addr:i32] -> [kind:i32]`        |
 
 ```wit
 enum event {
@@ -1569,7 +1569,7 @@ subtasks. (See also [Waiting](Async.md#waiting) in the async explainer and
 
 | Synopsis                   |                                                          |
 | -------------------------- | -------------------------------------------------------- |
-| Conceptual signature       | `func() -> [option<tuple<kind:event, payload:payload>>]` |
+| Conceptual signature       | `func() -> option<record { kind: event, payload1: u32, payload2:u32 }> ` |
 | Canonical ABI signature    | `[tuple_addr:i32] -> [is_some:i32]`                      |
 
 The `task.poll` built-in returns either `none` if no event was immediately

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1559,7 +1559,7 @@ also [Returning](Async.md#returning) in the async explainer and
 | Approximate WIT signature  | `func() -> event`                        |
 | Canonical ABI signature    | `[payload_addr:i32] -> [event-kind:i32]` |
 
-where `event`, `event-kind` and `payload` are defined in WIT as:
+where `event`, `event-kind`, and `payload` are defined in WIT as:
 ```wit
 record event {
     kind: event-kind,
@@ -1657,7 +1657,7 @@ receiving component into a `readable-stream<T>` that is "paired" with the origin
 An analogous relationship exists among `readable-future<T>`, `writable-future<T>`,
 and the WIT `future<T>`.
 
-###### 🔀 `stream.read`
+###### 🔀 `stream.read` and `stream.write`
 
 | Synopsis                   |                                                                                   |
 | -------------------------- | --------------------------------------------------------------------------------- |
@@ -1731,8 +1731,8 @@ in linear memory and the size in elements of the buffer. (See
 | Approximate WIT signature for `future.write` | `func<T>(out: writable-future<T>, buffer: readable-buffer<T; 1>) -> write-status` |
 | Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                                     |
 
-where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`](#-streamwrite).
+where `read-status` and `write-status` are defined as in
+[`stream.read` and `stream.write`](#-streamread-and-streamwrite).
 
 The `future.{read,write}` built-ins
 take the matching [readable or writable end](Async.md#streams-and-futures)
@@ -1761,8 +1761,8 @@ in linear memory.
 | Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>) -> write-status`  |
 | Canonical ABI signature                             | `[i32] -> [i32]`                                    |
 
-where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`](#-streamwrite).
+where `read-status` and `write-status` are defined as in
+[`stream.read` and `stream.write`](#-streamread-and-streamwrite).
 
 The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
 built-ins

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1833,6 +1833,8 @@ trapping if the stream or future has a mismatched direction or type or are in
 the middle of a `read` or `write`.
 (See also [the `close` built-ins] in the Canonical ABI explainer.)
 
+TODO: Describe how the `option<error-context>` is represented as i32 in the Canonical ABI.
+
 ##### 🔀 Error Context built-ins
 
 ###### `error-context.new`

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1799,7 +1799,7 @@ completion of the `read`
 or `write`. (See [`canon_stream_cancel_read`] in the Canonical ABI explainer
 for details.)
 
-###### 🔀 `stream.close-readable`, `stream.close-writeable`, `future.close-readable`, and `future.close-writeable`
+###### 🔀 `stream.close-readable`, `stream.close-writable`, `future.close-readable`, and `future.close-writable`
 
 | Synopsis                                            |                           |
 | --------------------------------------------------- | ------------------------- |

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1739,7 +1739,7 @@ in linear memory and the size in elements of the buffer. (See
 | Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                                     |
 
 where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`].
+and `write-status` is defined as in [`stream.write`](#-streamwrite).
 
 The `future.{read,write}` built-ins
 take the matching [readable or writable end](Async.md#streams-and-futures)
@@ -1769,7 +1769,7 @@ in linear memory.
 | Canonical ABI signature                             | `[i32] -> [i32]`                                    |
 
 where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`]. For `futures.*`, the
+and `write-status` is defined as in [`stream.write`](#-streamwrite). For `futures.*`, the
 number of elements returned when the value is `complete` is always `1`.
 
 The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1474,7 +1474,8 @@ eagerly) or the index of the in-progress drop.
 
 The `resource.rep` built-in returns the
 representation of the resource (with resource type `T`) pointed to by the
-handle `t`.
+handle `t`. Validation only allows `resource.rep T` to be used within the component
+that defined `T`.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1431,7 +1431,7 @@ canon ::= ...
 
 | Synopsis                   |                               |
 | -------------------------- | ----------------------------- |
-| Conceptual signature       | `func<T>(repr: repr<T>) -> T` |
+| Approximate WIT signature  | `func<T>(repr: repr<T>) -> T` |
 | Canonical ABI signature    | `[repr:i32] -> [i32]`         |
 
 The `resource.new` built-in creates a new
@@ -1445,14 +1445,14 @@ When the `async` immediate is false:
 
 | Synopsis                   |                      |
 | -------------------------- | -------------------- |
-| Conceptual signature       | `func<T>(t: T)`      |
+| Approximate WIT signature  | `func<T>(t: T)`      |
 | Canonical ABI signature    | `[t:i32] -> []`      |
 
 When `async` immediate is true:
 
 | Synopsis                   |                                 |
 | -------------------------- | ------------------------------- |
-| Conceptual signature       | `func<T>(t: T) -> option<task>` |
+| Approximate WIT signature  | `func<T>(t: T) -> option<task>` |
 | Canonical ABI signature    | `[t:i32] -> [i32]`              |
 
 The `resource.drop` drops a resource handle `t` (with resource type `T`).
@@ -1469,7 +1469,7 @@ eagerly) or the index of the in-progress drop.
 
 | Synopsis                   |                            |
 | -------------------------- | -------------------------- |
-| Conceptual signature       | `func<T>(t: T) -> repr<T>` |
+| Approximate WIT signature  | `func<T>(t: T) -> repr<T>` |
 | Canonical ABI signature    | `[t:i32] -> [i32]`         |
 
 The `resource.rep` built-in returns the
@@ -1515,7 +1515,7 @@ and the [Canonical ABI explainer] for detailed runtime semantics.
 
 | Synopsis                   |                       |
 | -------------------------- | --------------------- |
-| Conceptual signature       | `func(enable: bool)`  |
+| Approximate WIT signature  | `func(enable: bool)`  |
 | Canonical ABI signature    | `[enable:i32] -> []`  |
 
 The `task.backpressure` built-in allows the
@@ -1538,7 +1538,7 @@ also [Returning](Async.md#returning) in the async explainer and
 
 | Synopsis                   |                                          |
 | -------------------------- | ---------------------------------------- |
-| Conceptual signature       | `func() -> event`                        |
+| Approximate WIT signature  | `func() -> event`                        |
 | Canonical ABI signature    | `[payload_addr:i32] -> [event-kind:i32]` |
 
 where `event-kind` is defined in WIT as:
@@ -1587,7 +1587,7 @@ subtasks. (See also [Waiting](Async.md#waiting) in the async explainer and
 
 | Synopsis                   |                                     |
 | -------------------------- | ----------------------------------- |
-| Conceptual signature       | `func() -> option<event> `          |
+| Approximate WIT signature  | `func() -> option<event> `          |
 | Canonical ABI signature    | `[event_addr:i32] -> [is_some:i32]` |
 
 where `event`, `event-kind`, and `payload` are defined as in [`task.wait`].
@@ -1606,7 +1606,7 @@ the `event` value, containing the code and payloads are stored into the buffer p
 
 | Synopsis                   |            |
 | -------------------------- | ---------- |
-| Conceptual signature       | `func()`   |
+| Approximate WIT signature  | `func()`   |
 | Canonical ABI signature    | `[] -> []` |
 
 The `task.yield` built-in simply allows the runtime to
@@ -1618,7 +1618,7 @@ ABI explainer.)
 
 | Synopsis                   |                       |
 | -------------------------- | --------------------- |
-| Conceptual signature       | `func(subtask: task)` |
+| Approximate WIT signature  | `func(subtask: task)` |
 | Canonical ABI signature    | `[i32] -> []`         |
 
 The `subtask.drop` built-in removes the indicated
@@ -1627,11 +1627,11 @@ table, trapping if the subtask isn't done.
 
 ###### 🔀 `stream.new` and `future.new`
 
-| Synopsis                              |                          |
-| ------------------------------------- | ------------------------ |
-| Conceptual signature for `stream.new` | `func<T>() -> stream<T>` |
-| Conceptual signature for `future.new` | `func<T>() -> future<T>` |
-| Canonical ABI signature               | `[] -> [i32]`            |
+| Synopsis                                   |                          |
+| ------------------------------------------ | ------------------------ |
+| Approximate WIT signature for `stream.new` | `func<T>() -> stream<T>` |
+| Approximate WIT signature for `future.new` | `func<T>() -> future<T>` |
+| Canonical ABI signature                    | `[] -> [i32]`            |
 
 The `stream.new` and `future.new` built-ins return the
 [writable end](Async.md#streams-and-futures) of a new `stream<T>` or
@@ -1642,7 +1642,7 @@ The `stream.new` and `future.new` built-ins return the
 
 | Synopsis                   |                                                             |
 | -------------------------- | ----------------------------------------------------------- |
-| Conceptual signature       | `func<T>(stream: stream<T>, buffer: list-buffer<T>) -> stream-status`  |
+| Approximate WIT signature  | `func<T>(stream: stream<T>, buffer: list-buffer<T>) -> stream-status`  |
 | Canonical ABI signature    | `[stream:i32 ptr:i32 num:i32] -> [i32]`                     |
 
 where `stream-status` is defined in WIT as:
@@ -1678,11 +1678,11 @@ in linear memory and the size in elements of the buffer. (See
 
 ###### 🔀 `future.read` and `future.write`
 
-| Synopsis                                |                                                         |
-| --------------------------------------- | ------------------------------------------------------- |
-| Conceptual signature for `future.read`  | `func<T>(in: future<T>, buffer: one-buffer<T>) -> future-status`  |
-| Conceptual signature for `future.write` | `func<T>(out: future<T>, buffer: one-buffer<T>) -> future-status` |
-| Canonical ABI signature                 | `[future:i32 ptr:i32] -> [i32]`                         |
+| Synopsis                                     |                                                                   |
+| -------------------------------------------- | ----------------------------------------------------------------- |
+| Approximate WIT signature for `future.read`  | `func<T>(in: future<T>, buffer: one-buffer<T>) -> future-status`  |
+| Approximate WIT signature for `future.write` | `func<T>(out: future<T>, buffer: one-buffer<T>) -> future-status` |
+| Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                   |
 
 ```wit
 enum future-status {
@@ -1714,13 +1714,13 @@ in linear memory. (See
 
 ###### 🔀 `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
 
-| Synopsis                                       |                                            |
-| ---------------------------------------------- | ------------------------------------------ |
-| Conceptual signature for `stream.cancel-read`  | `func<T>(in: stream<T>) -> cancel-status`  |
-| Conceptual signature for `stream.cancel-write` | `func<T>(out: stream<T>) -> cancel-status` |
-| Conceptual signature for `future.cancel-read`  | `func<T>(in: future<T>) -> cancel-status`  |
-| Conceptual signature for `future.cancel-write` | `func<T>(out: future<T>) -> cancel-status` |
-| Canonical ABI signature                        | `[i32] -> [i32]`                           |
+| Synopsis                                            |                                            |
+| --------------------------------------------------- | ------------------------------------------ |
+| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: stream<T>) -> cancel-status`  |
+| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: stream<T>) -> cancel-status` |
+| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: future<T>) -> cancel-status`  |
+| Approximate WIT signature for `future.cancel-write` | `func<T>(out: future<T>) -> cancel-status` |
+| Canonical ABI signature                             | `[i32] -> [i32]`                           |
 
 ```wit
 enum cancel-status {
@@ -1758,13 +1758,13 @@ for details.)
 
 ###### 🔀 `stream.close-readable`, `stream.close-writeable`, `future.close-readable`, and `future.close-writeable`
 
-| Synopsis                                       |                           |
-| ---------------------------------------------- | ------------------------- |
-| Conceptual signature for `stream.cancel-read`  | `func<T>(in: stream<T>)`  |
-| Conceptual signature for `stream.cancel-write` | `func<T>(out: stream<T>)` |
-| Conceptual signature for `future.cancel-read`  | `func<T>(in: future<T>)`  |
-| Conceptual signature for `future.cancel-write` | `func<T>(out: future<T>)` |
-| Canonical ABI signature                        | `[i32] -> []`             |
+| Synopsis                                            |                           |
+| --------------------------------------------------- | ------------------------- |
+| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: stream<T>)`  |
+| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: stream<T>)` |
+| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: future<T>)`  |
+| Approximate WIT signature for `future.cancel-write` | `func<T>(out: future<T>)` |
+| Canonical ABI signature                             | `[i32] -> []`             |
 ``
 
 The `{stream,future}.close-{readable,writable}` built-ins
@@ -1779,7 +1779,7 @@ the middle of a `read` or `write`.
 
 | Synopsis                                       |                               |
 | ---------------------------------------------- | ----------------------------- |
-| Conceptual signature                           | `func(message: string) -> error-context` |
+| Approximate WIT signature                      | `func(message: string) -> error-context` |
 | Canonical ABI signature                        | `[ptr:i32 len:i32] -> [i32]`  |
 
 The `error-context.new` built-in
@@ -1795,7 +1795,7 @@ table.
 
 | Synopsis                                       |                                |
 | ---------------------------------------------- | ------------------------------ |
-| Conceptual signature                           | `func(errctx: error-context) -> string` |
+| Approximate WIT signature                      | `func(errctx: error-context) -> string` |
 | Canonical ABI signature                        | `[errctxi:i32 ptr:i32] -> []`  |
 
 The `error-context.debug-message` built-in
@@ -1811,7 +1811,7 @@ immediates.
 
 | Synopsis                                       |                               |
 | ---------------------------------------------- | ----------------------------- |
-| Conceptual signature                           | `func(errctx: error-context)` |
+| Approximate WIT signature                      | `func(errctx: error-context)` |
 | Canonical ABI signature                        | `[errctxi:i32] -> []`         |
 
 The `error-context.drop` built-in d drops the
@@ -1831,7 +1831,7 @@ Web/JS APIs.
 
 | Synopsis                   |                                                    |
 | -------------------------- | -------------------------------------------------- |
-| Conceptual signature       | `func<FuncTy, ArgTy>(f: FuncTy, c: ArgTy) -> bool` |
+| Approximate WIT signature  | `func<FuncTy, ArgTy>(f: FuncTy, c: ArgTy) -> bool` |
 | Canonical ABI signature    | `[f:(ref null $f) c:i32] -> [i32]`                 |
 
 The `thread.spawn` built-in
@@ -1842,7 +1842,7 @@ returning whether a thread was successfully spawned.
 
 | Synopsis                   |                 |
 | -------------------------- | --------------- |
-| Conceptual signature       | `func() -> u32` |
+| Approximate WIT signature  | `func() -> u32` |
 | Canonical ABI signature    | `[] -> [i32]`   |
 
 The `resource.hw_concurrency` built-in returns the

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1776,7 +1776,7 @@ must `task.wait`. If the stream or future is closed, the return value is
 `closed`.
 
 For `futures.*`, the
-number of elements returned when the value is `complete` is always `1`.
+number of elements returned when the value is `complete` is at most `1`.
 
 In the Canonical ABI with the `callback` option, returning to the event
 loop is equivalent to a `task.wait`, and a

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1769,7 +1769,7 @@ read or written into the given buffer (`0` or `1` for a `future`). If
 cancellation blocks, the return value is `blocked` and the caller must
 `task.wait`. If the stream or future is closed, the return value is `closed`.
 
-For `futures.*`, the number of elements returned when the value is `complete`
+For `future.*`, the number of elements returned when the value is `complete`
 is at most `1`.
 
 In the Canonical ABI with the `callback` option, returning to the event loop is

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1681,6 +1681,8 @@ In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory and the size in elements of the buffer. (See
 [`canon_stream_read`] in the Canonical ABI explainer for details.)
 
+TODO: Describe how `read-status` is mapped to the `i32` return.
+
 ###### 🔀 `stream.write`
 
 | Synopsis                   |                                                             |
@@ -1716,6 +1718,8 @@ indicating that the stream is closed (`closed`).
 In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory and the size in elements of the buffer. (See
 [`canon_stream_write`] in the Canonical ABI explainer for details.)
+
+TODO: Describe how `write-status` is mapped to the `i32` return.
 
 ###### 🔀 `future.read` and `future.write`
 
@@ -1753,6 +1757,11 @@ that the future is closed (`closed`).
 In the Canonical ABI, the buffer is passed as a pointer to a buffer
 in linear memory. (See
 (See [`canon_future_read`] in the Canonical ABI explainer for details.)
+
+TODO: Describe how `future-status` is mapped to the `i32` return.
+TODO: Should `blocked` have a `task`?
+TODO: Should `closed` have an `error-context` for the `future.read` case?
+TODO: Should there be separate readable-one-buffer and writable-one-buffer types?
 
 ###### 🔀 `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
 
@@ -1798,6 +1807,10 @@ loop is equivalent to a `task.wait`, and a
 completion of the `read`
 or `write`. (See [`canon_stream_cancel_read`] in the Canonical ABI explainer
 for details.)
+
+TODO: Describe how `cancel-status` is mapped to the `i32` return.
+TODO: Should `blocked` have a `task`?
+TODO: Should `closed` have an `error-context` for the `future.cancel-read` and `stream.cancel-read` cases?
 
 ###### 🔀 `stream.close-readable`, `stream.close-writable`, `future.close-readable`, and `future.close-writable`
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1817,14 +1817,14 @@ TODO: Should `closed` have an `error-context` for the `future.cancel-read` and `
 
 ###### 🔀 `stream.close-readable`, `stream.close-writable`, `future.close-readable`, and `future.close-writable`
 
-| Synopsis                                            |                                    |
-| --------------------------------------------------- | ---------------------------------- |
-| Approximate WIT signature for `stream.close-read`  | `func<T>(in: readable-stream<T>)`  |
+| Synopsis                                           |                                   |
+| -------------------------------------------------- | --------------------------------- |
+| Approximate WIT signature for `stream.close-read`  | `func<T>(in: readable-stream<T>)` |
 | Approximate WIT signature for `stream.close-write` | `func<T>(out: writable-stream<T>, err: option<error-context>)` |
-| Approximate WIT signature for `future.close-read`  | `func<T>(in: readable-future<T>)`  |
+| Approximate WIT signature for `future.close-read`  | `func<T>(in: readable-future<T>)` |
 | Approximate WIT signature for `future.close-write` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
-| Canonical ABI signature for `*.close-read`          | `[i32] -> []`                     |
-| Canonical ABI signature for `*.close-write`         | `[i32, i32] -> []`                |
+| Canonical ABI signature for `*.close-read`         | `[i32] -> []`                     |
+| Canonical ABI signature for `*.close-write`        | `[i32, i32] -> []`                |
 
 The `{stream,future}.close-{readable,writable}` built-ins
 remove the indicated [stream or future](Async.md#streams-and-futures)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1435,7 +1435,7 @@ canon ::= ...
 | Canonical ABI signature    | `[rep:i32] -> [i32]`       |
 
 The `resource.new` built-in creates a new
-resource (with resource type `T`) with `rep` as its
+resource (of resource type `T`) with `rep` as its
 representation, and returns a new handle pointing to the new resource.
 Validation only allows `resource.rep T` to be used within the component
 that defined `T`.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1666,7 +1666,7 @@ where `read-status` is defined in WIT as:
 ```wit
 enum read-status {
    // The operation completed and read this many elements.
-   complete(u64),
+   complete(u32),
 
    // The operation did not complete immediately, so callers must wait for
    // the operation to complete by using `task.wait` or by returning to the
@@ -1706,7 +1706,7 @@ where `write-status` is defined in WIT as:
 ```wit
 enum write-status {
    // The operation completed and wrote this many elements.
-   complete(u64),
+   complete(u32),
 
    // The operation did not complete immediately, so callers must wait for
    // the operation to complete by using `task.wait` or by returning to the
@@ -1789,7 +1789,7 @@ where `cancel-status` is defined in WIT as:
 ```wit
 enum cancel-status {
    // The operation completed and read or wrote this many elements.
-   complete(u64),
+   complete(u32),
 
    // The operation did not complete immediately, so callers must wait for
    // the operation to complete by using `task.wait` or by returning to the

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1823,7 +1823,8 @@ TODO: Should `closed` have an `error-context` for the `future.cancel-read` and `
 | Approximate WIT signature for `stream.close-write` | `func<T>(out: writable-stream<T>, err: option<error-context>)` |
 | Approximate WIT signature for `future.close-read`  | `func<T>(in: readable-future<T>)`  |
 | Approximate WIT signature for `future.close-write` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
-| Canonical ABI signature                             | `[i32] -> []`                      |
+| Canonical ABI signature for `*.close-read`          | `[i32] -> []`                     |
+| Canonical ABI signature for `*.close-write`         | `[i32, i32] -> []`                |
 
 The `{stream,future}.close-{readable,writable}` built-ins
 remove the indicated [stream or future](Async.md#streams-and-futures)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1819,10 +1819,10 @@ TODO: Should `closed` have an `error-context` for the `future.cancel-read` and `
 
 | Synopsis                                            |                                    |
 | --------------------------------------------------- | ---------------------------------- |
-| Approximate WIT signature for `stream.cancel-read`  | `func<T>(in: readable-stream<T>)`  |
-| Approximate WIT signature for `stream.cancel-write` | `func<T>(out: writable-stream<T>)` |
-| Approximate WIT signature for `future.cancel-read`  | `func<T>(in: readable-future<T>)`  |
-| Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>)` |
+| Approximate WIT signature for `stream.close-read`  | `func<T>(in: readable-stream<T>)`  |
+| Approximate WIT signature for `stream.close-write` | `func<T>(out: writable-stream<T>, err: option<error-context>)` |
+| Approximate WIT signature for `future.close-read`  | `func<T>(in: readable-future<T>)`  |
+| Approximate WIT signature for `future.close-write` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
 | Canonical ABI signature                             | `[i32] -> []`                      |
 
 The `{stream,future}.close-{readable,writable}` built-ins

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1680,7 +1680,8 @@ enum read-status {
 
 The `stream.read` built-in
 takes the matching [readable end](Async.md#streams-and-futures)
-of a stream as the first parameter and a buffer for `T` values to read into.
+of a stream as the first parameter and a buffer for the `T` values read from
+the stream to be written into.
 The return value is either the number of elements (possibly zero) that have
 been eagerly read, a sentinel indicating
 that the operation did not complete yet (`blocked`), or a sentinel

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1632,10 +1632,10 @@ ABI explainer.)
 
 ###### 🔀 `subtask.drop`
 
-| Synopsis                   |                       |
-| -------------------------- | --------------------- |
+| Synopsis                   |                          |
+| -------------------------- | ------------------------ |
 | Approximate WIT signature  | `func(subtask: subtask)` |
-| Canonical ABI signature    | `[i32] -> []`         |
+| Canonical ABI signature    | `[subtask:i32] -> []`    |
 
 The `subtask.drop` built-in removes the indicated
 [subtask](Async.md#subtask-and-supertask) from the current instance's subtask
@@ -1662,7 +1662,7 @@ from `stream.new` and from lowering a `stream<T>` in a function return type, and
 `readable-stream<T>`s are obtained from lowering a `stream<T>` in a function
 parameter type.
 
-The same relationship exists among `readable-future<T>`, `writable-future<T>`,
+An analogous relationship exists among `readable-future<T>`, `writable-future<T>`,
 and the WIT `future<T>`.
 
 ###### 🔀 `stream.read`
@@ -1724,7 +1724,7 @@ in linear memory and the size in elements of the buffer. (See
 `read-status` and `write-status` are lowered in the Canonical ABI as:
  - The value `0xffff_ffff` represents `blocked`.
  - Otherwise, if the bit `0x8000_0000` is set, the value represents `closed`.
-   For `read-status`, the bits `0x7fff_ffff` contain the index of an
+   For `read-status`, the remaining bits `0x7fff_ffff` contain the index of an
    `error-context` in the instance's `error-context` table.
  - Otherwise, the value represents `complete` and contains the number of
    element read or written.
@@ -1802,7 +1802,7 @@ for details.)
 | Approximate WIT signature for `future.close-readable` | `func<T>(in: readable-future<T>)` |
 | Approximate WIT signature for `future.close-writable` | `func<T>(out: writable-future<T>, err: option<error-context>)` |
 | Canonical ABI signature for `*.close-readable`        | `[in:i32] -> []`                  |
-| Canonical ABI signature for `*.close-writable`        | `[out:i32, err:i32] -> []`        |
+| Canonical ABI signature for `*.close-writable`        | `[out:i32 err:i32] -> []`         |
 
 The `{stream,future}.close-{readable,writable}` built-ins
 remove the indicated [stream or future](Async.md#streams-and-futures)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1540,6 +1540,7 @@ also [Returning](Async.md#returning) in the async explainer and
 | Conceptual signature       | `func() -> record { kind: event, payload1: u32, payload2: u32 }` |
 | Canonical ABI signature    | `[payloads_addr:i32] -> [kind:i32]`        |
 
+where `event` is defined in WIT as:
 ```wit
 enum event {
   call-starting,
@@ -1625,6 +1626,7 @@ The `stream.new` and `future.new` built-ins return the
 | Conceptual signature       | `func<T>(stream: stream<T>, buffer: list-buffer<T>) -> stream-status`  |
 | Canonical ABI signature    | `[stream:i32 ptr:i32 num:i32] -> [i32]`                     |
 
+where `stream-status` is defined in WIT as:
 ```wit
 enum stream-status {
    // The operation completed and read or wrote this many elements.

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1631,7 +1631,6 @@ where `stream-status` is defined in WIT as:
 ```wit
 enum stream-status {
    // The operation completed and read or wrote this many elements.
-   // This value is always non-zero.
    complete(u64),
 
    // The operation did not complete immediately, so callers must wait for

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1429,18 +1429,20 @@ canon ::= ...
 
 ###### `resource.new`
 
-| Synopsis                   |                               |
-| -------------------------- | ----------------------------- |
-| Approximate WIT signature  | `func<T>(repr: repr<T>) -> T` |
-| Canonical ABI signature    | `[repr:i32] -> [i32]`         |
+| Synopsis                   |                            |
+| -------------------------- | -------------------------- |
+| Approximate WIT signature  | `func<T>(rep: T.rep) -> T` |
+| Canonical ABI signature    | `[rep:i32] -> [i32]`       |
 
 The `resource.new` built-in creates a new
-resource (with resource type `T`) with `repr` as its
+resource (with resource type `T`) with `rep` as its
 representation, and returns a new handle pointing to the new resource.
 
-In the Canonical ABI, `repr<T>` is a `u32`, and the new handle is returned
-returning the `i32` index of a new handle pointing to this
-resource.
+In the Canonical ABI, `T.rep` is defined to be the `$rep` in the
+`(type $T (resource (rep $rep) ...))` type definition that defined `T`. While
+it's designed to allow different types in the future, it is currently hard-coded
+to always be `i32`.
+
 (See also [`canon_resource_new`] in the Canonical ABI explainer.)
 
 ###### `resource.drop`
@@ -1472,18 +1474,20 @@ eagerly) or the index of the in-progress drop task.
 
 ###### `resource.rep`
 
-| Synopsis                   |                            |
-| -------------------------- | -------------------------- |
-| Approximate WIT signature  | `func<T>(t: T) -> repr<T>` |
-| Canonical ABI signature    | `[t:i32] -> [i32]`         |
+| Synopsis                   |                          |
+| -------------------------- | ------------------------ |
+| Approximate WIT signature  | `func<T>(t: T) -> T.rep` |
+| Canonical ABI signature    | `[t:i32] -> [i32]`       |
 
 The `resource.rep` built-in returns the
 representation of the resource (with resource type `T`) pointed to by the
 handle `t`. Validation only allows `resource.rep T` to be used within the component
 that defined `T`.
 
-In the Canonical ABI, `repr<T>` is a `u32`, and the handle argument is passed
-as the `i32` index of the handle.
+In the Canonical ABI, `T.rep` is defined to be the `$rep` in the
+`(type $T (resource (rep $rep) ...))` type definition that defined `T`. While
+it's designed to allow different types in the future, it is currently hard-coded
+to always be `i32`.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1481,7 +1481,7 @@ handle `t`. Validation only allows `resource.rep T` to be used within the compon
 that defined `T`.
 
 In the Canonical ABI, `repr<T>` is a `u32`, and the handle argument is passed
-tshe `i32` index of the handle.
+as the `i32` index of the handle.
 
 As an example, the following component imports the `resource.new` built-in,
 allowing it to create and return new resources to its client:
@@ -1667,7 +1667,6 @@ enum read-status {
 }
 ```
 
-
 The `stream.read` built-in
 takes the matching [readable end](Async.md#streams-and-futures)
 of a stream as the first parameter and a buffer for `T` values to read into.
@@ -1705,7 +1704,6 @@ enum write-status {
 }
 ```
 
-
 The `stream.write` built-in
 takes the matching [writable end](Async.md#streams-and-futures)
 of a stream as the first parameter and a buffer for `T` values to
@@ -1727,6 +1725,7 @@ in linear memory and the size in elements of the buffer. (See
 | Approximate WIT signature for `future.write` | `func<T>(out: future<T>, buffer: one-buffer<T>) -> future-status` |
 | Canonical ABI signature                      | `[future:i32 ptr:i32] -> [i32]`                                   |
 
+where `future-status` is defined in WIT as:
 ```wit
 enum future-status {
    // The operation completed and read or wrote the value.
@@ -1765,6 +1764,7 @@ in linear memory. (See
 | Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>) -> cancel-status` |
 | Canonical ABI signature                             | `[i32] -> [i32]`                           |
 
+where `cancel-status` is defined in WIT as:
 ```wit
 enum cancel-status {
    // The operation completed and read or wrote this many elements.
@@ -1808,7 +1808,6 @@ for details.)
 | Approximate WIT signature for `future.cancel-read`  | `func<T>(in: readable-future<T>)`  |
 | Approximate WIT signature for `future.cancel-write` | `func<T>(out: writable-future<T>)` |
 | Canonical ABI signature                             | `[i32] -> []`             |
-``
 
 The `{stream,future}.close-{readable,writable}` built-ins
 remove the indicated [stream or future](Async.md#streams-and-futures)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1720,8 +1720,8 @@ enum write-status {
 
 The `stream.write` built-in
 takes the matching [writable end](Async.md#streams-and-futures)
-of a stream as the first parameter and a buffer for `T` values to
-write from.
+of a stream as the first parameter and a buffer from which the `T` values are
+to be read by the readable end of the stream.
 The return value is either the number of elements (possibly zero) that have
 been eagerly written, a sentinel indicating
 that the operation did not complete yet (`blocked`), or a sentinel

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1559,34 +1559,34 @@ also [Returning](Async.md#returning) in the async explainer and
 | Approximate WIT signature  | `func() -> event`                        |
 | Canonical ABI signature    | `[payload_addr:i32] -> [event-kind:i32]` |
 
-where `event-kind` is defined in WIT as:
-```wit
-enum event-kind {
-  call-starting,
-  call-started,
-  call-returned,
-  call-done,
-  yielded,
-  stream-read,
-  stream-write,
-  future-read,
-  future-write,
-}
-```
-
-`payload` is defined in WIT as:
-```wit
-record payload {
-    payload1: u32,
-    payload2: u32,
-}
-```
-
-and `event` is defined in WIT as:
+where `event` is defined in WIT as:
 ```wit
 record event {
     kind: event-kind,
     payload: payload,
+}
+```
+
+`event-kind` is defined in WIT as:
+```wit
+enum event-kind {
+    call-starting,
+    call-started,
+    call-returned,
+    call-done,
+    yielded,
+    stream-read,
+    stream-write,
+    future-read,
+    future-write,
+}
+```
+
+and `payload` is defined in WIT as:
+```wit
+record payload {
+    payload1: u32,
+    payload2: u32,
 }
 ```
 
@@ -1676,32 +1676,33 @@ and the WIT `future<T>`.
 where `read-status` is defined in WIT as:
 ```wit
 enum read-status {
-   // The operation completed and read this many elements.
-   complete(u32),
+    // The operation completed and read this many elements.
+    complete(u32),
 
-   // The operation did not complete immediately, so callers must wait for
-   // the operation to complete by using `task.wait` or by returning to the
-   // event loop.
-   blocked,
+    // The operation did not complete immediately, so callers must wait for
+    // the operation to complete by using `task.wait` or by returning to the
+    // event loop.
+    blocked,
 
-   // The end of the stream has been reached.
-   closed(option<error-context>),
+    // The end of the stream has been reached.
+    closed(option<error-context>),
 }
 ```
 
-and `write-status` is defined in WIT as:
+and `write-status` is the same as `read-status` except without the optional
+error on `closed`, so it is defined in WIT as:
 ```wit
 enum write-status {
-   // The operation completed and wrote this many elements.
-   complete(u32),
+    // The operation completed and wrote this many elements.
+    complete(u32),
 
-   // The operation did not complete immediately, so callers must wait for
-   // the operation to complete by using `task.wait` or by returning to the
-   // event loop.
-   blocked,
+    // The operation did not complete immediately, so callers must wait for
+    // the operation to complete by using `task.wait` or by returning to the
+    // event loop.
+    blocked,
 
-   // The reader is no longer reading data.
-   closed,
+    // The reader is no longer reading data.
+    closed,
 }
 ```
 
@@ -1730,7 +1731,7 @@ in linear memory and the size in elements of the buffer. (See
 
 (See [`pack_async_copy_result`] in the Canonical ABI explainer for details.)
 
-###### 🔀 `future.read`
+###### 🔀 `future.read` and `future.write`
 
 | Synopsis                                     |                                                                                     |
 | -------------------------------------------- | ----------------------------------------------------------------------------------- |
@@ -1769,8 +1770,7 @@ in linear memory.
 | Canonical ABI signature                             | `[i32] -> [i32]`                                    |
 
 where `read-status` is defined as in [`stream.read`](#-streamread)
-and `write-status` is defined as in [`stream.write`](#-streamwrite). For `futures.*`, the
-number of elements returned when the value is `complete` is always `1`.
+and `write-status` is defined as in [`stream.write`](#-streamwrite).
 
 The `stream.cancel-read`, `stream.cancel-write`, `future.cancel-read`, and `future.cancel-write`
 built-ins
@@ -1782,6 +1782,9 @@ or written into the given buffer (`0` or `1` for a `future`). If cancellation
 blocks, the return value is `blocked` and the caller
 must `task.wait`. If the stream or future is closed, the return value is
 `closed`.
+
+For `futures.*`, the
+number of elements returned when the value is `complete` is always `1`.
 
 In the Canonical ABI with the `callback` option, returning to the event
 loop is equivalent to a `task.wait`, and a


### PR DESCRIPTION
This moves the signatures for the canonical builtins out of prose paragraphs and into tables, which highlights them and simplifies the prose.

This also adds "conceptual signatures". The canonical ABI signatures are useful when one is writing compilers or bindings generators or other tools, while the conceptual signatures are useful for people seeking to understand what these builtins do at a conceptual level, before thinking about how all the various values are lowered into `i32`s.

And, this PR introduces greater separation between the logical builtins and the way they appear in the canonical ABI, with the conceptual signatures, and with prose that puts canonical ABI details in their own paragraphs. In theory, this should make it easier to reuse the logical builtins when adding new ABIs.

This is a follow-up to WebAssembly/component-model#407; I've re-added the `canon` ebpf for now, removed the "Binary encoding immediates" table rows, and tidied up the signatures to avoid using `...`.