### PR TITLE
Add a missing 🔀 on `resource.drop async`

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -286,7 +286,7 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x01 0x00 f:<funcidx> opts:<opts>                   => (canon lower f opts (core func))
            | 0x02 rt:<typeidx>                                   => (canon resource.new rt (core func))
            | 0x03 rt:<typeidx>                                   => (canon resource.drop rt (core func))
-           | 0x07 rt:<typdidx>                                   => (canon resource.drop rt async (core func))
+           | 0x07 rt:<typdidx>                                   => (canon resource.drop rt async (core func)) 🔀
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
            | 0x05 ft:<typeidx>                                   => (canon thread.spawn ft (core func)) 🧵
            | 0x06                                                => (canon thread.available_parallelism (core func)) 🧵


### PR DESCRIPTION
Adding a missing indicator that this is part of an extension to the component model.