### PR TITLE
Clarify the string-encoding=utf8 default in Binary.md and CanonicalABI.md

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -335,6 +335,8 @@ Notes:
 * The second `0x00` byte in `canon` stands for the `func` sort and thus the
   `0x00 <u32>` pair standards for a `func` `sortidx` or `core:sortidx`.
 * Validation prevents duplicate or conflicting `canonopt`.
+* When there is no `string-encoding` present, the default value is `utf8`.
+  For all other values, the default value is "none".
 * Validation of the individual canonical definitions is described in
   [`CanonicalABI.md`](CanonicalABI.md#canonical-definitions).
 

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -127,23 +127,28 @@ known to not contain `borrow`. The `CanonicalOptions`, `ComponentInstance`,
 
 ### Canonical ABI Options
 
+The following two classes list the various Canonical ABI options ([`canonopt`])
+that can be set on various Canonical ABI definitions. The default values of the
+Python fields are the default values when the associated `canonopt` is not
+present in the binary or text format definition.
+
 The `LiftLowerContext` class contains the subset of [`canonopt`] which are
 used to lift and lower the individual parameters and results of function
 calls:
 ```python
 @dataclass
 class LiftLowerOptions:
+  string_encoding: str = 'utf8'
   memory: Optional[bytearray] = None
-  string_encoding: Optional[str] = None
   realloc: Optional[Callable] = None
 
   def __eq__(self, other):
-    return self.memory is other.memory and \
-           self.string_encoding == other.string_encoding and \
+    return self.string_encoding == other.string_encoding and \
+           self.memory is other.memory and \
            self.realloc is other.realloc
 
   def copy(opts):
-    return LiftLowerOptions(opts.memory, opts.string_encoding, opts.realloc)
+    return LiftLowerOptions(opts.string_encoding, opts.memory, opts.realloc)
 ```
 The `__eq__` override specifies that equality of `LiftLowerOptions` (as used
 by, e.g., `canon_task_return` below) is defined in terms of the identity of

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1276,7 +1276,7 @@ encoding across Java, JavaScript and .NET VMs and allows a dynamic choice
 between either Latin-1 (which has a fixed 1-byte encoding, but limited Code
 Point range) or UTF-16 (which can express all Code Points, but uses either
 2 or 4 bytes per Code Point). If no `string-encoding` option is specified, the
-default is UTF-8. It is a validation error to include more than one
+default is `utf8`. It is a validation error to include more than one
 `string-encoding` option.
 
 The `(memory ...)` option specifies the memory that the Canonical ABI will

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -193,17 +193,17 @@ class LiftLowerContext:
 
 @dataclass
 class LiftLowerOptions:
+  string_encoding: str = 'utf8'
   memory: Optional[bytearray] = None
-  string_encoding: Optional[str] = None
   realloc: Optional[Callable] = None
 
   def __eq__(self, other):
-    return self.memory is other.memory and \
-           self.string_encoding == other.string_encoding and \
+    return self.string_encoding == other.string_encoding and \
+           self.memory is other.memory and \
            self.realloc is other.realloc
 
   def copy(opts):
-    return LiftLowerOptions(opts.memory, opts.string_encoding, opts.realloc)
+    return LiftLowerOptions(opts.string_encoding, opts.memory, opts.realloc)
 
 @dataclass
 class CanonicalOptions(LiftLowerOptions):


### PR DESCRIPTION
No change in current behavior; just clarifying an ambiguity raised in [#456](https://github.com/WebAssembly/component-model/pull/456#discussion_r1968445321).