### PR TITLE
Remove num_subtasks from Task state and Task.exit guard

### DIFF
--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -378,21 +378,19 @@ class Task:
   opts: CanonicalOptions
   inst: ComponentInstance
   ft: FuncType
-  caller: Optional[Task]
+  supertask: Optional[Task]
   on_return: Optional[Callable]
   on_block: Callable[[Awaitable], Awaitable]
-  num_subtasks: int
   num_borrows: int
   context: ContextLocalStorage
 
-  def __init__(self, opts, inst, ft, caller, on_return, on_block):
+  def __init__(self, opts, inst, ft, supertask, on_return, on_block):
     self.opts = opts
     self.inst = inst
     self.ft = ft
-    self.caller = caller
+    self.supertask = supertask
     self.on_return = on_return
     self.on_block = on_block
-    self.num_subtasks = 0
     self.num_borrows = 0
     self.context = ContextLocalStorage()
 
@@ -419,10 +417,10 @@ class Task:
     return lower_flat_values(cx, MAX_FLAT_PARAMS, on_start(), self.ft.param_types())
 
   def trap_if_on_the_stack(self, inst):
-    c = self.caller
+    c = self.supertask
     while c is not None:
       trap_if(c.inst is inst)
-      c = c.caller
+      c = c.supertask
 
   def may_enter(self, pending_task):
     return not self.inst.backpressure and \
@@ -501,7 +499,6 @@ class Task:
 
   def exit(self):
     assert(Task.current.locked())
-    trap_if(self.num_subtasks > 0)
     trap_if(self.on_return)
     assert(self.num_borrows == 0)
     if self.opts.sync:
@@ -620,7 +617,6 @@ class Subtask(Waitable):
   def add_to_waitables(self, task):
     assert(not self.supertask)
     self.supertask = task
-    self.supertask.num_subtasks += 1
     Waitable.__init__(self)
     return task.inst.waitables.add(self)
 
@@ -638,7 +634,6 @@ class Subtask(Waitable):
   def drop(self):
     trap_if(not self.finished)
     assert(self.state == CallState.RETURNED)
-    self.supertask.num_subtasks -= 1
     Waitable.drop(self)
 
 #### Stream State


### PR DESCRIPTION
#425 removed the final "done" state notification from subtasks to supertasks and the requirement that supertasks have to wait until all subtasks have reached the "done" state.  The async call stack was maintained rationalized as-if any supertask that finished before a subtask finished was "tail-calling" the subtask (and semantically still on the callstack).

However, #425 still unncessarily required a supertask to wait for subtasks to reach the "returned" state.  Originally, this requirement was necessary to enforce proper async borrow lifetimes, but #425 also tweaked these rules to only rely on ref-counting (which is also more permissive while still maintaining the key no-use-after-free invariant).  Thus, this "must wait for subtasks to reach the 'returned' state" requirement is vestigial, and indeed there are use cases where it's prohibitive.

The PR also rewrites the "structured concurrency" section in Async.md to do a better job explaining the situation.