### PR TITLE
Remove `TypeType` and `ValueType`.

### DIFF
--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -99,20 +99,6 @@ class FuncType(ExternType):
     return [t for name,t in vec]
 
 @dataclass
-class ValueType(ExternType):
-  t: ValType
-
-class Bounds: pass
-
-@dataclass
-class Eq(Bounds):
-  t: Type
-
-@dataclass
-class TypeType(ExternType):
-  bounds: Bounds
-
-@dataclass
 class PrimValType(ValType):
   pass
 


### PR DESCRIPTION
These types appear to have been used by the mangling implementation which has been removed, so they no longer appear to be needed.