### PR TITLE
Rename `hw_concurrency` to `available_parallelism`.

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -287,7 +287,7 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x07 rt:<typdidx>                                   => (canon resource.drop rt async (core func))
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
            | 0x05 ft:<typeidx>                                   => (canon thread.spawn ft (core func)) 🧵
-           | 0x06                                                => (canon thread.hw_concurrency (core func)) 🧵
+           | 0x06                                                => (canon thread.available_concurrency (core func)) 🧵
            | 0x08                                                => (canon task.backpressure (core func)) 🔀
            | 0x09 ft:<core:typeidx>                              => (canon task.return ft (core func)) 🔀
            | 0x0a async?:<async>? m:<core:memdix>                => (canon task.wait async? (memory m) (core func)) 🔀

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3418,22 +3418,22 @@ def canon_thread_spawn(f, c):
     return [-1]
 ```
 
-### 🧵 `canon thread.hw_concurrency`
+### 🧵 `canon thread.available_parallelism`
 
 For a canonical definition:
 ```wasm
-(canon thread.hw_concurrency (core func $f))
+(canon thread.available_parallelism (core func $f))
 ```
 validation specifies:
 * `$f` is given type `(func shared (result i32))`.
 
 Calling `$f` returns the number of threads the underlying hardware can be
-expected to execute concurrently. This value can be artificially limited by
+expected to execute in parallel. This value can be artificially limited by
 engine configuration and is not allowed to change over the lifetime of a
 component instance.
 
 ```python
-def canon_thread_hw_concurrency():
+def canon_thread_available_parallelism():
   if DETERMINISTIC_PROFILE:
     return [1]
   else:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1422,7 +1422,7 @@ canon ::= ...
         | (canon error-context.debug-message <canonopt>* (core func <id>?))
         | (canon error-context.drop (core func <id>?))
         | (canon thread.spawn <typeidx> (core func <id>?)) 🧵
-        | (canon thread.hw_concurrency (core func <id>?)) 🧵
+        | (canon thread.available_parallelism (core func <id>?)) 🧵
 ```
 
 ##### Resource built-ins
@@ -1864,17 +1864,21 @@ of `c` is currently hard-coded to always be `i32`.
 
 (See also [`canon_thread_spawn`] in the Canonical ABI explainer.)
 
-###### 🧵 `thread.hw_concurrency`
+###### 🧵 `thread.available_parallelism`
 
 | Synopsis                   |                 |
 | -------------------------- | --------------- |
 | Approximate WIT signature  | `func() -> u32` |
 | Canonical ABI signature    | `[] -> [i32]`   |
 
-The `thread.hw_concurrency` built-in returns the number of threads that can be
-expected to execute concurrently.
+The `thread.available_parallelism` built-in returns the number of threads that can be
+expected to execute in parallel.
 
-(See also [`canon_thread_hw_concurrency`] in the Canonical ABI explainer.)
+The concept of "available parallelism" corresponds is sometimes referred to
+as "hardware concurrency", such as in [`navigator.hardwareConcurrency`] in
+JavaScript.
+
+(See also [`canon_thread_available_parallelism`] in the Canonical ABI explainer.)
 
 ### 🪙 Value Definitions
 
@@ -2702,7 +2706,7 @@ For some use-case-focused, worked examples, see:
 [`canon_error_context_debug_message`]: CanonicalABI.md#-canon-error-contextdebug-message
 [`canon_error_context_drop`]: CanonicalABI.md#-canon-error-contextdrop
 [`canon_thread_spawn`]: CanonicalABI.md#-canon-theadspawn
-[`canon_thread_hw_concurrency`]: CanonicalABI.md#-canon-threadhw_concurrency
+[`canon_thread_available_parallelism`]: CanonicalABI.md#-canon-threadavailable_parallelism
 [`pack_async_copy_result`]: CanonicalABI.md#-canon-streamfuturereadwrite
 [the `close` built-ins]: CanonicalABI.md#-canon-streamfutureclose-readablewritable
 [Shared-Nothing]: ../high-level/Choices.md
@@ -2717,3 +2721,5 @@ For some use-case-focused, worked examples, see:
 
 [Scoping and Layering]: https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8
 [Future and Stream Types]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE
+
+[`navigator.hardwareConcurrency`]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency


### PR DESCRIPTION
Following the general computer-science meanings of the terms "concurrency" and "parallelism", rename `thread.hw_concurrency` to `thread.available_parallelism`, because it's about the number of threads that can execute in parallel.

This differs from the existing JS API of [`navigator.hardwareConcurrency`], so add a note mentioning the correspondence.

[`navigator.hardwareConcurrency`]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency