### PR TITLE
Make future and stream element types optional

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -296,6 +296,17 @@ readable and writable ends of streams and futures each have a well-defined
 parent `Task` that will receive "progress" events on all child streams/futures
 that have previously blocked.
 
+The `T` element type of streams and futures is optional, such that `future` and
+`stream` can be written in WIT without a trailing `<T>`. In this case, the
+asynchronous "values(s)" being delivered are effectively meaningless [unit]
+values. However, the *timing* of delivery is meaningful and thus `future` and
+`stream` can used to convey timing-related information. Note that, since
+functions are asynchronous by default, a plain `f: func()` conveys completion
+without requiring an explicit `future` return type. Thus, a function like
+`f2: func() -> future` would convey *two* events: first, the return of `f2`, at
+which point the caller receives the readable end of a `future` that, when
+successfully read, conveys the completion of a second event.
+
 From a [structured-concurrency](#structured-concurrency) perspective, the
 readable and writable ends of streams and futures are leaves of the async call
 tree. Unlike subtasks, the parent of the readable ends of streams and future
@@ -606,6 +617,7 @@ comes after:
 [CPS Transform]: https://en.wikipedia.org/wiki/Continuation-passing_style
 [Event Loop]: https://en.wikipedia.org/wiki/Event_loop
 [Structured Concurrency]: https://en.wikipedia.org/wiki/Structured_concurrency
+[Unit]: https://en.wikipedia.org/wiki/Unit_type
 
 [AST Explainer]: Explainer.md
 [Lift and Lower Definitions]: Explainer.md#canonical-definitions

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -203,8 +203,8 @@ defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x6a t?:<valtype>? u?:<valtype>?        => (result t? (error u)?)
                 | 0x69 i:<typeidx>                        => (own i)
                 | 0x68 i:<typeidx>                        => (borrow i)
-                | 0x66 i:<typeidx>                        => (stream i)
-                | 0x65 i:<typeidx>                        => (future i)
+                | 0x66 i?:<typeidx>?                      => (stream i?)
+                | 0x65 i?:<typeidx>?                      => (future i?)
 labelvaltype  ::= l:<label'> t:<valtype>                  => l t
 case          ::= l:<label'> t?:<valtype>? 0x00           => (case l t?)
 label'        ::= len:<u32> l:<label>                     => l    (if len = |l|)

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -738,7 +738,7 @@ variant-case payloads and function results, when `T` is absent, the "value(s)"
 being asynchronously passed can be thought of as [unit] values. In such cases,
 there is no representation of the value in Core WebAssembly (pointers into
 linear memory are ignored) however the *timing* of completed reads and writes
-is observable and meaningful. Thus, empty futures and streams can be useful for
+and the number of elements they contain are observable and meaningful. Thus, empty futures and streams can be useful for
 timing-related APIs.
 
 Currently, validation rejects `(stream T)` and `(future T)` when `T`

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -555,8 +555,8 @@ defvaltype    ::= bool
                 | (result <valtype>? (error <valtype>)?)
                 | (own <typeidx>)
                 | (borrow <typeidx>)
-                | (stream <typeidx>)
-                | (future <typeidx>)
+                | (stream <typeidx>?)
+                | (future <typeidx>?)
 valtype       ::= <typeidx>
                 | <defvaltype>
 resourcetype  ::= (resource (rep i32) (dtor async? <funcidx> (callback <funcidx>)?)?)
@@ -732,6 +732,14 @@ traditional `async` function -- all functions are effectively `async`. Instead
 futures are useful in more advanced scenarios where a parameter or result
 value may not be ready at the same time as the other synchronous parameters or
 results.
+
+The `T` element type of `stream` and `future` is an optional `valtype`. As with
+variant-case payloads and function results, when `T` is absent, the "value(s)"
+being asynchronously passed can be thought of as [unit] values. In such cases,
+there is no representation of the value in Core WebAssembly (pointers into
+linear memory are ignored) however the *timing* of completed reads and writes
+is observable and meaningful. Thus, empty futures and streams can be useful for
+timing-related APIs.
 
 Currently, validation rejects `(stream T)` and `(future T)` when `T`
 transitively contains a `borrow`. This restriction could be relaxed in the
@@ -2672,6 +2680,7 @@ For some use-case-focused, worked examples, see:
 [Subtyping]: https://en.wikipedia.org/wiki/Subtyping
 [Universal Types]: https://en.wikipedia.org/wiki/System_F
 [Existential Types]: https://en.wikipedia.org/wiki/System_F
+[Unit]: https://en.wikipedia.org/wiki/Unit_type
 
 [Generative]: https://www.researchgate.net/publication/2426300_A_Syntactic_Theory_of_Type_Generativity_and_Sharing
 [Avoidance Problem]: https://counterexamples.org/avoidance.html

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1557,6 +1557,8 @@ ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | option
      | result
      | handle
+     | future
+     | stream
      | id
 
 tuple ::= 'tuple' '<' tuple-list '>'
@@ -1574,6 +1576,12 @@ result ::= 'result' '<' ty ',' ty '>'
          | 'result' '<' '_' ',' ty '>'
          | 'result' '<' ty '>'
          | 'result'
+
+future ::= 'future' '<' ty '>'
+         | 'future'
+
+stream ::= 'stream' '<' ty '>'
+         | 'stream'
 ```
 
 The `tuple` type is semantically equivalent to a `record` with numerical fields,
@@ -1607,6 +1615,9 @@ variant result {
 
 These types are so frequently used and frequently have language-specific
 meanings though so they're also provided as first-class types.
+
+The `future` and `stream` types are described as part of the [async
+explainer](Async.md#streams-and-futures).
 
 Finally the last case of a `ty` is simply an `id` which is intended to refer to
 another type or resource defined in the document. Note that definitions can come


### PR DESCRIPTION
For the same reason that `variant` and `result` case payloads and `func` results are optional, it seems like the element types of `future` and `stream` should be optional, allowing them to convey (single-shot or recurring) timing events.  When the element-type is absent, the `ptr` (read-from or written-to) is simply ignored (as if `elem_size(Unit) == 0`, but without the messy implications if we did this in general).  This is already present in the current implementation for `future` (but not yet `stream`), so this helps converge the spec with the impl.

(credit to @rvolosatovs for pointing out the omission)