### PR TITLE
Fix a grammar error

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -922,7 +922,7 @@ readability but this isn't required.
 Concretely, the structure of a `wit` file is:
 
 ```ebnf
-wit-file ::= package-decl? (package-items | nested-package-definition)*
+wit-file ::= (package-decl ';')? (package-items | nested-package-definition)*
 
 nested-package-definition ::= package-decl '{' package-items* '}'
 
@@ -1188,7 +1188,7 @@ WIT files optionally start with a package declaration which defines the name of
 the package.
 
 ```ebnf
-package-decl        ::= 'package' ( id ':' )+ id ( '/' id )* ('@' valid-semver)?  ';'
+package-decl        ::= 'package' ( id ':' )+ id ( '/' id )* ('@' valid-semver)?
 ```
 
 The production `valid-semver` is as defined by


### PR DESCRIPTION
In the existing situation, the package-decl **always** requires a semicolon at the end, which has some unexpected effects for nested package definitions:

**Incorrectly** considered **valid** according to the current grammar:

```
package foo:bar; {
  …
}
```

Note the semicolon between the package name and the curly braces.


**Incorrectly** considered **invalid** according to the current grammar:

```
package foo:bar {
  …
}
```

In order to fix this, this PR lifts the semicolon token out of the package-decl rule, into the wit-file rule.
