### PR TITLE
Separately gate `error-context` from async

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -190,7 +190,7 @@ primvaltype   ::= 0x7f                                    => bool
                 | 0x75                                    => f64
                 | 0x74                                    => char
                 | 0x73                                    => string
-                | 0x64                                    => error-context 🔀
+                | 0x64                                    => error-context 📝
 defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x72 lt*:vec(<labelvaltype>)            => (record (field lt)*)    (if |lt*| > 0)
                 | 0x71 case*:vec(<case>)                  => (variant case+) (if |case*| > 0)
@@ -307,9 +307,9 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x19 t:<typeidx> async?:<async?>                    => (canon future.cancel-write async? (core func)) 🔀
            | 0x1a t:<typeidx>                                    => (canon future.close-readable t (core func)) 🔀
            | 0x1b t:<typeidx>                                    => (canon future.close-writable t (core func)) 🔀
-           | 0x1c opts:<opts>                                    => (canon error-context.new opts (core func)) 🔀
-           | 0x1d opts:<opts>                                    => (canon error-context.debug-message opts (core func)) 🔀
-           | 0x1e                                                => (canon error-context.drop (core func)) 🔀
+           | 0x1c opts:<opts>                                    => (canon error-context.new opts (core func)) 📝
+           | 0x1d opts:<opts>                                    => (canon error-context.debug-message opts (core func)) 📝
+           | 0x1e                                                => (canon error-context.drop (core func)) 📝
            | 0x1f                                                => (canon waitable-set.new (core func)) 🔀
            | 0x20 async?:<async>? m:<core:memidx>                => (canon waitable-set.wait async? (memory m) (core func)) 🔀
            | 0x21 async?:<async>? m:<core:memidx>                => (canon waitable-set.poll async? (memory m) (core func)) 🔀


### PR DESCRIPTION
This commit adds a new emoji-gate of 📝 to gate the `error-context` type separately from async. This additionally removes integration of `error-context` with built-in future/stream types where they can still be closed but are no longer closed with an optional error.

Closes #474
Closes #472
Closes #469