### PR TITLE
CABI: Remove the zero-index special case for callback return value

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -906,7 +906,11 @@ not externally-visible behavior.
     (func (export "cb") (param $event i32) (param $p1 i32) (param $p2 i32)
       ...
       if (result i32)         ;; if subtasks remain:
-        i32.const 2           ;; return WAIT
+        (i32.or               ;; return (WAIT | ($wsi << 4))
+          (i32.const 2)
+          (i32.shl
+            (global.get $wsi)
+            (i32.const 4)))
       else                    ;; if no subtasks remain:
         ...
         call $task_return     ;; return the string result (pointer,length)


### PR DESCRIPTION
This PR removes a small optimization in the callback event loop which allowed the returned waitable-set index to be `0` (in which case the previous waitable-set was used).  As is, there is no consideration for what happens if you `waitable-set.drop` the waitable-set in the interim, and adding rules to fix it seems to add more trouble than this small optimization is worth.  Since `0` will always trap, we can always re-add this in the future if there were perf data suggesting it.