### PR TITLE
Add more documentation for `stream.{read,write}`.

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3897,7 +3897,7 @@ ownership of `buffer` and prevent any further partial reads/writes. Thus, up
 until event delivery, the other end of the stream is free to repeatedly
 read/write from/to `buffer`, ideally filling it up and minimizing context
 switches. Next, `copying` is cleared to reenable future `stream.{read,write}`
-calls. However, if the `CopyResult` is `DROPPED`, `dropped` is set to disallow
+calls. However, if the `CopyResult` is `DROPPED`, `done` is set to disallow
 all future use of this stream end. Lastly, `stream_event` packs the
 `CopyResult` and number of elements copied up until this point into a single
 `i32` payload for core wasm.


### PR DESCRIPTION
Notably:

 - Document what stream.{read,write} do after a `copy-result.dropped`, similar to what is documented for future.{read,write}.

 - Document that `copy-result.dropped` does not signify an error.

 - Reword "the only valid next operation is" to "anything subsequent operation [...] traps" to avoid confusion about what "valid" means in this context.

 - Say "single-element" instead of "length-1" so that it doesn't risk scanning as "length minus one".