### PR TITLE
Add subtask.cancel/task.cancel built-ins

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -500,8 +500,8 @@ incremented so that the correct counter can be decremented.
 
 Once an async call has started, blocked and been added to the caller's table of
 waitables, the caller may decide that it no longer needs the results or effects
-of the subtask and **cancel** the subtask by calling the [`subtask.cancel`]
-built-in.
+of the subtask. In this case, the caller may **cancel** the subtask by calling
+the [`subtask.cancel`] built-in.
 
 Once cancellation is requested, since the subtask may have already racily
 returned a value, the caller may still receive a return value. However, the
@@ -531,16 +531,17 @@ Thus, the `subtask.cancel` built-in can block and works just like an import
 call in that it can be called synchronously or asynchronously.
 
 On the callee side of cancellation: when a caller requests cancellation via
-`subtask.cancel`, the callee receives a [`TASK_CANCELLED`] event (produced by
-one of the `waitable-set.{wait,poll}` or `yield` built-ins). Upon receiving
-notice of cancellation, the callee can call the [`task.cancel`] built-in to
-resolve the subtask without returning a value or the callee can call
-[`task.return`] as-if there were no cancellation. `task.cancel` doesn't take a
-value to return but does enforce the same [borrow](#borrows) rules as
-`task.return`. Ideally, a callee will `task.cancel` itself as soon as possible
-after receiving a `TASK_CANCELLED` event so that any caller waiting for the
-recovery of lent handles is unblocked ASAP. As with `task.return`, after
-calling `task.cancel`, a callee can continue executing before exiting the task.
+`subtask.cancel`, the callee receives a [`TASK_CANCELLED`] event (as produced
+by one of the `waitable-set.{wait,poll}` or `yield` built-ins or as received by
+the `callback` function). Upon receiving notice of cancellation, the callee can
+call the [`task.cancel`] built-in to resolve the subtask without returning a
+value. Alternatively, the callee can still call [`task.return`] as-if there
+were no cancellation. `task.cancel` doesn't take a value to return but does
+enforce the same [borrow](#borrows) rules as `task.return`. Ideally, a callee
+will `task.cancel` itself as soon as possible after receiving a
+`TASK_CANCELLED` event so that any caller waiting for the recovery of lent
+handles is unblocked ASAP. As with `task.return`, after calling `task.cancel`,
+a callee can continue executing before exiting the task.
 
 See the [`canon_subtask_cancel`] and [`canon_task_cancel`] functions in the
 Canonical ABI explainer for more details.

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -291,9 +291,11 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
            | 0x08                                                => (canon backpressure.set (core func)) 🔀
            | 0x09 rs:<resultlist> opts:<opts>                    => (canon task.return rs opts (core func)) 🔀
+           | 0x05                                                => (canon task.cancel (core func)) 🔀
            | 0x0a 0x7f i:<u32>                                   => (canon context.get i32 i (core func)) 🔀
            | 0x0b 0x7f i:<u32>                                   => (canon context.set i32 i (core func)) 🔀
            | 0x0c async?:<async>?                                => (canon yield async? (core func)) 🔀
+           | 0x06 async?:<async?>                                => (canon subtask.cancel async? (core func)) 🔀
            | 0x0d                                                => (canon subtask.drop (core func)) 🔀
            | 0x0e t:<typeidx>                                    => (canon stream.new t (core func)) 🔀
            | 0x0f t:<typeidx> opts:<opts>                        => (canon stream.read t opts (core func)) 🔀

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1743,17 +1743,18 @@ table and can be any type of waitable (`subtask` or
 
 ###### 🔀 `subtask.cancel`
 
-| Synopsis                   |                                                   |
-| -------------------------- | ------------------------------------------------- |
-| Approximate WIT signature  | `func(subtask: subtask) -> option<subtask-state>` |
-| Canonical ABI signature    | `[subtask:i32] -> [i32]`                          |
+| Synopsis                   |                                                           |
+| -------------------------- | --------------------------------------------------------- |
+| Approximate WIT signature  | `func<async?>(subtask: subtask) -> option<subtask-state>` |
+| Canonical ABI signature    | `[subtask:i32] -> [i32]`                                  |
 
 The `subtask.cancel` built-in requests [cancellation] of the indicated subtask.
-If `none` is returned (reprented as `-1` in the Canonical ABI), the subtask
-blocked before it was resolved. Otherwise, the subtask resolved synchronously
-and ended up in one of the 3 [resolved] states (`returned`,
-`cancelled-before-started` or `cancelled-before-returned`). (See also
-[`canon_subtask_cancel`] in the Canonical ABI explainer for details.)
+If the `async` is present, `none` is returned (reprented as `-1` in the
+Canonical ABI) to indicate that the subtask blocked before it was [resolved].
+Otherwise, `subtask.cancel` returns the `subtask-state` that the subtask
+resolved to (which is one of `returned`, `cancelled-before-started` or
+`cancelled-before-returned`). (See also [`canon_subtask_cancel`] in the
+Canonical ABI explainer for details.)
 
 ###### 🔀 `subtask.drop`
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1609,11 +1609,11 @@ ABI explainer.)
 
 The `task.cancel` built-in indicates that the [current task] is now [resolved]
 and has dropped all borrowed handles lent to it during the call (trapping if
-otherwise). `task.cancel` can only be called after `waitable-set.{wait,poll}`
-or `yield` has indicated that the supertask has requested cancellation and
-thus is not expecting a return value. (See also "[Cancellation]" in the async
-explainer and [`canon_task_cancel`] in the Canonical ABI explainer for
-details.)
+otherwise). `task.cancel` can only be called after the `TASK_CANCELLED` event
+has been received (via `callback`, `waitable-set.{wait,poll}` or `yield`) to
+indicate that the supertask has requested cancellation and thus is not
+expecting a return value. (See also "[Cancellation]" in the async explainer and
+[`canon_task_cancel`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `yield`
 


### PR DESCRIPTION
This PR adds the subtask.cancel/task.cancel built-ins as sketched in #495 to support subtask cancellation.  For a high-level summary, see the new "Cancellation" section added to Async.md in this PR.