### PR TITLE
Document `future-read-result.cancelled`'s Canonical ABI encoding.

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1899,7 +1899,9 @@ In the Canonical ABI, the `{readable,writable}-future-end` is passed as an
 `i32` describing the linear memory offset of the
 `{readable,writable}-buffer<T; 1>`. The `option<future-{read,write}-result>`
 return value is bit-packed into the single `i32` return value where
-`0xffff_ffff` represents `none`.
+`0xffff_ffff` represents `none`. And, `future-read-result.canceled` is encoded
+as the value of `future-write-result.canceled`, rather than the value implied
+by the `enum` definition above.
 
 (See [`canon_future_read`] in the Canonical ABI explainer for details.)
 


### PR DESCRIPTION
In the Canonical ABI, `future-read-result` has the same encoding as `future-write-result`, even though the `enum`s defined in the documentation have `cancelled` at different indices. Add a sentence to the documentation mentioning this.