### PR TITLE
Gate some spec features separately from async

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -616,7 +616,8 @@ the core wasm toolchain) `$retp` must be a 4-byte-aligned pointer into linear
 memory from which the 8-byte (pointer, length) of the string result can be
 loaded.
 
-The async export ABI provides two flavors: stackful and stackless.
+The async export ABI provides two flavors: stackful and stackless. The stackful
+ABI is currently gated by the 🚟 feature.
 
 The async stackful export function signature is:
 ```wat
@@ -716,11 +717,12 @@ replaced with `...` to focus on the overall flow of function calls.
   (core instance $libc (instantiate $Libc))
   (alias $libc "mem" (core memory $mem))
   (alias $libc "realloc" (core func $realloc))
+  ;; requires 🚟 for the stackful abi
   (canon lower $fetch async (memory $mem) (realloc $realloc) (core func $fetch'))
   (canon waitable-set.new (core func $new))
   (canon waitable-set.wait async (memory $mem) (core func $wait))
   (canon waitable.join (core func $join))
-  (canon task.return (result string) async (memory $mem) (realloc $realloc) (core func $task_return))
+  (canon task.return (result string) (memory $mem) (core func $task_return))
   (core instance $main (instantiate $Main (with "" (instance
     (export "mem" (memory $mem))
     (export "realloc" (func $realloc))

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3275,7 +3275,7 @@ For a canonical definition:
 ```
 validation specifies:
 * `$f` is given type `(func)`
-* 🚝 - `async` is allowed (otherwise it must be `false`)
+* 🚟 - `async` is allowed (otherwise it must be `false`)
 
 Calling `$f` calls `Task.yield_` to allow other tasks to execute:
 ```python
@@ -3322,6 +3322,7 @@ For a canonical definition:
 ```
 validation specifies:
 * `$f` is given type `(func (param $si) (param $ptr i32) (result i32))`
+* 🚟 - `async` is allowed (otherwise it must be `false`)
 
 Calling `$f` invokes the following function which waits for progress to be made
 on a waitable in the given waitable set (indicated by index `$si`) and then
@@ -3366,7 +3367,7 @@ For a canonical definition:
 ```
 validation specifies:
 * `$f` is given type `(func (param $si i32) (param $ptr i32) (result i32))`
-* 🚝 - `async` is allowed (otherwise it must be `false`)
+* 🚟 - `async` is allowed (otherwise it must be `false`)
 
 Calling `$f` invokes the following function, which returns `NONE` (`0`) instead
 of blocking if there is no event available, and otherwise returns the event the

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -2720,6 +2720,8 @@ present, is validated as such:
 * `post-return` - only allowed on [`canon lift`](#canon-lift), which has rules
   for validation
 * 🔀 `async` - cannot be present with `post-return`
+* 🔀,not(🚟) `async` - `callback` must also be present. Note that with the 🚟
+  feature (the "stackful" ABI), this restriction is lifted.
 * 🔀 `callback` - the function has type `(func (param i32 i32 i32 i32) (result
   i32))` and cannot be present without `async` and is only allowed with [`canon
   lift`](#canon-lift)
@@ -3087,6 +3089,7 @@ For a canonical definition:
 validation specifies:
 * `$rt` must refer to resource type
 * `$f` is given type `(func (param i32))`
+* 🔀+🚝 - `async` is allowed (otherwise it is not allowed)
 
 Calling `$f` invokes the following function, which removes the handle from the
 current component instance's `resources` table and, if the handle was owning,
@@ -3272,6 +3275,7 @@ For a canonical definition:
 ```
 validation specifies:
 * `$f` is given type `(func)`
+* 🚝 - `async` is allowed (otherwise it must be `false`)
 
 Calling `$f` calls `Task.yield_` to allow other tasks to execute:
 ```python
@@ -3362,6 +3366,7 @@ For a canonical definition:
 ```
 validation specifies:
 * `$f` is given type `(func (param $si i32) (param $ptr i32) (result i32))`
+* 🚝 - `async` is allowed (otherwise it must be `false`)
 
 Calling `$f` invokes the following function, which returns `NONE` (`0`) instead
 of blocking if there is no event available, and otherwise returns the event the
@@ -3627,6 +3632,7 @@ For canonical definitions:
 ```
 validation specifies:
 * `$f` is given type `(func (param i32) (result i32))`
+* 🚝 - `async` is allowed (otherwise it must be `false`)
 
 The implementation of these four built-ins all funnel down to a single
 parameterized `cancel_copy` function:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -50,6 +50,8 @@ implemented, considered stable and included in a future milestone:
 * 🪙: value imports/exports and component-level start function
 * 🪺: nested namespaces and packages in import/export names
 * 🔀: async
+  * 🚝: marking some builtins as `async`
+  * 🚟: using `async` with `canon lift` without `callback` (stackful lift)
 * 🧵: threading built-ins
 * 🔧: fixed-length lists
 


### PR DESCRIPTION
This commit comes out of some discussion with folks today where a few features of the async specification are going to be gated behind separate feature gates distinct from the current one. This is to help reduce scope slightly for the 0.3.0 release of WASI and focus on the other features to ship. Here two new emoji-features are added:

* 🚝: marking some builtins as `async`
* 🚟: using `async` with `canon lift` without `callback` (stackful abi)

I've tried to update `Async.md` and `CanonicalABI.md` where appropriate with these new emoji.