### PR TITLE
Tidy up whitespace in Binary.md.

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -25,7 +25,7 @@ magic     ::= 0x00 0x61 0x73 0x6D
 version   ::= 0x0d 0x00
 layer     ::= 0x01 0x00
 section   ::=    section_0(<core:custom>)         => ϵ
-            | m:section_1(<core:module>)          => [core-prefix(m)]
+            | m: section_1(<core:module>)         => [core-prefix(m)]
             | i*:section_2(vec(<core:instance>))  => core-prefix(i)*
             | t*:section_3(vec(<core:type>))      => core-prefix(t)*
             | c: section_4(<component>)           => [c]


### PR DESCRIPTION
Make a small whitespace change in Binary.md to make `section_1` consistent with the other sections, and to vertically align it when displayed in a fixed-width font.