### PR TITLE
Handle same-instance stream/future writes when element is empty

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -363,8 +363,8 @@ signalled by performing a `0`-length read or write (see the [Stream State]
 section in the Canonical ABI explainer for details).
 
 As a temporary limitation, if a `read` and `write` for a single stream or
-future occur from within the same component, there is a trap. In the future
-this limitation will be removed.
+future occur from within the same component and the element type is non-empty,
+there is a trap. In the future this limitation will be removed.
 
 The `T` element type of streams and futures is optional, such that `future` and
 `stream` can be written in WIT without a trailing `<T>`. In this case, the

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1362,7 +1362,8 @@ but in the opposite direction. Both are implemented by a single underlying
       self.set_pending(inst, buffer, on_partial_copy, on_copy_done)
       return 'blocked'
     else:
-      trap_if(inst is self.pending_inst) # temporary
+      assert(self.t == src.t == dst.t)
+      trap_if(inst is self.pending_inst and self.t is not None) # temporary
       if self.pending_buffer.remain() > 0:
         if buffer.remain() > 0:
           dst.write(src.read(min(src.remain(), dst.remain())))
@@ -1379,6 +1380,13 @@ but in the opposite direction. Both are implemented by a single underlying
         else:
           return 'done'
 ```
+Currently, there is a trap when both the `read` and `write` come from the same
+component instance and there is a non-empty element type. This trap will be
+removed in a subsequent release; the reason for the trap is that when lifting
+and lowering can alias the same memory, interleavings can be complex and must
+be handled carefully. Future improvements to the Canonical ABI ([lazy lowering])
+can greatly simplify this interleaving and be more practical to implement.
+
 The meaning of a `read` or `write` when the length is `0` is that the caller is
 querying the "readiness" of the other side. When a `0`-length read/write
 rendezvous with a non-`0`-length read/write, only the `0`-length read/write

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -810,7 +810,8 @@ class ReadableStreamGuestImpl(ReadableStream):
       self.set_pending(inst, buffer, on_partial_copy, on_copy_done)
       return 'blocked'
     else:
-      trap_if(inst is self.pending_inst) # temporary
+      assert(self.t == src.t == dst.t)
+      trap_if(inst is self.pending_inst and self.t is not None) # temporary
       if self.pending_buffer.remain() > 0:
         if buffer.remain() > 0:
           dst.write(src.read(min(src.remain(), dst.remain())))


### PR DESCRIPTION
As discussed in #475, as a temporary expediency, the CABI currently traps when trying to lift and lower in the same component instance to avoid the otherwise subtle ordering issues that arise with memory aliasing.  However, if the element type is empty (as enabled by #440), there is no such memory aliasing issue.  Moreover, such futures/streams can be used as a simple way to support #459 use cases without having to add anything fancier like the `wait-async` built-in suggested in #459.  Thus, this tiny PR loosens the same-instance trapping condition to only trap if there is a non-empty element type.