### PR TITLE
Make close-{readable,writable} symmetric in taking an optional error-context

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1878,12 +1878,11 @@ delivered to indicate the completion of the `read` or `write`. (See
 
 | Synopsis                                              |                                                                  |
 | ----------------------------------------------------- | ---------------------------------------------------------------- |
-| Approximate WIT signature for `stream.close-readable` | `func<T>(e: readable-stream-end<T>)`                             |
+| Approximate WIT signature for `stream.close-readable` | `func<T>(e: readable-stream-end<T>, err: option<error-context>)` |
 | Approximate WIT signature for `stream.close-writable` | `func<T>(e: writable-stream-end<T>, err: option<error-context>)` |
-| Approximate WIT signature for `future.close-readable` | `func<T>(e: readable-future-end<T>)`                             |
+| Approximate WIT signature for `future.close-readable` | `func<T>(e: readable-future-end<T>, err: option<error-context>)` |
 | Approximate WIT signature for `future.close-writable` | `func<T>(e: writable-future-end<T>, err: option<error-context>)` |
-| Canonical ABI signature for `*.close-readable`        | `[readable-end:i32] -> []`                                       |
-| Canonical ABI signature for `*.close-writable`        | `[writable-end:i32 err:i32] -> []`                               |
+| Canonical ABI signature                               | `[end:i32 err:i32] -> []`                                        |
 
 The `{stream,future}.close-{readable,writable}` built-ins remove the indicated
 [stream or future] from the current component instance's table of [waitables],


### PR DESCRIPTION
The 0.3 updates to `wasi:http` in [wasi-http/#143](https://github.com/WebAssembly/wasi-http/pull/143) helped highlight the fact that the reasoning for why we want to be able to pass an `error-context` into `stream.close-readable` and get an `error-context` out of `stream.read` applies just as well in the opposite direction (to `stream.close-writable` and `stream.write`, resp.).  This PR basically just removes one of the few asymmetries from the otherwise-quite-symmetric read/write code.