### PR TITLE
Limit context-local-storage length to 1 and add convention note

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -444,7 +444,7 @@ when threads are integrated, each `thread.spawn`ed thread would also get a
 fresh, zero-initialized `ContextLocalStorage`.)
 ```python
 class ContextLocalStorage:
-  LENGTH = 2
+  LENGTH = 1
   array: list[int]
 
   def __init__(self):
@@ -457,6 +457,9 @@ class ContextLocalStorage:
   def get(self, i):
     return self.array[i]
 ```
+`LENGTH` is currently set to `1`, but the plan is to increase it to `2` once
+toolchains are ready to migrate the linear-memory-stack pointer from a
+`global` to context-local storage as part of implementing threads.
 
 
 #### Task State

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -358,7 +358,7 @@ class WritableBufferGuestImpl(BufferGuestImpl, WritableBuffer):
 #### Context-Local Storage
 
 class ContextLocalStorage:
-  LENGTH = 2
+  LENGTH = 1
   array: list[int]
 
   def __init__(self):


### PR DESCRIPTION
This is intended to close #485 and subsume #491 based on updated discussion with @alexcrichton.