### PR TITLE
chore: rename revoke_buffer to reclaim_buffer

### DIFF
--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -1088,8 +1088,8 @@ class HostSink:
     async def read_all():
       while True:
         await self.write_event.wait()
-        def on_copy(revoke_buffer):
-          revoke_buffer()
+        def on_copy(reclaim_buffer):
+          reclaim_buffer()
           if not f.done():
             f.set_result(None)
         def on_copy_done(result):


### PR DESCRIPTION
This commit renames `revoke_buffer` which is used during stream copying to `reclaim_buffer` which hopefully better conveys (if only slightly) the handoff/change in ownership of the buffer in use.