### PR TITLE
Change stream/future built-ins' typeidx to refer to full stream/future type

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3653,11 +3653,12 @@ async def canon_subtask_drop(task, i):
 
 For canonical definitions:
 ```wat
-(canon stream.new $t (core func $f))
-(canon future.new $t (core func $f))
+(canon stream.new $stream_t (core func $f))
+(canon future.new $future_t (core func $f))
 ```
 validation specifies:
 * `$f` is given type `(func (result i64))`
+* `$stream_t`/`$future_t` is a type of the form `(stream $t?)`/`(future $t?)`
 
 Calling `$f` calls `canon_{stream,future}_new` which adds two elements to the
 current component instance's `waitables` table and returns the indices packed
@@ -3668,16 +3669,16 @@ the readable end is subsequently transferred to another component (or the host)
 via `stream` or `future` parameter/result type (see `lift_{stream,future}`
 above).
 ```python
-async def canon_stream_new(elem_type, task):
+async def canon_stream_new(stream_t, task):
   trap_if(not task.inst.may_leave)
-  stream = ReadableStreamGuestImpl(elem_type)
+  stream = ReadableStreamGuestImpl(stream_t.t)
   ri = task.inst.waitables.add(ReadableStreamEnd(stream))
   wi = task.inst.waitables.add(WritableStreamEnd(stream))
   return [ ri | (wi << 32) ]
 
-async def canon_future_new(t, task):
+async def canon_future_new(future_t, task):
   trap_if(not task.inst.may_leave)
-  future = ReadableStreamGuestImpl(t)
+  future = ReadableStreamGuestImpl(future_t.t)
   ri = task.inst.waitables.add(ReadableFutureEnd(future))
   wi = task.inst.waitables.add(WritableFutureEnd(future))
   return [ ri | (wi << 32) ]
@@ -3692,45 +3693,49 @@ the future built-ins below.
 
 For canonical definitions:
 ```wat
-(canon stream.read $t $opts (core func $f))
-(canon stream.write $t $opts (core func $f))
+(canon stream.read $stream_t $opts (core func $f))
+(canon stream.write $stream_t $opts (core func $f))
 ```
 In addition to [general validation of `$opts`](#canonopt-validation) validation
 specifies:
 * `$f` is given type `(func (param i32 i32 i32) (result i32))`
-* [`lower($t)` above](#canonopt-validation) defines required options for `stream.write`
-* [`lift($t)` above](#canonopt-validation) defines required options for `stream.read`
-* `memory` is required to be present
+* `$stream_t` is a type of the form `(stream $t?)`
+* If `$t` is present:
+  * [`lower($t)` above](#canonopt-validation) defines required options for `stream.write`
+  * [`lift($t)` above](#canonopt-validation) defines required options for `stream.read`
+  * `memory` is required to be present
 
 For canonical definitions:
 ```wat
-(canon future.read $t $opts (core func $f))
-(canon future.write $t $opts (core func $f))
+(canon future.read $future_t $opts (core func $f))
+(canon future.write $future_t $opts (core func $f))
 ```
 validation specifies:
 * `$f` is given type `(func (param i32 i32) (result i32))`
-* [`lower($t)` above](#canonopt-validation) defines required options for `future.write`
-* [`lift($t)` above](#canonopt-validation) defines required options for `future.read`
-* `memory` is required to be present
+* `$future_t` is a type of the form `(future $t?)`
+* If `$t` is present:
+  * [`lower($t)` above](#canonopt-validation) defines required options for `future.write`
+  * [`lift($t)` above](#canonopt-validation) defines required options for `future.read`
+  * `memory` is required to be present
 
 The implementation of these four built-ins all funnel down to a single
 parameterized `copy` function:
 ```python
-async def canon_stream_read(t, opts, task, i, ptr, n):
+async def canon_stream_read(stream_t, opts, task, i, ptr, n):
   return await copy(ReadableStreamEnd, WritableBufferGuestImpl, EventCode.STREAM_READ,
-                    t, opts, task, i, ptr, n)
+                    stream_t, opts, task, i, ptr, n)
 
-async def canon_stream_write(t, opts, task, i, ptr, n):
+async def canon_stream_write(stream_t, opts, task, i, ptr, n):
   return await copy(WritableStreamEnd, ReadableBufferGuestImpl, EventCode.STREAM_WRITE,
-                    t, opts, task, i, ptr, n)
+                    stream_t, opts, task, i, ptr, n)
 
-async def canon_future_read(t, opts, task, i, ptr):
+async def canon_future_read(future_t, opts, task, i, ptr):
   return await copy(ReadableFutureEnd, WritableBufferGuestImpl, EventCode.FUTURE_READ,
-                    t, opts, task, i, ptr, 1)
+                    future_t, opts, task, i, ptr, 1)
 
-async def canon_future_write(t, opts, task, i, ptr):
+async def canon_future_write(future_t, opts, task, i, ptr):
   return await copy(WritableFutureEnd, ReadableBufferGuestImpl, EventCode.FUTURE_WRITE,
-                    t, opts, task, i, ptr, 1)
+                    future_t, opts, task, i, ptr, 1)
 ```
 
 Introducing the `copy` function in chunks, `copy` first checks that the
@@ -3740,15 +3745,15 @@ finite number of pipelined reads or writes.) Then a readable or writable buffer
 is created which (in `Buffer`'s constructor) eagerly checks the alignment and
 bounds of (`i`, `n`).
 ```python
-async def copy(EndT, BufferT, event_code, t, opts, task, i, ptr, n):
+async def copy(EndT, BufferT, event_code, stream_or_future_t, opts, task, i, ptr, n):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.get(i)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   trap_if(e.copying)
-  assert(not contains_borrow(t))
+  assert(not contains_borrow(stream_or_future_t))
   cx = LiftLowerContext(opts, task.inst, borrow_scope = None)
-  buffer = BufferT(t, cx, ptr, n)
+  buffer = BufferT(stream_or_future_t.t, cx, ptr, n)
 ```
 
 Next, in the synchronous case, `Task.wait_on` is used to synchronously and
@@ -3830,35 +3835,36 @@ the `read` or `write` and so this number is packed into the `i32` result.
 
 For canonical definitions:
 ```wat
-(canon stream.cancel-read $t $async? (core func $f))
-(canon stream.cancel-write $t $async? (core func $f))
-(canon future.cancel-read $t $async? (core func $f))
-(canon future.cancel-write $t $async? (core func $f))
+(canon stream.cancel-read $stream_t $async? (core func $f))
+(canon stream.cancel-write $stream_t $async? (core func $f))
+(canon future.cancel-read $future_t $async? (core func $f))
+(canon future.cancel-write $future_t $async? (core func $f))
 ```
 validation specifies:
 * `$f` is given type `(func (param i32) (result i32))`
+* `$stream_t`/`$future_t` is a type of the form `(stream $t?)`/`(future $t?)`
 * 🚝 - `async` is allowed (otherwise it must be `false`)
 
 The implementation of these four built-ins all funnel down to a single
 parameterized `cancel_copy` function:
 ```python
-async def canon_stream_cancel_read(t, sync, task, i):
-  return await cancel_copy(ReadableStreamEnd, EventCode.STREAM_READ, t, sync, task, i)
+async def canon_stream_cancel_read(stream_t, sync, task, i):
+  return await cancel_copy(ReadableStreamEnd, EventCode.STREAM_READ, stream_t, sync, task, i)
 
-async def canon_stream_cancel_write(t, sync, task, i):
-  return await cancel_copy(WritableStreamEnd, EventCode.STREAM_WRITE, t, sync, task, i)
+async def canon_stream_cancel_write(stream_t, sync, task, i):
+  return await cancel_copy(WritableStreamEnd, EventCode.STREAM_WRITE, stream_t, sync, task, i)
 
-async def canon_future_cancel_read(t, sync, task, i):
-  return await cancel_copy(ReadableFutureEnd, EventCode.FUTURE_READ, t, sync, task, i)
+async def canon_future_cancel_read(future_t, sync, task, i):
+  return await cancel_copy(ReadableFutureEnd, EventCode.FUTURE_READ, future_t, sync, task, i)
 
-async def canon_future_cancel_write(t, sync, task, i):
-  return await cancel_copy(WritableFutureEnd, EventCode.FUTURE_WRITE, t, sync, task, i)
+async def canon_future_cancel_write(future_t, sync, task, i):
+  return await cancel_copy(WritableFutureEnd, EventCode.FUTURE_WRITE, future_t, sync, task, i)
 
-async def cancel_copy(EndT, event_code, t, sync, task, i):
+async def cancel_copy(EndT, event_code, stream_or_future_t, sync, task, i):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.get(i)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   trap_if(not e.copying)
   if not e.has_pending_event():
     e.stream.cancel()
@@ -3897,36 +3903,37 @@ caller can assume that ownership of the buffer has been returned.
 
 For canonical definitions:
 ```wat
-(canon stream.close-readable $t (core func $f))
-(canon stream.close-writable $t (core func $f))
-(canon future.close-readable $t (core func $f))
-(canon future.close-writable $t (core func $f))
+(canon stream.close-readable $stream_t (core func $f))
+(canon stream.close-writable $stream_t (core func $f))
+(canon future.close-readable $future_t (core func $f))
+(canon future.close-writable $future_t (core func $f))
 ```
 validation specifies:
 * `$f` is given type `(func (param i32 i32))`
+* `$stream_t`/`$future_t` is a type of the form `(stream $t?)`/`(future $t?)`
 
 Calling `$f` removes the readable or writable end of the stream or future at
 the given index from the current component instance's `waitable` table,
 performing the guards and bookkeeping defined by
 `{Readable,Writable}{Stream,Future}End.drop()` above.
 ```python
-async def canon_stream_close_readable(t, task, i):
-  return await close(ReadableStreamEnd, t, task, i)
+async def canon_stream_close_readable(stream_t, task, i):
+  return await close(ReadableStreamEnd, stream_t, task, i)
 
-async def canon_stream_close_writable(t, task, hi):
-  return await close(WritableStreamEnd, t, task, hi)
+async def canon_stream_close_writable(stream_t, task, hi):
+  return await close(WritableStreamEnd, stream_t, task, hi)
 
-async def canon_future_close_readable(t, task, i):
-  return await close(ReadableFutureEnd, t, task, i)
+async def canon_future_close_readable(future_t, task, i):
+  return await close(ReadableFutureEnd, future_t, task, i)
 
-async def canon_future_close_writable(t, task, hi):
-  return await close(WritableFutureEnd, t, task, hi)
+async def canon_future_close_writable(future_t, task, hi):
+  return await close(WritableFutureEnd, future_t, task, hi)
 
-async def close(EndT, t, task, hi):
+async def close(EndT, stream_or_future_t, task, hi):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.remove(hi)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   e.drop()
   return []
 ```

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -2136,47 +2136,47 @@ async def canon_subtask_drop(task, i):
 
 ### 🔀 `canon {stream,future}.new`
 
-async def canon_stream_new(elem_type, task):
+async def canon_stream_new(stream_t, task):
   trap_if(not task.inst.may_leave)
-  stream = ReadableStreamGuestImpl(elem_type)
+  stream = ReadableStreamGuestImpl(stream_t.t)
   ri = task.inst.waitables.add(ReadableStreamEnd(stream))
   wi = task.inst.waitables.add(WritableStreamEnd(stream))
   return [ ri | (wi << 32) ]
 
-async def canon_future_new(t, task):
+async def canon_future_new(future_t, task):
   trap_if(not task.inst.may_leave)
-  future = ReadableStreamGuestImpl(t)
+  future = ReadableStreamGuestImpl(future_t.t)
   ri = task.inst.waitables.add(ReadableFutureEnd(future))
   wi = task.inst.waitables.add(WritableFutureEnd(future))
   return [ ri | (wi << 32) ]
 
 ### 🔀 `canon {stream,future}.{read,write}`
 
-async def canon_stream_read(t, opts, task, i, ptr, n):
+async def canon_stream_read(stream_t, opts, task, i, ptr, n):
   return await copy(ReadableStreamEnd, WritableBufferGuestImpl, EventCode.STREAM_READ,
-                    t, opts, task, i, ptr, n)
+                    stream_t, opts, task, i, ptr, n)
 
-async def canon_stream_write(t, opts, task, i, ptr, n):
+async def canon_stream_write(stream_t, opts, task, i, ptr, n):
   return await copy(WritableStreamEnd, ReadableBufferGuestImpl, EventCode.STREAM_WRITE,
-                    t, opts, task, i, ptr, n)
+                    stream_t, opts, task, i, ptr, n)
 
-async def canon_future_read(t, opts, task, i, ptr):
+async def canon_future_read(future_t, opts, task, i, ptr):
   return await copy(ReadableFutureEnd, WritableBufferGuestImpl, EventCode.FUTURE_READ,
-                    t, opts, task, i, ptr, 1)
+                    future_t, opts, task, i, ptr, 1)
 
-async def canon_future_write(t, opts, task, i, ptr):
+async def canon_future_write(future_t, opts, task, i, ptr):
   return await copy(WritableFutureEnd, ReadableBufferGuestImpl, EventCode.FUTURE_WRITE,
-                    t, opts, task, i, ptr, 1)
+                    future_t, opts, task, i, ptr, 1)
 
-async def copy(EndT, BufferT, event_code, t, opts, task, i, ptr, n):
+async def copy(EndT, BufferT, event_code, stream_or_future_t, opts, task, i, ptr, n):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.get(i)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   trap_if(e.copying)
-  assert(not contains_borrow(t))
+  assert(not contains_borrow(stream_or_future_t))
   cx = LiftLowerContext(opts, task.inst, borrow_scope = None)
-  buffer = BufferT(t, cx, ptr, n)
+  buffer = BufferT(stream_or_future_t.t, cx, ptr, n)
   if opts.sync:
     final_revoke_buffer = None
     def on_partial_copy(revoke_buffer, why = 'completed'):
@@ -2225,23 +2225,23 @@ def pack_copy_result(task, e, buffer, why):
 
 ### 🔀 `canon {stream,future}.cancel-{read,write}`
 
-async def canon_stream_cancel_read(t, sync, task, i):
-  return await cancel_copy(ReadableStreamEnd, EventCode.STREAM_READ, t, sync, task, i)
+async def canon_stream_cancel_read(stream_t, sync, task, i):
+  return await cancel_copy(ReadableStreamEnd, EventCode.STREAM_READ, stream_t, sync, task, i)
 
-async def canon_stream_cancel_write(t, sync, task, i):
-  return await cancel_copy(WritableStreamEnd, EventCode.STREAM_WRITE, t, sync, task, i)
+async def canon_stream_cancel_write(stream_t, sync, task, i):
+  return await cancel_copy(WritableStreamEnd, EventCode.STREAM_WRITE, stream_t, sync, task, i)
 
-async def canon_future_cancel_read(t, sync, task, i):
-  return await cancel_copy(ReadableFutureEnd, EventCode.FUTURE_READ, t, sync, task, i)
+async def canon_future_cancel_read(future_t, sync, task, i):
+  return await cancel_copy(ReadableFutureEnd, EventCode.FUTURE_READ, future_t, sync, task, i)
 
-async def canon_future_cancel_write(t, sync, task, i):
-  return await cancel_copy(WritableFutureEnd, EventCode.FUTURE_WRITE, t, sync, task, i)
+async def canon_future_cancel_write(future_t, sync, task, i):
+  return await cancel_copy(WritableFutureEnd, EventCode.FUTURE_WRITE, future_t, sync, task, i)
 
-async def cancel_copy(EndT, event_code, t, sync, task, i):
+async def cancel_copy(EndT, event_code, stream_or_future_t, sync, task, i):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.get(i)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   trap_if(not e.copying)
   if not e.has_pending_event():
     e.stream.cancel()
@@ -2256,23 +2256,23 @@ async def cancel_copy(EndT, event_code, t, sync, task, i):
 
 ### 🔀 `canon {stream,future}.close-{readable,writable}`
 
-async def canon_stream_close_readable(t, task, i):
-  return await close(ReadableStreamEnd, t, task, i)
+async def canon_stream_close_readable(stream_t, task, i):
+  return await close(ReadableStreamEnd, stream_t, task, i)
 
-async def canon_stream_close_writable(t, task, hi):
-  return await close(WritableStreamEnd, t, task, hi)
+async def canon_stream_close_writable(stream_t, task, hi):
+  return await close(WritableStreamEnd, stream_t, task, hi)
 
-async def canon_future_close_readable(t, task, i):
-  return await close(ReadableFutureEnd, t, task, i)
+async def canon_future_close_readable(future_t, task, i):
+  return await close(ReadableFutureEnd, future_t, task, i)
 
-async def canon_future_close_writable(t, task, hi):
-  return await close(WritableFutureEnd, t, task, hi)
+async def canon_future_close_writable(future_t, task, hi):
+  return await close(WritableFutureEnd, future_t, task, hi)
 
-async def close(EndT, t, task, hi):
+async def close(EndT, stream_or_future_t, task, hi):
   trap_if(not task.inst.may_leave)
   e = task.inst.waitables.remove(hi)
   trap_if(not isinstance(e, EndT))
-  trap_if(e.stream.t != t)
+  trap_if(e.stream.t != stream_or_future_t.t)
   e.drop()
   return []
 

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -1156,48 +1156,48 @@ async def test_eager_stream_completion():
     assert(len(args) == 1)
     rsi1 = args[0]
     assert(rsi1 == 1)
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi2,wsi2 = unpack_new_ends(packed)
     [] = await canon_task_return(task, [StreamType(U8Type())], opts, [rsi2])
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi1, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi1, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
     assert(mem[0:4] == b'\x01\x02\x03\x04')
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi3,wsi3 = unpack_new_ends(packed)
     retp = 12
     await asyncio.sleep(0)
     [ret] = await canon_lower(opts, ft, host_import, task, [rsi3, retp])
     assert(ret == 0)
     rsi4 = mem[retp]
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi3, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi3, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
     await asyncio.sleep(0)
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi4, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi4, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi2, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi2, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi1, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi1, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.CLOSED)
     assert(mem[0:4] == b'\x05\x06\x07\x08')
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi3, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi3, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
     await asyncio.sleep(0)
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi4, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi4, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi2, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi2, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi1)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi4)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi2)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi3)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi1)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi4)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi2)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi3)
     return []
 
   await canon_lift(opts, inst, ft, core_func, None, on_start, on_resolve, host_on_block)
@@ -1245,10 +1245,10 @@ async def test_async_stream_ops():
   async def core_func(task, args):
     [rsi1] = args
     assert(rsi1 == 1)
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi2,wsi2 = unpack_new_ends(packed)
     [] = await canon_task_return(task, [StreamType(U8Type())], opts, [rsi2])
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi1, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi1, 0, 4)
     assert(ret == definitions.BLOCKED)
     src_stream.write([1,2,3,4])
     retp = 16
@@ -1261,13 +1261,13 @@ async def test_async_stream_ops():
     result,n = unpack_result(mem[retp+4])
     assert(n == 4 and result == definitions.COMPLETED)
     assert(mem[0:4] == b'\x01\x02\x03\x04')
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi3,wsi3 = unpack_new_ends(packed)
     [ret] = await canon_lower(opts, ft, host_import, task, [rsi3, retp])
     assert(ret == 0)
     rsi4 = mem[16]
     assert(rsi4 == 2)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi3, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi3, 0, 4)
     assert(ret == definitions.BLOCKED)
     host_import_incoming.set_remain(100)
     [] = await canon_waitable_join(task, wsi3, seti)
@@ -1276,10 +1276,10 @@ async def test_async_stream_ops():
     assert(mem[retp+0] == wsi3)
     result,n = unpack_result(mem[retp+4])
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_read(U8Type(), sync_opts, task, rsi4, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), sync_opts, task, rsi4, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi2, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi2, 0, 4)
     assert(ret == definitions.BLOCKED)
     dst_stream.set_remain(100)
     [] = await canon_waitable_join(task, wsi2, seti)
@@ -1290,16 +1290,16 @@ async def test_async_stream_ops():
     assert(n == 4 and result == definitions.COMPLETED)
     src_stream.write([5,6,7,8])
     src_stream.destroy_once_empty()
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi1, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi1, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.CLOSED)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi1)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi1)
     assert(mem[0:4] == b'\x05\x06\x07\x08')
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi3, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi3, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi3)
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi4, 0, 4)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi3)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi4, 0, 4)
     assert(ret == definitions.BLOCKED)
     [] = await canon_waitable_join(task, rsi4, seti)
     [event] = await canon_waitable_set_wait(False, mem, task, seti, retp)
@@ -1307,13 +1307,13 @@ async def test_async_stream_ops():
     assert(mem[retp+0] == rsi4)
     result,n = unpack_result(mem[retp+4])
     assert(n == 4 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_read(U8Type(), sync_opts, task, rsi4, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), sync_opts, task, rsi4, 0, 4)
     assert(ret == definitions.CLOSED)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi4)
-    [ret] = await canon_stream_write(U8Type(), sync_opts, task, wsi2, 0, 4)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), sync_opts, task, wsi2, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 4 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi2)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi2)
     [] = await canon_waitable_set_drop(task, seti)
     return []
 
@@ -1359,11 +1359,11 @@ async def test_receive_own_stream():
 
   async def core_func(task, args):
     assert(len(args) == 0)
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi,wsi = unpack_new_ends(packed)
     assert(rsi == 1)
     assert(wsi == 2)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi, 0, 4)
     assert(ret == definitions.BLOCKED)
     retp = 8
     [ret] = await canon_lower(opts, host_ft, host_import, task, [rsi, retp])
@@ -1371,10 +1371,10 @@ async def test_receive_own_stream():
     rsi2 = int.from_bytes(mem[retp : retp+4], 'little', signed=False)
     assert(rsi2 == 1)
     try:
-      await canon_stream_cancel_write(U8Type(), True, task, wsi)
+      await canon_stream_cancel_write(StreamType(U8Type()), True, task, wsi)
     except Trap:
       pass
-    [] = await canon_stream_close_writable(U8Type(), task, wsi)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi)
     return []
 
   def on_start(): return []
@@ -1408,15 +1408,15 @@ async def test_host_partial_reads_writes():
     assert(ret == 0)
     rsi = mem[retp]
     assert(rsi == 1)
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
     assert(mem[0:2] == b'\x01\x02')
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi, 0, 4)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
     assert(mem[0:2] == b'\x03\x04')
-    [ret] = await canon_stream_read(U8Type(), opts, task, rsi, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts, task, rsi, 0, 4)
     assert(ret == definitions.BLOCKED)
     src.write([5,6])
 
@@ -1427,19 +1427,19 @@ async def test_host_partial_reads_writes():
     assert(mem[retp+0] == rsi)
     result,n = unpack_result(mem[retp+4])
     assert(n == 2 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi)
 
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi,wsi = unpack_new_ends(packed)
     assert(rsi == 1)
     assert(wsi == 2)
     [ret] = await canon_lower(opts, sink_ft, host_sink, task, [rsi])
     assert(ret == 0)
     mem[0:6] = b'\x01\x02\x03\x04\x05\x06'
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi, 0, 6)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi, 0, 6)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(U8Type(), opts, task, wsi, 2, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts, task, wsi, 2, 4)
     assert(ret == definitions.BLOCKED)
     dst.set_remain(4)
     [] = await canon_waitable_join(task, wsi, seti)
@@ -1449,7 +1449,7 @@ async def test_host_partial_reads_writes():
     result,n = unpack_result(mem[retp+4])
     assert(n == 4 and result == definitions.COMPLETED)
     assert(dst.received == [1,2,3,4,5,6])
-    [] = await canon_stream_close_writable(U8Type(), task, wsi)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi)
     [] = await canon_waitable_set_drop(task, seti)
     dst.set_remain(100)
     assert(await dst.consume(100) is None)
@@ -1472,24 +1472,24 @@ async def test_wasm_to_wasm_stream():
   ft1 = FuncType([], [StreamType(U8Type())])
   async def core_func1(task, args):
     assert(not args)
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi,wsi = unpack_new_ends(packed)
     [] = await canon_task_return(task, [StreamType(U8Type())], opts1, [rsi])
 
     await task.on_block(fut1)
 
     mem1[0:4] = b'\x01\x02\x03\x04'
-    [ret] = await canon_stream_write(U8Type(), opts1, task, wsi, 0, 2)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts1, task, wsi, 0, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(U8Type(), opts1, task, wsi, 2, 2)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts1, task, wsi, 2, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
 
     await task.on_block(fut2)
 
     mem1[0:8] = b'\x05\x06\x07\x08\x09\x0a\x0b\x0c'
-    [ret] = await canon_stream_write(U8Type(), opts1, task, wsi, 0, 8)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts1, task, wsi, 0, 8)
     assert(ret == definitions.BLOCKED)
 
     fut3.set_result(None)
@@ -1503,7 +1503,7 @@ async def test_wasm_to_wasm_stream():
     result,n = unpack_result(mem1[retp+4])
     assert(n == 4 and result == definitions.COMPLETED)
 
-    [ret] = await canon_stream_write(U8Type(), opts1, task, wsi, 12345, 0)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts1, task, wsi, 12345, 0)
     assert(ret == definitions.BLOCKED)
 
     fut4.set_result(None)
@@ -1513,11 +1513,11 @@ async def test_wasm_to_wasm_stream():
     assert(mem1[retp+0] == wsi)
     assert(mem1[retp+4] == 0)
 
-    [ret] = await canon_stream_write(U8Type(), opts1, task, wsi, 12345, 0)
+    [ret] = await canon_stream_write(StreamType(U8Type()), opts1, task, wsi, 12345, 0)
     assert(ret == 0)
 
     [errctxi] = await canon_error_context_new(opts1, task, 0, 0)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi)
     [] = await canon_waitable_set_drop(task, seti)
     [] = await canon_error_context_drop(task, errctxi)
     return []
@@ -1539,7 +1539,7 @@ async def test_wasm_to_wasm_stream():
     rsi = mem2[retp]
     assert(rsi == 1)
 
-    [ret] = await canon_stream_read(U8Type(), opts2, task, rsi, 0, 8)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts2, task, rsi, 0, 8)
     assert(ret == definitions.BLOCKED)
 
     fut1.set_result(None)
@@ -1556,22 +1556,22 @@ async def test_wasm_to_wasm_stream():
     fut2.set_result(None)
     await task.on_block(fut3)
 
-    [ret] = await canon_stream_read(U8Type(), opts2, task, rsi, 12345, 0)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts2, task, rsi, 12345, 0)
     assert(ret == 0)
 
     mem2[0:8] = bytes(8)
-    [ret] = await canon_stream_read(U8Type(), opts2, task, rsi, 0, 2)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts2, task, rsi, 0, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
     assert(mem2[0:6] == b'\x05\x06\x00\x00\x00\x00')
-    [ret] = await canon_stream_read(U8Type(), opts2, task, rsi, 2, 2)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts2, task, rsi, 2, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
     assert(mem2[0:6] == b'\x05\x06\x07\x08\x00\x00')
 
     await task.on_block(fut4)
 
-    [ret] = await canon_stream_read(U8Type(), opts2, task, rsi, 12345, 0)
+    [ret] = await canon_stream_read(StreamType(U8Type()), opts2, task, rsi, 12345, 0)
     assert(ret == definitions.BLOCKED)
 
     [event] = await canon_waitable_set_wait(False, mem2, task, seti, retp)
@@ -1581,7 +1581,7 @@ async def test_wasm_to_wasm_stream():
     errctxi = 1
     assert(p2 == (definitions.CLOSED | errctxi))
 
-    [] = await canon_stream_close_readable(U8Type(), task, rsi)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi)
     [] = await canon_waitable_set_drop(task, seti)
     return []
 
@@ -1597,22 +1597,22 @@ async def test_wasm_to_wasm_stream_empty():
   ft1 = FuncType([], [StreamType(None)])
   async def core_func1(task, args):
     assert(not args)
-    [packed] = await canon_stream_new(None, task)
+    [packed] = await canon_stream_new(StreamType(None), task)
     rsi,wsi = unpack_new_ends(packed)
     [] = await canon_task_return(task, [StreamType(None)], opts1, [rsi])
 
     await task.on_block(fut1)
 
-    [ret] = await canon_stream_write(None, opts1, task, wsi, 10000, 2)
+    [ret] = await canon_stream_write(StreamType(None), opts1, task, wsi, 10000, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_write(None, opts1, task, wsi, 10000, 2)
+    [ret] = await canon_stream_write(StreamType(None), opts1, task, wsi, 10000, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
 
     await task.on_block(fut2)
 
-    [ret] = await canon_stream_write(None, opts1, task, wsi, 0, 8)
+    [ret] = await canon_stream_write(StreamType(None), opts1, task, wsi, 0, 8)
     assert(ret == definitions.BLOCKED)
 
     fut3.set_result(None)
@@ -1629,7 +1629,7 @@ async def test_wasm_to_wasm_stream_empty():
     fut4.set_result(None)
 
     [errctxi] = await canon_error_context_new(opts1, task, 0, 0)
-    [] = await canon_stream_close_writable(None, task, wsi)
+    [] = await canon_stream_close_writable(StreamType(None), task, wsi)
     [] = await canon_error_context_drop(task, errctxi)
     return []
 
@@ -1650,7 +1650,7 @@ async def test_wasm_to_wasm_stream_empty():
     rsi = mem2[0]
     assert(rsi == 1)
 
-    [ret] = await canon_stream_read(None, opts2, task, rsi, 0, 8)
+    [ret] = await canon_stream_read(StreamType(None), opts2, task, rsi, 0, 8)
     assert(ret == definitions.BLOCKED)
 
     fut1.set_result(None)
@@ -1666,19 +1666,19 @@ async def test_wasm_to_wasm_stream_empty():
     fut2.set_result(None)
     await task.on_block(fut3)
 
-    [ret] = await canon_stream_read(None, opts2, task, rsi, 1000000, 2)
+    [ret] = await canon_stream_read(StreamType(None), opts2, task, rsi, 1000000, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [ret] = await canon_stream_read(None, opts2, task, rsi, 1000000, 2)
+    [ret] = await canon_stream_read(StreamType(None), opts2, task, rsi, 1000000, 2)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
 
     await task.on_block(fut4)
 
-    [ret] = await canon_stream_read(None, opts2, task, rsi, 1000000, 2)
+    [ret] = await canon_stream_read(StreamType(None), opts2, task, rsi, 1000000, 2)
     result,n = unpack_result(ret)
     assert(n == 0 and result == definitions.CLOSED)
-    [] = await canon_stream_close_readable(None, task, rsi)
+    [] = await canon_stream_close_readable(StreamType(None), task, rsi)
     return []
 
   await canon_lift(opts2, inst2, ft2, core_func2, None, lambda:[], lambda _:(), host_on_block)
@@ -1709,37 +1709,37 @@ async def test_cancel_copy():
   async def core_func(task, args):
     assert(not args)
 
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi,wsi = unpack_new_ends(packed)
     [ret] = await canon_lower(lower_opts, host_ft1, host_func1, task, [rsi])
     assert(ret == 0)
     mem[0:4] = b'\x0a\x0b\x0c\x0d'
-    [ret] = await canon_stream_write(U8Type(), lower_opts, task, wsi, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), lower_opts, task, wsi, 0, 4)
     assert(ret == definitions.BLOCKED)
     host_sink.set_remain(2)
     got = await host_sink.consume(2)
     assert(got == [0xa, 0xb])
-    [ret] = await canon_stream_cancel_write(U8Type(), True, task, wsi)
+    [ret] = await canon_stream_cancel_write(StreamType(U8Type()), True, task, wsi)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi)
     host_sink.set_remain(100)
     assert(await host_sink.consume(100) is None)
 
-    [packed] = await canon_stream_new(U8Type(), task)
+    [packed] = await canon_stream_new(StreamType(U8Type()), task)
     rsi,wsi = unpack_new_ends(packed)
     [ret] = await canon_lower(lower_opts, host_ft1, host_func1, task, [rsi])
     assert(ret == 0)
     mem[0:4] = b'\x01\x02\x03\x04'
-    [ret] = await canon_stream_write(U8Type(), lower_opts, task, wsi, 0, 4)
+    [ret] = await canon_stream_write(StreamType(U8Type()), lower_opts, task, wsi, 0, 4)
     assert(ret == definitions.BLOCKED)
     host_sink.set_remain(2)
     got = await host_sink.consume(2)
     assert(got == [1, 2])
-    [ret] = await canon_stream_cancel_write(U8Type(), False, task, wsi)
+    [ret] = await canon_stream_cancel_write(StreamType(U8Type()), False, task, wsi)
     result,n = unpack_result(ret)
     assert(n == 2 and result == definitions.COMPLETED)
-    [] = await canon_stream_close_writable(U8Type(), task, wsi)
+    [] = await canon_stream_close_writable(StreamType(U8Type()), task, wsi)
     host_sink.set_remain(100)
     assert(await host_sink.consume(100) is None)
 
@@ -1747,20 +1747,20 @@ async def test_cancel_copy():
     [ret] = await canon_lower(lower_opts, host_ft2, host_func2, task, [retp])
     assert(ret == 0)
     rsi = mem[retp]
-    [ret] = await canon_stream_read(U8Type(), lower_opts, task, rsi, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), lower_opts, task, rsi, 0, 4)
     assert(ret == definitions.BLOCKED)
-    [ret] = await canon_stream_cancel_read(U8Type(), True, task, rsi)
+    [ret] = await canon_stream_cancel_read(StreamType(U8Type()), True, task, rsi)
     result,n = unpack_result(ret)
     assert(n == 0 and result == definitions.CANCELLED)
-    [] = await canon_stream_close_readable(U8Type(), task, rsi)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi)
 
     [ret] = await canon_lower(lower_opts, host_ft2, host_func2, task, [retp])
     assert(ret == 0)
     rsi = mem[retp]
-    [ret] = await canon_stream_read(U8Type(), lower_opts, task, rsi, 0, 4)
+    [ret] = await canon_stream_read(StreamType(U8Type()), lower_opts, task, rsi, 0, 4)
     assert(ret == definitions.BLOCKED)
     host_source.eager_cancel = False
-    [ret] = await canon_stream_cancel_read(U8Type(), False, task, rsi)
+    [ret] = await canon_stream_cancel_read(StreamType(U8Type()), False, task, rsi)
     assert(ret == definitions.BLOCKED)
     host_source.write([7,8])
     await asyncio.sleep(0)
@@ -1772,7 +1772,7 @@ async def test_cancel_copy():
     result,n = unpack_result(mem[retp+4])
     assert(n == 2 and result == definitions.CANCELLED)
     assert(mem[0:2] == b'\x07\x08')
-    [] = await canon_stream_close_readable(U8Type(), task, rsi)
+    [] = await canon_stream_close_readable(StreamType(U8Type()), task, rsi)
     [] = await canon_waitable_set_drop(task, seti)
 
     return []
@@ -1859,7 +1859,7 @@ async def test_futures():
   lift_opts = mk_opts()
   async def core_func(task, args):
     assert(not args)
-    [packed] = await canon_future_new(U8Type(), task)
+    [packed] = await canon_future_new(FutureType(U8Type()), task)
     rfi,wfi = unpack_new_ends(packed)
     retp = 16
     [ret] = await canon_lower(lower_opts, host_ft1, host_func, task, [rfi, retp])
@@ -1867,12 +1867,12 @@ async def test_futures():
     rfi = mem[retp]
 
     readp = 0
-    [ret] = await canon_future_read(U8Type(), lower_opts, task, rfi, readp)
+    [ret] = await canon_future_read(FutureType(U8Type()), lower_opts, task, rfi, readp)
     assert(ret == definitions.BLOCKED)
 
     writep = 8
     mem[writep] = 42
-    [ret] = await canon_future_write(U8Type(), lower_opts, task, wfi, writep)
+    [ret] = await canon_future_write(FutureType(U8Type()), lower_opts, task, wfi, writep)
     result,n = unpack_result(ret)
     assert(n == 1 and result == definitions.CLOSED)
 
@@ -1885,36 +1885,36 @@ async def test_futures():
     assert(n == 1 and result == definitions.CLOSED)
     assert(mem[readp] == 43)
 
-    [] = await canon_future_close_writable(U8Type(), task, wfi)
-    [] = await canon_future_close_readable(U8Type(), task, rfi)
+    [] = await canon_future_close_writable(FutureType(U8Type()), task, wfi)
+    [] = await canon_future_close_readable(FutureType(U8Type()), task, rfi)
     [] = await canon_waitable_set_drop(task, seti)
 
-    [packed] = await canon_future_new(U8Type(), task)
+    [packed] = await canon_future_new(FutureType(U8Type()), task)
     rfi,wfi = unpack_new_ends(packed)
     [ret] = await canon_lower(lower_opts, host_ft1, host_func, task, [rfi, retp])
     assert(ret == 0)
     rfi = mem[retp]
 
     readp = 0
-    [ret] = await canon_future_read(U8Type(), lower_opts, task, rfi, readp)
+    [ret] = await canon_future_read(FutureType(U8Type()), lower_opts, task, rfi, readp)
     assert(ret == definitions.BLOCKED)
 
     writep = 8
     mem[writep] = 42
-    [ret] = await canon_future_write(U8Type(), lower_opts, task, wfi, writep)
+    [ret] = await canon_future_write(FutureType(U8Type()), lower_opts, task, wfi, writep)
     result,n = unpack_result(ret)
     assert(n == 1 and result == definitions.CLOSED)
 
     while not task.inst.waitables.get(rfi).stream.closed():
       await task.yield_(sync = False)
 
-    [ret] = await canon_future_cancel_read(U8Type(), True, task, rfi)
+    [ret] = await canon_future_cancel_read(FutureType(U8Type()), True, task, rfi)
     result,n = unpack_result(ret)
     assert(n == 1 and result == definitions.CLOSED)
     assert(mem[readp] == 43)
 
-    [] = await canon_future_close_writable(U8Type(), task, wfi)
-    [] = await canon_future_close_readable(U8Type(), task, rfi)
+    [] = await canon_future_close_writable(FutureType(U8Type()), task, wfi)
+    [] = await canon_future_close_readable(FutureType(U8Type()), task, rfi)
 
     return []
 


### PR DESCRIPTION
As discussed in #508, this PR changes the interpretation of the `typeidx` immediate of the stream/future built-ins from referring to the type of the *element* to the compound `stream`/`future` type, which addresses the issues described in https://github.com/WebAssembly/component-model/pull/508#issuecomment-2840528865 and also matches the current implementation.