### PR TITLE
fix(docs): remove extra async from resource-method

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -80,7 +80,7 @@ package local:b {
 }
 ```
 
-It is worth noting that defining nested packages does not remove the need for the "root" package declaration above. These nested package definitions simply provide the contents of other packages inline so that they don't have to be otherwise resolved via the filesystem or a registry. 
+It is worth noting that defining nested packages does not remove the need for the "root" package declaration above. These nested package definitions simply provide the contents of other packages inline so that they don't have to be otherwise resolved via the filesystem or a registry.
 
 Package names are used to generate the [names of imports and exports]
 in the Component Model's representation of [`interface`s][interfaces] and
@@ -1540,7 +1540,7 @@ Specifically, the syntax for a `resource` definition is:
 resource-item ::= 'resource' id ';'
                 | 'resource' id '{' resource-method* '}'
 resource-method ::= func-item
-                  | id ':' 'static' 'async'? func-type ';'
+                  | id ':' 'static' func-type ';'
                   | 'constructor' param-list ';'
 ```
 


### PR DESCRIPTION
Resolves https://github.com/WebAssembly/component-model/issues/482 by removing extra `'async'?` from `resource-emthod` BNF definition
