### PR TITLE
async: Fix typo in binary format of futures/streams

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -203,8 +203,8 @@ defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x6a t?:<valtype>? u?:<valtype>?        => (result t? (error u)?)
                 | 0x69 i:<typeidx>                        => (own i)
                 | 0x68 i:<typeidx>                        => (borrow i)
-                | 0x66 i?:<typeidx>?                      => (stream i?) 🔀
-                | 0x65 i?:<typeidx>?                      => (future i?) 🔀
+                | 0x66 t?:<valtype>?                      => (stream t?) 🔀
+                | 0x65 t?:<valtype>?                      => (future t?) 🔀
 labelvaltype  ::= l:<label'> t:<valtype>                  => l t
 case          ::= l:<label'> t?:<valtype>? 0x00           => (case l t?)
 label'        ::= len:<u32> l:<label>                     => l    (if len = |l|)


### PR DESCRIPTION
This commit fixes (what I believe is) a typo in the binary encoding of futures/streams. Previously they were specified as a `<typeidx>?` but I think these are supposed to be similar to `option<T>` where it's a `<valtype>?` instead.