### PR TITLE
Clarify memory equality check in task.return

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1590,9 +1590,10 @@ The `task.return` built-in takes as parameters the result values of the
 currently-executing task. This built-in must be called exactly once per export
 activation. The `canon task.return` definition takes component-level return
 type and the list of `canonopt` to be used to lift the return value. When
-called, the declared return type and `canonopt`s are checked to exactly match
-those of the current task. (See also "[Returning]" in the async explainer and
-[`canon_task_return`] in the Canonical ABI explainer.)
+called, the declared return type and the `string-encoding` and `memory`
+`canonopt`s are checked to exactly match those of the current task. (See also
+"[Returning]" in the async explainer and [`canon_task_return`] in the Canonical
+ABI explainer.)
 
 ###### 🔀 `yield`
 

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -192,18 +192,17 @@ class LiftLowerContext:
 ### Canonical ABI Options
 
 @dataclass
-class LiftLowerOptions:
+class LiftOptions:
   string_encoding: str = 'utf8'
   memory: Optional[bytearray] = None
+
+  def equal(lhs, rhs):
+    return lhs.string_encoding == rhs.string_encoding and \
+           lhs.memory is rhs.memory
+
+@dataclass
+class LiftLowerOptions(LiftOptions):
   realloc: Optional[Callable] = None
-
-  def __eq__(self, other):
-    return self.string_encoding == other.string_encoding and \
-           self.memory is other.memory and \
-           self.realloc is other.realloc
-
-  def copy(opts):
-    return LiftLowerOptions(opts.string_encoding, opts.memory, opts.realloc)
 
 @dataclass
 class CanonicalOptions(LiftLowerOptions):
@@ -1931,11 +1930,11 @@ async def canon_backpressure_set(task, flat_args):
 
 ### 🔀 `canon task.return`
 
-async def canon_task_return(task, result_type, opts: LiftLowerOptions, flat_args):
+async def canon_task_return(task, result_type, opts: LiftOptions, flat_args):
   trap_if(not task.inst.may_leave)
   trap_if(task.opts.sync and not task.opts.always_task_return)
   trap_if(result_type != task.ft.results)
-  trap_if(opts != LiftLowerOptions.copy(task.opts))
+  trap_if(not LiftOptions.equal(opts, task.opts))
   task.return_(flat_args)
   return []
 


### PR DESCRIPTION
This PR clarifies the wording to answer #464.  It also removes `realloc` from the set of options considered which @dicej pointed out are not relevant when lifting.