### PR TITLE
Improve binary EBNF consistency

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -195,7 +195,7 @@ defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x72 lt*:vec(<labelvaltype>)            => (record (field lt)*)    (if |lt*| > 0)
                 | 0x71 case*:vec(<case>)                  => (variant case+) (if |case*| > 0)
                 | 0x70 t:<valtype>                        => (list t)
-                | 0x67 t:<valtype> len:<u32>              => (list t len) 🔧
+                | 0x67 t:<valtype> len:<u32>              => (list t len)  (if len > 0) 🔧
                 | 0x6f t*:vec(<valtype>)                  => (tuple t+)    (if |t*| > 0)
                 | 0x6e l*:vec(<label'>)                   => (flags l+)    (if 0 < |l*| <= 32)
                 | 0x6d l*:vec(<label'>)                   => (enum l+)     (if |l*| > 0)


### PR DESCRIPTION
Add inline non-zero length constraint to fixed-length list matching surrounding rules.

Followup to https://github.com/WebAssembly/component-model/pull/504