### PR TITLE
Remove the final "done" state of subtasks from the async ABI

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -249,6 +249,8 @@ Notes:
 * Validation of `functype` rejects any transitive use of `borrow` in a
   `result` type. Similarly, validation of components and component types
   rejects any transitive use of `borrow` in an exported value type.
+* Validation of `stream` and `future` rejects element types that transitively
+  contain a `borrow`.
 * Validation of `resourcetype` requires the destructor (if present) to have
   type `[i32] -> []`.
 * Validation of `instancedecl` (currently) only allows the `type` and

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -601,14 +601,12 @@ The `return_` method is called by either `canon_task_return` or `canon_lift`
 (both defined below) to lift and return results to the caller using the
 `on_return` callback that was supplied by the caller to `canon_lift`. Using a
 callback instead of simply returning the values from `canon_lift` enables the
-callee to keep executing after returning its results. However, it does
-introduce a dynamic error condition if `canon task.return` is called less or
-more than once which must be checked by `return_` and `exit`. Since ownership
-of borrowed handles is returned to the caller when the caller is notified that
-the `Subtask` is in the `RETURNED` state, `num_borrows` is guarded to be `0`.
-Since tasks can keep executing arbitrary code after calling `task.return`, this
-means that borrowed handles must be dropped potentially much earlier than the
-observable end of the task.
+callee to keep executing after returning its results. There is a dynamic error
+if `task.return` is not called exactly once and if the callee has not dropped
+all borrowed handles by the time `task.return` is called. This means that the
+caller can assume that ownership all its lent borrowed handles has been
+returned to it when it is notified that the `Subtask` has reached the
+`RETURNED` state.
 ```python
   def return_(self, flat_results):
     trap_if(not self.on_return)

--- a/design/mvp/FutureFeatures.md
+++ b/design/mvp/FutureFeatures.md
@@ -8,6 +8,19 @@ also the high-level [post-MVP use cases](../high-level/UseCases.md#post-mvp)
 and [non-goals](../high-level/Goals.md#non-goals).
 
 
+## Blast zones
+
+While the Component Model MVP allows strong software isolation of capabilities
+(in the form of link-time imports and runtime handles) there is currently no
+way for a host component to execute a guest component robustly in the face of
+traps or runaway resource memory/CPU usage. A post-MVP "blast zone" feature
+would allow a parent component to dynamically instantiate a child component in
+a separate "blast zone" such that a trap in the blast zone could be safely and
+predictably handled by the parent outside the blast zone. Furthermore, the
+parent could use a non-deterministic timeout or resource quota trigger to
+preemptively inject a trap into the blast zone.
+
+
 ## Custom ABIs via "adapter functions"
 
 The original Interface Types proposal includes the goal of avoiding a fixed
@@ -36,24 +49,6 @@ optimization of calls between components (which both use the Canonical ABI) and
 between a component and the host (which often must use a fixed ABI for calling
 to and from the statically-compiled host implementation language). See
 [`list.lift_canon` and `list.lower_canon`] for more details.
-
-
-## Shared-some-things linking via "adapter modules"
-
-The original [Interface Types proposal] and the re-layered [Module Linking
-proposal] both included an "adapter module" definition that allowed import and
-export of both Core WebAssembly and Component Model Definitions and thus did
-not establish a shared-nothing boundary. Since [component invariants] and
-[GC-free runtime instantiation] both require a shared-nothing boundary, two
-distinct "component" and "adapter module" concepts would need to be defined,
-with all their own distinct types, index spaces, etc. Having both features in
-the MVP adds non-trivial implementation complexity over having just one.
-Additionally, having two similar-but-different, partially-overlapping concepts
-makes the whole proposal harder to explain. Thus, the MVP drops the concept of
-"adapter modules", including only shared-nothing "components". However, if
-concrete future use cases emerged for creating modules that partially used
-shared-nothing component values and partially shared linear memory, "adapter
-modules" could be added as a future feature.
 
 
 ## Shared-everything Module Linking in Core WebAssembly


### PR DESCRIPTION
This PR has 2 commits, the first one is pure refactoring, no observable change (moving code from `Subtask` into `canon_lower`, which makes the logic easier to follow, imo), the second one removes `CallState.DONE`.

Before this PR, excusive ownership of borrowed handles is returned when a subtask (i.e., `async` import call) reaches the "done" state.  Abstractly this made sense, but working through source-language bindings, there is no good way of expressing when this event happens in the syntax, and this is an important event to express well (since it determines whether dropping/transferring the borrowed handle traps).  Syntactically, the natural place to return borrows is when the subtask returns its value, which is the "returned" state (which precedes the "done" state), since that maps to, e.g., when a `Promise`/`Future` is visibly resolved.  So that's what this PR does.

With that change, there is no need for the "done" state, it just adds noise, so this PR removes the "done" state entirely, allowing the subtask to be dropped by its caller immediately after receiving the return value.  This does mean that subtasks can continue executing (after `task.return`) even after their supertask finishes, but this doesn't break Structured Concurrency (and the existence of an unambiguous call-tree, which is semantically used by the reentrance guard) if we view the supertask as "async tail-calling" any still-executing subtasks when it exits.  A blurb is added to Async.md by this PR explaining this more.

Two other notes:
* The rules for lifting `borrow` are tweaked (in CanonicalABI.md) to account for the fact that a supertask can now return before its subtasks have returned, so simply checking that a `borrow` handle is passed to a nested subtask is no longer a sufficient condition to ensure proper nesting.  However, the new rule is actually more expressive than the old rule, so it's probably what it should have been all along.
* Since the current implementation plan does not allow `borrow` inside `stream<T>` or `future<T>` anyways, this PR changes the validation rules in the proposal to match, which is a conservative change we relax in the future if someone actually finds a use case for this (I'm not aware of any, atm).