### PR TITLE
Update table max length

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -269,7 +269,7 @@ that are used in preference to growing the table. The free list is represented
 as a Python list here, but an optimizing implementation could instead store the
 free list in the free elements of `array`.
 
-The limit of `2**30` ensures that the high 2 bits of table indices are unset
+The limit of `2**28` ensures that the high 2 bits of table indices are unset
 and available for other use in guest code (e.g., for tagging, packed words or
 sentinel values).
 


### PR DESCRIPTION
The code says `2**28` but the prose says `2**30`.  I believe the former is the correct value?