### PR TITLE
Async: add and decouple "waitable sets" from tasks

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -290,11 +290,11 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
            | 0x05 ft:<typeidx>                                   => (canon thread.spawn ft (core func)) 🧵
            | 0x06                                                => (canon thread.available_parallelism (core func)) 🧵
-           | 0x08                                                => (canon task.backpressure (core func)) 🔀
+           | 0x08                                                => (canon backpressure.set (core func)) 🔀
            | 0x09 rs:<resultlist> opts:<opts>                    => (canon task.return rs opts (core func)) 🔀
-           | 0x0a async?:<async>? m:<core:memdix>                => (canon task.wait async? (memory m) (core func)) 🔀
-           | 0x0b async?:<async>? m:<core:memidx>                => (canon task.poll async? (memory m) (core func)) 🔀
-           | 0x0c async?:<async>?                                => (canon task.yield async? (core func)) 🔀
+           | 0x0a 0x7f i:<u32>                                   => (canon context.get i32 i (core func)) 🔀
+           | 0x0b 0x7f i:<u32>                                   => (canon context.set i32 i (core func)) 🔀
+           | 0x0c async?:<async>?                                => (canon yield async? (core func)) 🔀
            | 0x0d                                                => (canon subtask.drop (core func)) 🔀
            | 0x0e t:<typeidx>                                    => (canon stream.new t (core func)) 🔀
            | 0x0f t:<typeidx> opts:<opts>                        => (canon stream.read t opts (core func)) 🔀
@@ -313,6 +313,11 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x1c opts:<opts>                                    => (canon error-context.new opts (core func)) 🔀
            | 0x1d opts:<opts>                                    => (canon error-context.debug-message opts (core func)) 🔀
            | 0x1e                                                => (canon error-context.drop (core func)) 🔀
+           | 0x1f                                                => (canon waitable-set.new (core func)) 🔀
+           | 0x20 async?:<async>? m:<core:memidx>                => (canon waitable-set.wait async? (memory m) (core func)) 🔀
+           | 0x21 async?:<async>? m:<core:memidx>                => (canon waitable-set.poll async? (memory m) (core func)) 🔀
+           | 0x22                                                => (canon waitable-set.drop (core func)) 🔀
+           | 0x23                                                => (canon waitable.join (core func)) 🔀
 async?   ::= 0x00                                                =>
            | 0x01                                                => async
 opts     ::= opt*:vec(<canonopt>)                                => opt*


### PR DESCRIPTION
Currently, every task has an implicit set of "waitables" (async import calls, async stream/future operations) that are collectively waited on by `task.wait`.  However, for more advanced cases, different libraries may each need to own and manage their own sets of waitables independently of tasks.  An example would a component that uses libc (which will need to maintain a set of waitables to implement `select()`) and contains a language runtime which implements its own async runtime that is not based on libc.  This PR decouples waitable sets from tasks, making them first-class with new built-ins to create, use and destroy them.

The PR is broken into two initial commits:

The first commit is pure refactoring, no semantic changes.  The first commit introduces the `Waitable` and `WaitableSet` classes and uses them to re-implement the current async functionality which makes the next commit much smaller.  This ended up enabling a bunch of simplifications to the Python code that touches a bunch of code and descriptive text in CanonicalABI.md so it's a big commit and I'd recommend reading it separately from the next one (or skipping if you just want a summary of the semantic changes).  Some interesting changes in this refactoring are:
* "events" are no longer stored in a separate queue between when the event is generated and consumed by core wasm.  Instead, events are stored as a field in the waitable element of the `waitables` table until they are delivered to core wasm.
* The readable/writable ends of streams/futures are no longer called `*Handle`s, but `*End`s.  So "handles" are for resources, "ends" are for futures/streams, which avoids some ambiguity I've noticed when "handles" was used for both.
* The internal stream interface (that abstracts over wasm-vs-host-implemented streams) switched to using callbacks in a way that more-clearly/precisely describes how cancellation and multiple partial reads/writes from the same buffer work in component-to-component cases and eliminates some weird corner cases in the previous code that required non-obvious code.

The semantic changes in the second commit are:
* Tasks no longer have an implicit waitable set; `task.wait`/`task.poll` are removed.
* Canon built-ins `waitable-set.{new,wait,poll,drop}` are added.  See Explainer.md for summaries/signatures.
* Waitables have 0-or-1 associated waitable sets; waitables start with no associated waitable set and a new `waitable.join` built-in is added to set/change/clear it.
* The `callback` ABI is changed so that an explicit waitable-set-index can be supplied (via return value).  This ended up requiring a few supporting changes:
  * To avoid threading *both* the "context" and waitable-set-index `i32`s through each call (using linear memory due to lack of multi-return...), the "context" `i32` is removed and replaced by adding "context-local storage" in the form of `context.get` and `context.set` built-ins.  This is already a pending (breaking) change that would need to be made when we integrate `thread.spawn`, so doing it now just front-loads the breakage.  See Async.md#context-local-storage for a better description.
  * To maintain parity between the `callback` and non-`callback` ABIs, the packed return value for the `callback` ABI now has an opcode saying what to do: exit, yield, wait or poll.  For wait/poll, the opcode is bit-packed with the waitable-set-index to wait/poll on.
  * Table indices have the top two bits clear (the max table length is 2<sup>30</sup>-1).  While the 4 above opcodes technically fit in 2 bits, this seems very likely to be insufficient in the future.  Since 64-bit tables may one day be added to handle very-large cases and since 256M table-entries is larger than many implementations would allow anyways, this commit lowers the max table length to 2<sup>28</sup>-1, thereby giving us 4 total bits.
  * `canon lower async`'s bit-packing scheme is changed to be symmetric with the `callback` bitpacking scheme (reserving 4 bits for the `CallState` and putting the `CallState` in the low bits).
* Since this (should be) the last breaking change to async before 0.3.0, and since 0.3.x will need a `CANCELLED` value of `CallState`, the `EventCode` enum is renumbered to reserve a spot.  Also `YIELDED` is renamed to `NONE` and given value `0` to make it a natural sentinel value for the `callback` ABI after a yield or poll-with-no-event.
* Since the `task.*` namespace has been mostly evacuated and since `task.backpressure` and `task.yield` are not actually task-related operations (backpressure is component-instance field and yielding (will) yield the current *thread*, not *task*), they are renamed to `backpressure.set` (in anticipation of a possible `backpressure.get` if there's ever a use case for it) and `yield`.