### PR TITLE
Document fixed-size-lists must be non-empty

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -275,6 +275,8 @@ Notes:
   to match the preceding `sort`.
 * (The `0x00` immediate of `case` may be reinterpreted in the future as the
   `none` case of an optional immediate.)
+* 🔧 for fixed-sized lists the length of the list must be larger than 0 to pass
+  validation.
 
 
 ## Canonical Definitions

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -672,7 +672,7 @@ and sequencing contained values.
 
 🔧 When the optional `<u32>` immediate of the `list` type constructor is present,
 the list has a fixed length and the representation of the list in memory is
-specialized to this length.
+specialized to this length. Note that the fixed length must be larger than 0.
 
 ##### Handle types
 


### PR DESCRIPTION
Currently the component model and WIT generally avoid zero-sized types since they're not always handled well in all languages. Given the niche use case of a zero-sized list add a validation rule that fixed-size-lists are non-zero in length.

Closes #503