### PR TITLE
fix(docs): use correct signed integer types in WIT mvp

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -295,7 +295,7 @@ in popular source language features/libraries. Often, "Structured Concurrency"
 refers to an invariant that all "child" tasks finish or are cancelled before a
 "parent" task completes. However, the Component Model doesn't force subtasks to
 [return](#returning) or be cancelled before the supertask returns (this is left
-as an option to particular source langauges to enforce or not). The reason for
+as an option to particular source languages to enforce or not). The reason for
 not enforcing a stricter form of Structured Concurrency at the Component
 Model level is that there are important use cases where forcing a supertask to
 stay resident simply to wait for a subtask to finish would waste resources

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -2463,7 +2463,7 @@ something more idiomatic to the language. For example, the `plainname`
 nested inside a class `MyResource`. To unburden bindings generators from having
 to consider pathological cases where two unique-in-the-component names get
 mapped to the same source-language identifier, Component Model validation
-imposes a stronger form of uniquness than simple string equality on all the
+imposes a stronger form of uniqueness than simple string equality on all the
 names that appear within the same scope.
 
 To determine whether two names (defined as sequences of [Unicode Scalar

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -80,7 +80,7 @@ package local:b {
 }
 ```
 
-It is worth noting that defining nested packages does not remove the need for the "root" package declaration above. These nested package definitions simply provide the contents of other packages inline so that they don't have to be otherwise resolved via the filesystem or a registry. 
+It is worth noting that defining nested packages does not remove the need for the "root" package declaration above. These nested package definitions simply provide the contents of other packages inline so that they don't have to be otherwise resolved via the filesystem or a registry.
 
 Package names are used to generate the [names of imports and exports]
 in the Component Model's representation of [`interface`s][interfaces] and
@@ -1055,7 +1055,7 @@ interface calc {
     }
 
     @since(version = 0.1.0)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 
@@ -1074,13 +1074,13 @@ interface calc {
     }
 
     @since(version = 0.1.0)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 
     /// By convention, feature flags should be prefixed with package name to reduce chance of collisions
     ///
     /// see: https://github.com/WebAssembly/WASI/blob/main/Contributing.md#filing-changes-to-existing-phase-3-proposals
     @unstable(feature = fgates-calc-minus)
-    sub: func(x: i32, y: i32) -> result<i32, calc-error>;
+    sub: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 
@@ -1103,10 +1103,10 @@ interface calc {
     }
 
     @since(version = 0.1.0)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 
     @since(version = 0.1.2)
-    sub: func(x: i32, y: i32) -> result<i32, calc-error>;
+    sub: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 
@@ -1129,10 +1129,10 @@ interface calc {
     }
 
     @since(version = 0.1.0)
-    add-one: func(x: i32) -> result<i32, calc-error>;
+    add-one: func(x: s32) -> result<s32, calc-error>;
 
     @since(version = 0.1.1)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 
@@ -1151,10 +1151,10 @@ interface calc {
     }
 
     @deprecated(version = 0.1.2)
-    add-one: func(x: i32) -> result<i32, calc-error>;
+    add-one: func(x: s32) -> result<s32, calc-error>;
 
     @since(version = 0.1.1)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 
@@ -1175,7 +1175,7 @@ interface calc {
     }
 
     @since(version = 0.1.1)
-    add: func(x: i32, y: i32) -> result<i32, calc-error>;
+    add: func(x: s32, y: s32) -> result<s32, calc-error>;
 }
 ```
 


### PR DESCRIPTION
https://component-model.bytecodealliance.org/design/wit.html#primitive-types

The WIT primitive types documentation references an `s32` rather than `i32`, while `i32` is present in WAT/WASM types specs I was unable to find one in WIT specs.