### PR TITLE
Extend number of flat parameters in async lower from 1 to 4

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -625,8 +625,8 @@ Given these imported WIT functions (using the fixed-length-list feature 🔧):
 world w {
   import foo: func(s: string) -> u32;
   import bar: func(s: string) -> string;
-  import baz: func(t: tuple<u64; 5>) -> string;
-  import quux: func(t: tuple<u32; 17>) -> string;
+  import baz: func(t: list<u64; 5>) -> string;
+  import quux: func(t: list<u32; 17>) -> string;
 }
 ```
 the default/synchronous lowered import function signatures are:

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -2466,6 +2466,8 @@ def flatten_functype(opts, ft, context):
   else:
     match context:
       case 'lift':
+        if len(flat_params) > MAX_FLAT_PARAMS:
+          flat_params = ['i32']
         if opts.callback:
           flat_results = ['i32']
         else:

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -2446,6 +2446,7 @@ stack), passing in an `i32` pointer as an parameter instead of returning an
 Given all this, the top-level definition of `flatten_functype` is:
 ```python
 MAX_FLAT_PARAMS = 16
+MAX_FLAT_ASYNC_PARAMS = 4
 MAX_FLAT_RESULTS = 1
 
 def flatten_functype(opts, ft, context):
@@ -2470,7 +2471,7 @@ def flatten_functype(opts, ft, context):
         else:
           flat_results = []
       case 'lower':
-        if len(flat_params) > 1:
+        if len(flat_params) > MAX_FLAT_ASYNC_PARAMS:
           flat_params = ['i32']
         if len(flat_results) > 0:
           flat_params += ['i32']
@@ -3124,7 +3125,7 @@ always returns control flow back to the caller without blocking:
 ```python
   def on_start():
     on_progress()
-    return lift_flat_values(cx, 1, flat_args, ft.param_types())
+    return lift_flat_values(cx, MAX_FLAT_ASYNC_PARAMS, flat_args, ft.param_types())
 
   def on_resolve(results):
     on_progress()

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -1521,6 +1521,7 @@ def lower_async_value(ReadableEndT, cx, v, t):
 ### Flattening
 
 MAX_FLAT_PARAMS = 16
+MAX_FLAT_ASYNC_PARAMS = 4
 MAX_FLAT_RESULTS = 1
 
 def flatten_functype(opts, ft, context):
@@ -1545,7 +1546,7 @@ def flatten_functype(opts, ft, context):
         else:
           flat_results = []
       case 'lower':
-        if len(flat_params) > 1:
+        if len(flat_params) > MAX_FLAT_ASYNC_PARAMS:
           flat_params = ['i32']
         if len(flat_results) > 0:
           flat_params += ['i32']
@@ -1932,7 +1933,7 @@ async def canon_lower(opts, ft, callee, task, flat_args):
 
   def on_start():
     on_progress()
-    return lift_flat_values(cx, 1, flat_args, ft.param_types())
+    return lift_flat_values(cx, MAX_FLAT_ASYNC_PARAMS, flat_args, ft.param_types())
 
   def on_resolve(results):
     on_progress()

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -1541,6 +1541,8 @@ def flatten_functype(opts, ft, context):
   else:
     match context:
       case 'lift':
+        if len(flat_params) > MAX_FLAT_PARAMS:
+          flat_params = ['i32']
         if opts.callback:
           flat_results = ['i32']
         else:

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,14 @@ This directory contains Component Model reference tests, grouped by functionalit
 
 ## Running in Wasmtime
 
+All tests currently run and (except temporarily while spec changes are rolling out)
+pass using the [`dev` release of `wasip3-prototyping`](https://github.com/bytecodealliance/wasip3-prototyping/releases/tag/dev).
+
 A single `.wast` test can be run via:
 ```
 wasmtime wast -W component-model-async=y the-test.wast
+```
+All the tests can be run from this directory via:
+```
+find . -name "*.wast" | xargs wasmtime-p3 wast -W component-model-async=y
 ```

--- a/test/async/async-calls-sync.wast
+++ b/test/async/async-calls-sync.wast
@@ -119,8 +119,8 @@
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "unblock" (func $unblock))
-      (import "" "sync-func1" (func $sync-func1 (param i32 i32) (result i32)))
-      (import "" "sync-func2" (func $sync-func2 (param i32 i32) (result i32)))
+      (import "" "sync-func1" (func $sync-func1 (param i32) (result i32)))
+      (import "" "sync-func2" (func $sync-func2 (param i32) (result i32)))
 
       (global $ws (mut i32) (i32.const 0))
       (func $start (global.set $ws (call $waitable-set.new)))
@@ -134,22 +134,22 @@
         ;; call 'sync-func1' and 'sync-func2' asynchronously, both of which will block
         ;; (on $AsyncInner.blocking-call). because 'sync-func1/2' are in different instances,
         ;; both calls will reach the STARTED state.
-        (local.set $ret (call $sync-func1 (i32.const 0xdeadbeef) (i32.const 8)))
+        (local.set $ret (call $sync-func1 (i32.const 8)))
         (if (i32.ne (i32.const 0x21 (; STARTED=1 | (subtask=2 << 4) ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (i32.const 2) (global.get $ws))
-        (local.set $ret (call $sync-func2 (i32.const 0xdeadbeef) (i32.const 12)))
+        (local.set $ret (call $sync-func2 (i32.const 12)))
         (if (i32.ne (i32.const 0x31 (; STARTED=1 | (subtask=3 << 4) ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (i32.const 3) (global.get $ws))
 
         ;; now start another pair of 'sync-func1/2' calls, both of which should see auto
         ;; backpressure and get stuck in the STARTING state.
-        (local.set $ret (call $sync-func1 (i32.const 0xdeadbeef) (i32.const 16)))
+        (local.set $ret (call $sync-func1 (i32.const 16)))
         (if (i32.ne (i32.const 0x40 (; STARTING=0 | (subtask=4 << 4) ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (i32.const 4) (global.get $ws))
-        (local.set $ret (call $sync-func2 (i32.const 0xdeadbeef) (i32.const 20)))
+        (local.set $ret (call $sync-func2 (i32.const 20)))
         (if (i32.ne (i32.const 0x50 (; STARTING=0 | (subtask=5 << 4) ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (i32.const 5) (global.get $ws))

--- a/test/async/cancel-subtask.wast
+++ b/test/async/cancel-subtask.wast
@@ -59,7 +59,7 @@
       (import "" "mem" (memory 1))
       (import "" "subtask.cancel" (func $subtask.cancel (param i32) (result i32)))
       (import "" "subtask.drop" (func $subtask.drop (param i32)))
-      (import "" "f" (func $f (param i32 i32) (result i32)))
+      (import "" "f" (func $f (param i32) (result i32)))
 
       (func $run (export "run") (result i32)
         (local $ret i32) (local $retp i32)
@@ -69,7 +69,7 @@
         ;; call 'f'; it should block
         (local.set $retp (i32.const 4))
         (i32.store (local.get $retp) (i32.const 0xbad0bad0))
-        (local.set $ret (call $f (i32.const 0xdeadbeef) (local.get $retp)))
+        (local.set $ret (call $f (local.get $retp)))
         (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
           (then unreachable))
         (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))

--- a/test/async/deadlock.wast
+++ b/test/async/deadlock.wast
@@ -40,11 +40,11 @@
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
-      (import "" "f" (func $f (param i32 i32) (result i32)))
+      (import "" "f" (func $f (param i32) (result i32)))
 
       (func (export "g") (result i32)
         (local $ws i32) (local $ret i32) (local $subtaski i32)
-        (local.set $ret (call $f (i32.const 0) (i32.const 0)))
+        (local.set $ret (call $f (i32.const 0)))
         (local.set $subtaski (i32.shr_u (local.get $ret) (i32.const 4)))
         (local.set $ws (call $waitable-set.new))
         (call $waitable.join (local.get $subtaski) (local.get $ws))

--- a/test/async/drop-subtask.wast
+++ b/test/async/drop-subtask.wast
@@ -62,14 +62,14 @@
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
-      (import "" "loop" (func $loop (param i32 i32) (result i32)))
+      (import "" "loop" (func $loop (result i32)))
       (import "" "return" (func $return))
 
       (func $drop-after-return (export "drop-after-return") (result i32)
         (local $ret i32) (local $ws i32) (local $subtask i32)
 
         ;; start 'loop'
-        (local.set $ret (call $loop (i32.const 0xdead) (i32.const 0xbeef)))
+        (local.set $ret (call $loop))
         (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
           (then unreachable))
         (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))

--- a/test/async/drop-waitable-set.wast
+++ b/test/async/drop-waitable-set.wast
@@ -51,14 +51,14 @@
     (core instance $memory (instantiate $Memory))
     (core module $Core
       (import "" "mem" (memory 1))
-      (import "" "wait-on-set" (func $wait-on-set (param i32 i32) (result i32)))
+      (import "" "wait-on-set" (func $wait-on-set (result i32)))
       (import "" "drop-while-waiting" (func $drop-while-waiting))
       (func $run (export "run") (result i32)
         (local $ret i32)
 
         ;; start an async call to 'wait-on-set' which blocks, waiting on a
         ;; waitable-set.
-        (local.set $ret (call $wait-on-set (i32.const 0xdeadbeef) (i32.const 0xdeadbeef)))
+        (local.set $ret (call $wait-on-set))
         (if (i32.ne (i32.const 0x11) (local.get $ret))
           (then unreachable))
 

--- a/test/async/empty-wait.wast
+++ b/test/async/empty-wait.wast
@@ -126,8 +126,8 @@
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
       (import "" "subtask.drop" (func $subtask.drop (param i32)))
-      (import "" "blocker" (func $blocker (param i32 i32) (result i32)))
-      (import "" "unblocker" (func $unblocker (param i32 i32) (result i32)))
+      (import "" "blocker" (func $blocker (param i32) (result i32)))
+      (import "" "unblocker" (func $unblocker (param i32) (result i32)))
 
       (global $ws (mut i32) (i32.const 0))
       (func $start (global.set $ws (call $waitable-set.new)))
@@ -140,7 +140,7 @@
 
         ;; call 'blocker'; it should block
         (local.set $retp1 (i32.const 4))
-        (local.set $ret (call $blocker (i32.const 0xdeadbeef) (local.get $retp1)))
+        (local.set $ret (call $blocker (local.get $retp1)))
         (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
           (then unreachable))
         (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))
@@ -149,7 +149,7 @@
 
         ;; call 'unblocker' to unblock 'blocker'; it should complete eagerly
         (local.set $retp2 (i32.const 8))
-        (local.set $ret (call $unblocker (i32.const 0xbeefdead) (local.get $retp2)))
+        (local.set $ret (call $unblocker (local.get $retp2)))
         (if (i32.ne (i32.const 2 (; RETURNED ;)) (local.get $ret))
           (then unreachable))
         (if (i32.ne (i32.const 43) (i32.load (local.get $retp2)))

--- a/test/async/partial-stream-copies.wast
+++ b/test/async/partial-stream-copies.wast
@@ -145,7 +145,7 @@
       (import "" "transform" (func $transform (param i32 i32) (result i32)))
 
       (func $run (export "run") (result i32)
-        (local $ret i32) (local $ret64 i64) (local $paramp i32) (local $retp i32)
+        (local $ret i32) (local $ret64 i64) (local $retp i32)
         (local $insr i32) (local $insw i32) (local $outsr i32)
         (local $subtask i32) (local $event_code i32) (local $index i32) (local $payload i32)
         (local $ws i32)
@@ -160,10 +160,8 @@
           (then unreachable))
 
         ;; call 'transform' which will return a readable stream $outsr eagerly
-        (local.set $paramp (i32.const 4))
         (local.set $retp (i32.const 8))
-        (i32.store (local.get $paramp) (local.get $insr))
-        (local.set $ret (call $transform (local.get $paramp) (local.get $retp)))
+        (local.set $ret (call $transform (local.get $insr) (local.get $retp)))
         (if (i32.ne (i32.const 2 (; RETURNED=2 | (0<<4) ;)) (local.get $ret))
           (then unreachable))
         (local.set $outsr (i32.load (local.get $retp)))

--- a/test/async/trap-on-reenter.wast
+++ b/test/async/trap-on-reenter.wast
@@ -24,12 +24,12 @@
     (core instance $memory (instantiate $Memory))
 
     (core module $CoreChild
-      (import "" "a" (func $a (param i32 i32) (result i32)))
+      (import "" "a" (func $a (result i32)))
       (func (export "b") (result i32)
         (i32.const 1 (; YIELD ;))
       )
       (func (export "b-cb") (param i32 i32 i32) (result i32)
-        (call $a (i32.const 0xdeadbeef) (i32.const 0xdeadbeef))
+        (call $a)
         unreachable
       )
     )
@@ -45,12 +45,12 @@
   (instance $child (instantiate $Child (with "a" (func $a))))
 
   (core module $CoreOuter
-    (import "" "b" (func $b (param i32 i32) (result i32)))
+    (import "" "b" (func $b (result i32)))
     (func $c (export "c") (result i32)
       (i32.const 1 (; YIELD ;))
     )
     (func $c-cb (export "c-cb") (param i32 i32 i32) (result i32)
-      (call $b (i32.const 0xdeadbeef) (i32.const 0xdeadbeef))
+      (call $b)
     )
   )
   (canon lower (func $child "b") async (memory $core_inner "mem") (core func $b))


### PR DESCRIPTION
As suggested in #434, this PR increases the number of flattened parameters allow in async-lowered calls from 1 to 4.  (This is different than the `MAX_FLAT_ARGS` of 16 for sync-lowered calls because runtimes will likely need to reserve space for the flat argument tuple in an inline fixed-size "subtask" structure.)

For consistency, it would also make sense to change `future.write` to take flattened arguments, but this is a larger change (at least in the spec text) since futures are defined as specialized streams which work in terms of buffers, so I was thinking of breaking that out into a separate PR.