### PR TITLE
Allow stream.{read,write}s of length 0 to query/signal readiness

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -356,7 +356,11 @@ These built-ins can either return immediately if >0 elements were able to be
 written or read immediately (without blocking) or return a sentinel "blocked"
 value indicating that the read or write will execute concurrently. The readable
 and writable ends of streams and futures can then be [waited](#waiting) on to
-make progress.
+make progress. Notification of progress signals *completion* of a read or write
+(i.e., the bytes have already been copied into the buffer). Additionally,
+*readiness* (to perform a read or write in the future) can be queried and
+signalled by performing a `0`-length read or write (see the [Stream State]
+section in the Canonical ABI explainer for details).
 
 As a temporary limitation, if a `read` and `write` for a single stream or
 future occur from within the same component, there is a trap. In the future


### PR DESCRIPTION
This PR relaxes the rules for `stream.{read,write}` to accept lengths of `0`.  This can be useful for signalling and querying readiness which in turn can be used to implement non-blocking POSIX operations, as discussed in #441.