### PR TITLE
fix: add ReadableStream write fn

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -1279,11 +1279,12 @@ OnCopyDone = Callable[[CopyResult], None]
 class ReadableStream:
   t: ValType
   read: Callable[[ComponentInstance, WritableBuffer, OnCopy, OnCopyDone], None]
+  write: Callable[[ComponentInstance, WritableBuffer, OnCopy, OnCopyDone], None]
   cancel: Callable[[], None]
   drop: Callable[[], None]
 ```
 The key operation is `read` which works as follows:
-* `read` never blocks and returns its values by either synchronously or
+* `read` and `write` never block and return values by either synchronously or
   asynchronously writing to the given `WritableBuffer` and then calling the
   given `OnCopy*` callbacks to notify the caller of progress.
 * `OnCopyDone` is called to indicate that the `read` is finished copying and

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -764,6 +764,7 @@ OnCopyDone = Callable[[CopyResult], None]
 class ReadableStream:
   t: ValType
   read: Callable[[ComponentInstance, WritableBuffer, OnCopy, OnCopyDone], None]
+  write: Callable[[ComponentInstance, WritableBuffer, OnCopy, OnCopyDone], None]
   cancel: Callable[[], None]
   drop: Callable[[], None]
 


### PR DESCRIPTION
`ReadableStream.write` appeared to be missing from the docs -- it should work near identically to `read` (except for internal implementation of course), but wasn't called out.