### PR TITLE
Disallow `post-return` from calling imports, allow blocking import calls even when `callback` is used

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -333,7 +333,6 @@ canonopt ::= 0x00                                                => string-encod
            | 0x05 f:<core:funcidx>                               => (post-return f)
            | 0x06                                                => async 🔀
            | 0x07 f:<core:funcidx>                               => (callback f) 🔀
-           | 0x08                                                => always-task-return 🔀
 ```
 Notes:
 * The second `0x00` byte in `canon` stands for the `func` sort and thus the

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1268,7 +1268,6 @@ canonopt ::= string-encoding=utf8
            | (post-return <core:funcidx>)
            | async 🔀
            | (callback <core:funcidx>) 🔀
-           | always-task-return 🔀
 ```
 While the production `externdesc` accepts any `sort`, the validation rules
 for `canon lift` would only allow the `func` sort. In the future, other sorts
@@ -1325,13 +1324,6 @@ validated to have the following core function type:
       (result $done i32))
 ```
 Again, see the [async explainer] for more details.
-
-🔀 The `always-task-return` option may only be present in `canon lift` when
-`post-return` is not set and specifies that even synchronously-lifted functions
-will call `canon task.return` to return their results instead of returning
-them as core function results. This is a simpler alternative to `post-return`
-for freeing memory after lifting and thus `post-return` may be deprecated in
-the future.
 
 Based on this description of the AST, the [Canonical ABI explainer] gives a
 detailed walkthrough of the static and dynamic semantics of `lift` and `lower`.


### PR DESCRIPTION
This PR disallows calling imports during `post-return` which means that sync-to-sync calls never require a fiber (noting that, if `post-return` can call imports, it can block after returning-to-and-unblocking the synchronous caller, thereby requiring a fiber to continue asynchronous execution in the callee), preserving the intended cost model of synchronous calls.

This implies that `post-return` will stick around instead of getting deprecated and removed in the future, thereby removing the reason for having the (as yet unimplemented) `always-task-return` `canonopt`.  Note that, with only a bit more work, a synchronous export that wants to use `task.return` could always lift `async` (no `callback`) and use `backpressure.set` to achieve serialized execution.

The PR also relaxes a few of the traps that prevent certain blocking calls from being used in conjunction with `callback`.  These traps were intended to avoid the need for fibers in some cases, but based on implementation experience, we think they'll be too strict and prevent various realistic scenarios where an unaware transitive dependency does a little unexpected blocking.  Notes and TODOs are added to Async.md explaining this more.