### PR TITLE
Change task.return to take component-level type + canonopt immediates

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -289,7 +289,7 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x05 ft:<typeidx>                                   => (canon thread.spawn ft (core func)) 🧵
            | 0x06                                                => (canon thread.available_parallelism (core func)) 🧵
            | 0x08                                                => (canon task.backpressure (core func)) 🔀
-           | 0x09 ft:<core:typeidx>                              => (canon task.return ft (core func)) 🔀
+           | 0x09 rs:<resultlist> opts:<opts>                    => (canon task.return rs opts (core func)) 🔀
            | 0x0a async?:<async>? m:<core:memdix>                => (canon task.wait async? (memory m) (core func)) 🔀
            | 0x0b async?:<async>? m:<core:memidx>                => (canon task.poll async? (memory m) (core func)) 🔀
            | 0x0c async?:<async>?                                => (canon task.yield async? (core func)) 🔀

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1399,7 +1399,7 @@ canon ::= ...
         | (canon resource.drop <typeidx> async? (core func <id>?))
         | (canon resource.rep <typeidx> (core func <id>?))
         | (canon task.backpressure (core func <id>?)) 🔀
-        | (canon task.return <core:typeidx> (core func <id>?)) 🔀
+        | (canon task.return (result <valtype>)? <canonopt>* (core func <id>?)) 🔀
         | (canon task.wait async? (memory <core:memidx>) (core func <id>?)) 🔀
         | (canon task.poll async? (memory <core:memidx>) (core func <id>?)) 🔀
         | (canon task.yield async? (core func <id>?)) 🔀
@@ -1543,12 +1543,11 @@ the Canonical ABI explainer.)
 
 The `task.return` built-in takes as parameters the result values of the
 currently-executing task. This built-in must be called exactly once per export
-activation. The `canon task.return` definition takes the type index of a core
-function type and produces a core function with exactly that type. When called,
-the declared core function type is checked to match the lowered function type
-of a component-level function taking the result types of the current task. (See
-also [Returning](Async.md#returning) in the async explainer and
-[`canon_task_return`] in the Canonical ABI explainer.)
+activation. The `canon task.return` definition takes component-level return
+type and the list of `canonopt` to be used to lift the return value. When
+called, the declared return type and `canonopt`s are checked to exactly match
+those of the current task. (See also [Returning](Async.md#returning) in the
+async explainer and [`canon_task_return`] in the Canonical ABI explainer.)
 
 ###### 🔀 `task.wait`
 

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -1855,12 +1855,11 @@ async def canon_task_backpressure(task, flat_args):
 
 ### 🔀 `canon task.return`
 
-async def canon_task_return(task, core_ft, flat_args):
+async def canon_task_return(task, result_type, opts, flat_args):
   trap_if(not task.inst.may_leave)
   trap_if(task.opts.sync and not task.opts.always_task_return)
-  sync_opts = copy(task.opts)
-  sync_opts.sync = True
-  trap_if(core_ft != flatten_functype(sync_opts, FuncType(task.ft.results, []), 'lower'))
+  trap_if(result_type != task.ft.results)
+  trap_if(opts != task.opts)
   task.return_(flat_args)
   return []
 


### PR DESCRIPTION
In the original async PR (#363), there seemed to be a reason to reuse the same core wasm type-equality test used by `call_indirect` in `task.return` to avoid a new kind of (component-level) type equality test.  However, the streams PR (#405) ended up adding a well-motivated runtime component-type-equality test.  Without that reason, passing the component-level return type + `canonopt`s seems to be the more natural choice, so this PR switches to that.