### PR TITLE
fix: output types of Task.yield_

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -933,7 +933,7 @@ external I/O. This is emulated in the Python code below by waiting on an
 immediately-resolved future, which calls the `OnBlock` callback, which allows
 control flow to switch to other `asyncio.Task`s.
 ```python
-  async def yield_(self, sync) -> bool:
+  async def yield_(self, sync) -> EventTuple:
     if self.state == Task.State.PENDING_CANCEL:
       self.state = Task.State.CANCEL_DELIVERED
       return (EventCode.TASK_CANCELLED, 0, 0)

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -587,7 +587,7 @@ class Task:
       waitable_set.num_waiting -= 1
     return e
 
-  async def yield_(self, sync) -> bool:
+  async def yield_(self, sync) -> EventTuple:
     if self.state == Task.State.PENDING_CANCEL:
       self.state = Task.State.CANCEL_DELIVERED
       return (EventCode.TASK_CANCELLED, 0, 0)


### PR DESCRIPTION
Small change for the python type bindings -- it seems `Task.yield_` is written such that it *has* to return an actual event tuple (not even an option of one).