### PR TITLE
Remove an unneeded `None` check.

### DIFF
--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -808,8 +808,6 @@ def contains_async_value(t):
 def contains(t, p):
   t = despecialize(t)
   match t:
-    case None:
-      return False
     case PrimValType() | OwnType() | BorrowType():
       return p(t)
     case ListType(u) | StreamType(u) | FutureType(u):


### PR DESCRIPTION
`despecialize` doesn't return an optional type, so there's no need to check it for `None`.