### PR TITLE
Normalize WAT codeblock syntax names

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -644,7 +644,7 @@ this approach is that a non-`shared` component-level function could be safely
 lowered with `async shared`. In the case that the lifted function being lowered
 was also `async shared`, the entire call could happen on the non-main thread
 without a context switch. But if the lifting side was non-`shared`, then the
-Component Model could automatically handle the synchronization of enqueing a
+Component Model could automatically handle the synchronization of enqueuing a
 call to the export (as in the backpressure case mentioned above), returning a
 subtask for the async caller to wait on as usual. Thus, the sync+async
 composition story described above could naturally be extended to a

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -456,7 +456,7 @@ Notes:
     - [`core:utf8`]
 * `&` operator is used to denote bitwise AND operation, which performs AND on every bit of two numbers in their binary form
 * `isnan` is a function, which takes a floating point number as a parameter and returns `true` iff it represents a NaN as defined in [IEEE 754 standard]
-* `||B||` is the length of the byte sequence generated from the production `B` in a derivation as defined in [Core convention auxilary notation]
+* `||B||` is the length of the byte sequence generated from the production `B` in a derivation as defined in [Core convention auxiliary notation]
 
 ## Name Section
 
@@ -518,4 +518,4 @@ named once.
 [module-linking]: https://github.com/WebAssembly/module-linking/blob/main/proposals/module-linking/Explainer.md
 
 [IEEE 754 standard]: https://ieeexplore.ieee.org/document/8766229
-[Core convention auxilary notation]: https://webassembly.github.io/spec/core/binary/conventions.html#auxiliary-notation
+[Core convention auxiliary notation]: https://webassembly.github.io/spec/core/binary/conventions.html#auxiliary-notation

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -753,7 +753,7 @@ returned to it when it is notified that the `Subtask` has reached the
 ```
 The maximum flattened core wasm values depends on whether this is a normal
 synchronous call (in which return values are returned by core wasm) or a newer
-async or sychronous-using-`always-task-return` call, in which case return
+async or synchronous-using-`always-task-return` call, in which case return
 values are passed as parameters to `canon task.return`.
 
 Lastly, the `Task.exit` method is called when the task has signalled that it
@@ -887,7 +887,7 @@ A "waitable set" contains a collection of waitables that can be waited on or
 polled for *any* element to make progress. Although the `WaitableSet` class
 below represents `elems` as a `list` and implements `poll` with an O(n) search,
 because a waitable can be associated with at most one set and can contain at
-most one pending event, a real implemenation could instead store a list of
+most one pending event, a real implementation could instead store a list of
 waitables-with-pending-events as a linked list embedded directly in the
 `Waitable` table element to avoid the separate allocation while providing O(1)
 polling.
@@ -2789,7 +2789,7 @@ happens by core wasm calling `waitable-set.wait`.
       task.exit()
       return
 ```
-In contrast, the aynchronous `callback` case does asynchronous waiting in
+In contrast, the asynchronous `callback` case does asynchronous waiting in
 the event loop, with core wasm (repeatedly) returning instructions for what
 to do next:
 ```python

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -2703,7 +2703,7 @@ cover each of these `canon` cases.
 ### `canon lift`
 
 For a canonical definition:
-```wasm
+```wat
 (canon lift $callee:<funcidx> $opts:<canonopt>* (func $f (type $ft)))
 ```
 validation specifies:
@@ -2866,7 +2866,7 @@ async def call_and_trap_on_throw(callee, task, args):
 ### `canon lower`
 
 For a canonical definition:
-```wasm
+```wat
 (canon lower $callee:<funcidx> $opts:<canonopt>* (core func $f))
 ```
 where `$callee` has type `$ft`, validation specifies:
@@ -3016,7 +3016,7 @@ as post-MVP [adapter functions].
 ### `canon resource.new`
 
 For a canonical definition:
-```wasm
+```wat
 (canon resource.new $rt (core func $f))
 ```
 validation specifies:
@@ -3039,7 +3039,7 @@ async def canon_resource_new(rt, task, rep):
 ### `canon resource.drop`
 
 For a canonical definition:
-```wasm
+```wat
 (canon resource.drop $rt $async? (core func $f))
 ```
 validation specifies:
@@ -3093,7 +3093,7 @@ destructor is an encapsualted implementation detail of the resource type.
 ### `canon resource.rep`
 
 For a canonical definition:
-```wasm
+```wat
 (canon resource.rep $rt (core func $f))
 ```
 validation specifies:
@@ -3116,7 +3116,7 @@ component instance defining a resource can access its representation.
 ### 🔀 `canon context.get`
 
 For a canonical definition:
-```wasm
+```wat
 (canon context.get $t $i (core func $f))
 ```
 validation specifies:
@@ -3137,7 +3137,7 @@ async def canon_context_get(t, i, task):
 ### 🔀 `canon context.set`
 
 For a canonical definition:
-```wasm
+```wat
 (canon context.set $t $i (core func $f))
 ```
 validation specifies:
@@ -3159,7 +3159,7 @@ async def canon_context_set(t, i, task, v):
 ### 🔀 `canon backpressure.set`
 
 For a canonical definition:
-```wasm
+```wat
 (canon backpressure.set (core func $f))
 ```
 validation specifies:
@@ -3181,7 +3181,7 @@ consume resources.
 ### 🔀 `canon task.return`
 
 For a canonical definition:
-```wasm
+```wat
 (canon task.return (result $t)? $opts (core func $f))
 ```
 validation specifies:
@@ -3212,7 +3212,7 @@ a thunk that is indirectly called by `task.return` after these guards.
 ### 🔀 `canon yield`
 
 For a canonical definition:
-```wasm
+```wat
 (canon yield $async? (core func $f))
 ```
 validation specifies:
@@ -3240,7 +3240,7 @@ activations.
 ### 🔀 `canon waitable-set.new`
 
 For a canonical definition:
-```wasm
+```wat
 (canon waitable-set.new (core func $f))
 ```
 validation specifies:
@@ -3258,7 +3258,7 @@ async def canon_waitable_set_new(task):
 ### 🔀 `canon waitable-set.wait`
 
 For a canonical definition:
-```wasm
+```wat
 (canon waitable-set.wait $async? (memory $mem) (core func $f))
 ```
 validation specifies:
@@ -3302,7 +3302,7 @@ handle multiple overlapping callback activations.
 ### 🔀 `canon waitable-set.poll`
 
 For a canonical definition:
-```wasm
+```wat
 (canon waitable-set.poll $async? (memory $mem) (core func $f))
 ```
 validation specifies:
@@ -3333,7 +3333,7 @@ activations.
 ### 🔀 `canon waitable-set.drop`
 
 For a canonical definition:
-```wasm
+```wat
 (canon waitable-set.drop (core func $f))
 ```
 validation specifies:
@@ -3354,7 +3354,7 @@ async def canon_waitable_set_drop(task, i):
 ### 🔀 `canon waitable.join`
 
 For a canonical definition:
-```wasm
+```wat
 (canon waitable.join (core func $f))
 ```
 validation specifies:
@@ -3380,7 +3380,7 @@ given waitable is already in one set, it will be transferred.
 ### 🔀 `canon subtask.drop`
 
 For a canonical definition:
-```wasm
+```wat
 (canon subtask.drop (core func $f))
 ```
 validation specifies:
@@ -3402,7 +3402,7 @@ async def canon_subtask_drop(task, i):
 ### 🔀 `canon {stream,future}.new`
 
 For canonical definitions:
-```wasm
+```wat
 (canon stream.new $t (core func $f))
 (canon future.new $t (core func $f))
 ```
@@ -3432,7 +3432,7 @@ the future built-ins below.
 ### 🔀 `canon {stream,future}.{read,write}`
 
 For canonical definitions:
-```wasm
+```wat
 (canon stream.read $t $opts (core func $f))
 (canon stream.write $t $opts (core func $f))
 ```
@@ -3440,7 +3440,7 @@ validation specifies:
 * `$f` is given type `(func (param i32 i32 i32) (result i32))`
 
 For canonical definitions:
-```wasm
+```wat
 (canon future.read $t $opts (core func $f))
 (canon future.write $t $opts (core func $f))
 ```
@@ -3563,7 +3563,7 @@ same direction as values, as an optional last value of the stream or future.
 ### 🔀 `canon {stream,future}.cancel-{read,write}`
 
 For canonical definitions:
-```wasm
+```wat
 (canon stream.cancel-read $t $async? (core func $f))
 (canon stream.cancel-write $t $async? (core func $f))
 (canon future.cancel-read $t $async? (core func $f))
@@ -3629,7 +3629,7 @@ caller can assume that ownership of the buffer has been returned.
 ### 🔀 `canon {stream,future}.close-{readable,writable}`
 
 For canonical definitions:
-```wasm
+```wat
 (canon stream.close-readable $t (core func $f))
 (canon future.close-readable $t (core func $f))
 ```
@@ -3637,7 +3637,7 @@ validation specifies:
 * `$f` is given type `(func (param i32))`
 
 and for canonical definitions:
-```wasm
+```wat
 (canon stream.close-writable $t (core func $f))
 (canon future.close-writable $t (core func $f))
 ```
@@ -3681,7 +3681,7 @@ direction as values as an optional last value of the stream or future.
 ### 🔀 `canon error-context.new`
 
 For a canonical definition:
-```wasm
+```wat
 (canon error-context.new $opts (core func $f))
 ```
 validation specifies:
@@ -3720,7 +3720,7 @@ Canonical ABI and stands for an arbitrary host-defined function.)
 ### 🔀 `canon error-context.debug-message`
 
 For a canonical definition:
-```wasm
+```wat
 (canon error-context.debug-message $opts (core func $f))
 ```
 validation specifies:
@@ -3745,7 +3745,7 @@ the pointer and length of the debug string (allocated via `opts.realloc`).
 ### 🔀 `canon error-context.drop`
 
 For a canonical definition:
-```wasm
+```wat
 (canon error-context.drop (core func $f))
 ```
 validation specifies:
@@ -3764,7 +3764,7 @@ async def canon_error_context_drop(task, i):
 ### 🧵 `canon thread.spawn`
 
 For a canonical definition:
-```wasm
+```wat
 (canon thread.spawn (type $ft) (core func $st))
 ```
 validation specifies:
@@ -3811,7 +3811,7 @@ def canon_thread_spawn(f, c):
 ### 🧵 `canon thread.available_parallelism`
 
 For a canonical definition:
-```wasm
+```wat
 (canon thread.available_parallelism (core func $f))
 ```
 validation specifies:

--- a/design/mvp/Linking.md
+++ b/design/mvp/Linking.md
@@ -88,7 +88,7 @@ shared-nothing linking works at the WAT level, see
 With both `wasm-tools link` and `wac`, the developer will have the option to
 either store child modules or components **inline** or to **import** them from
 an external registry. This registry toolchain integration is still in progress,
-but by reusing common support libries such as [`wasm-pkg-tools`], higher-level
+but by reusing common support libraries such as [`wasm-pkg-tools`], higher-level
 tooling can uniformly interact with multiple kinds of storage backends such as
 local directories, [OCI Wasm Artifacts] stored in standard [OCI Registries] and
 [warg registries]. Of note, even when modules or components are stored inline

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -926,7 +926,7 @@ nested-package-definition ::= package-decl '{' package-items* '}'
 package-items ::= toplevel-use-item | interface-item | world-item
 ```
 
-Essentially, these top level items are [worlds], [interfaces], [use statements][use] and other package defintions.
+Essentially, these top level items are [worlds], [interfaces], [use statements][use] and other package definitions.
 
 ### Feature Gates
 

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -111,7 +111,7 @@ represents an interface called `host` which provides one function, `log`, which
 takes a single `string` argument. If this were imported into a component then it
 would correspond to:
 
-```wasm
+```wat
 (component
   (import "local:demo/host" (instance $host
     (export "log" (func (param "msg" string)))
@@ -174,7 +174,7 @@ world my-world {
 
 can be thought of as this component type:
 
-```wasm
+```wat
 (type $my-world (component
   (import "host" (instance
     (export "log" (func (param "param" string)))
@@ -616,7 +616,7 @@ world my-world {
 
 would generate this component:
 
-```wasm
+```wat
 (component
   (import "local:demo/shared" (instance $shared
     (type $metadata (record (; ... ;)))
@@ -1746,7 +1746,7 @@ interface namespace {
 }
 ```
 can be packaged into a component as:
-```wasm
+```wat
 (component
   (type (export "types") (component
     (export "local:demo/types" (instance
@@ -1813,7 +1813,7 @@ interface foo {
 }
 ```
 is encoded as:
-```wasm
+```wat
 (component
   (type (export "foo") (component
     (import "wasi:http/types" (instance $types
@@ -1838,7 +1838,7 @@ world the-world {
 }
 ```
 is encoded as:
-```wasm
+```wat
 (component
   (type (export "the-world") (component
     (export "local:demo/the-world" (component
@@ -1868,7 +1868,7 @@ interface console {
 }
 ```
 is encoded as:
-```wasm
+```wat
 (component
   (type (export "the-world") (component
     (export "local:demo/the-world" (component
@@ -1914,7 +1914,7 @@ world proxy {
 }
 ```
 are encoded as:
-```wasm
+```wat
 (component
   (type (export "types") (component
     (export "wasi:http/types" (instance

--- a/design/mvp/examples/LinkTimeVirtualization.md
+++ b/design/mvp/examples/LinkTimeVirtualization.md
@@ -14,7 +14,7 @@ instance imported by the `parent` instance.
 
 We start with the `child.wat` that has been written and compiled separately,
 without regard to `parent.wasm`:
-```wasm
+```wat
 ;; child.wat
 (component
   (import "wasi:filesystem/types" (instance
@@ -28,7 +28,7 @@ without regard to `parent.wasm`:
 We want to write a parent component that reuses the child component, giving the
 child component a virtual filesystem. This virtual filesystem can be factored
 out and reused as a separate component:
-```wasm
+```wat
 ;; virtualize.wat
 (component
   (import "wasi:filesystem/types" (instance $fs
@@ -46,7 +46,7 @@ out and reused as a separate component:
 
 We now write the parent component by composing `child.wasm` with
 `virtualize.wasm`:
-```wasm
+```wat
 ;; parent.wat
 (component
   (import "wasi:filesystem/types" (instance $real-fs ...))
@@ -63,7 +63,7 @@ We now write the parent component by composing `child.wasm` with
 Here we import the `child` and `virtualize` components, but they could also be
 trivially copied in-line into the `parent` component using nested component
 definitions in place of imports:
-```wasm
+```wat
 ;; parent.wat
 (component
   (import "wasi:filesystem/types" (instance $real-fs ...))

--- a/design/mvp/examples/SharedEverythingDynamicLinking.md
+++ b/design/mvp/examples/SharedEverythingDynamicLinking.md
@@ -33,7 +33,7 @@ participating modules. Here, as in most conventions, `libc` serves a special
 role and is assumed to be bundled with the compiler. As part of this special
 role, `libc` defines and exports linear memory, with the convention that
 every other module imports memory from `libc`:
-```wasm
+```wat
 ;; libc.wat
 (module
   (memory (export "memory") 1)
@@ -65,7 +65,7 @@ void* LIBC(malloc)(size_t n);
 
 With these annotations, C programs that include and call this function will be
 compiled to contain the following import:
-```wasm
+```wat
 (import "libc" "malloc" (func (param i32) (result i32)))
 ```
 
@@ -95,7 +95,7 @@ so that client modules generate proper wasm *import definitions* while `libzip.c
 annotates the `zip` definition with an *export* attribute so that this function
 generates a proper *export definition* in the compiled module. Compiling with
 `clang -shared libzip.c` produces a module shaped like:
-```wasm
+```wat
 ;; libzip.wat
 (module
   (import "libc" "memory" (memory 1))
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
 
 When compiled by a (future) component-aware `clang`, the resulting component
 would look like:
-```wasm
+```wat
 ;; zipper.wat
 (component
   (import "libc" (core module $Libc
@@ -207,7 +207,7 @@ Compiling with `clang -shared libimg.c` produces a `libimg` module:
 The main module of the `imgmgk` component is implemented by including
 `stddef.h`, `libzip.h` and `libimg.h`. When compiled by a (future)
 component-aware `clang`, the resulting component would look like:
-```wasm
+```wat
 ;; imgmgk.wat
 (component $Imgmgk
   (import "libc" (core module $Libc ...))
@@ -251,7 +251,7 @@ dynamically-linked modules expressed through `instance` definitions.
 
 Finally, we can create the `app` component by composing the `zipper` and `imgmgk`
 components. The resulting component could look like:
-```wasm
+```wat
 ;; app.wat
 (component
   (import "libc" (core module $Libc ...))


### PR DESCRIPTION
The repo seems to have a mix of `` ```wat `` and ` ```wasm ` codeblocks:
https://github.com/WebAssembly/component-model/blob/53ee310d0727f880f0f7765b94192d953f39b40c/design/mvp/WIT.md?plain=1#L114-L121
https://github.com/WebAssembly/component-model/blob/53ee310d0727f880f0f7765b94192d953f39b40c/design/mvp/WIT.md?plain=1#L1985-L1993


Though the `` ```wasm `` syntax declaration does seem to syntax the WAT s-expressions correctly, the mixed use led to a bit of confusion on my part. 

After a bit of [reading](https://webassembly.js.org/docs/contrib-wat-vs-wast.html), WAT is defined as the "retranscription of the [WASM] binary format in text".

This PR replaces codeblocks declared as "wasm" to "wat".