### PR TITLE
threads: add `thread.*` canonical built-ins to TOC

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -54,7 +54,8 @@ being specified here.
   * [`canon error-context.new`](#-canon-error-contextnew) 🔀
   * [`canon error-context.debug-message`](#-canon-error-contextdebug-message) 🔀
   * [`canon error-context.drop`](#-canon-error-contextdrop) 🔀
-
+  * [`canon thread.spawn`](#-canon-threadspawn) 🧵
+  * [`canon thread.available_parallelism`](#-canon-threadavailable_parallelism) 🧵
 
 ## Supporting definitions
 


### PR DESCRIPTION
This fixes some missing table of contents entries for thread built-ins.