### PR TITLE
Don't deliver cancellation to sync wait/poll/yield

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1615,14 +1615,17 @@ expecting a return value. (See also "[Cancellation]" in the async explainer and
 | Canonical ABI signature    | `[] -> [i32]`            |
 
 The `yield` built-in allows the runtime to switch to other tasks, enabling a
-long-running computation to cooperatively interleave execution. `yield` returns
-`true` (`1`) if the caller has requested [cancellation] of the [current task].
+long-running computation to cooperatively interleave execution. If the `async`
+immediate is present, the runtime can switch to other tasks in the *same*
+component instance, which the calling core wasm must be prepared to handle. If
+`async` is not present, only tasks in *other* component instances may be
+switched to.
 
-If the `async` immediate is present, the runtime can switch to other tasks in
-the *same* component instance, which the calling core wasm must be prepared to
-handle. If `async` is not present, only tasks in *other* component instances
-may be switched to. (See also [`canon_yield`] in the Canonical ABI explainer
-for details.)
+If `async` is set, `yield` can return `true` (`1`) if the caller has
+requested [cancellation] of the [current task]. If `async` is not set,
+`yield` will always return `false` (`0`).
+
+(See also [`canon_yield`] in the Canonical ABI explainer for details.)
 
 ###### 🔀 `waitable-set.new`
 
@@ -1682,6 +1685,11 @@ state (the meanings of which are described by the [async explainer]).
 The meanings of the `{stream,future}-{read,write}` events/payloads are given as
 part [`stream.read` and `stream.write`](#-streamread-and-streamwrite) and
 [`future.read` and `future.write`](#-futureread-and-futurewrite) below.
+
+If the `async` immediate is set, `waitable-set.wait` can return the
+`task-cancelled` event to indicate that the caller requested [cancellation] of
+the [current task]. If `async` is not set, `task-cancelled` will never be
+delivered.
 
 In the Canonical ABI, the `event-code` return value provides the `event`
 discriminant and the case payloads are stored as two contiguous `i32`s at the

--- a/test/async/cancel-subtask.wast
+++ b/test/async/cancel-subtask.wast
@@ -9,8 +9,10 @@
     (core module $CM
       (import "" "mem" (memory 1))
       (import "" "task.cancel" (func $task.cancel))
+      (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
 
       ;; $ws is waited on by 'f'
       (global $ws (mut i32) (i32.const 0))
@@ -34,24 +36,53 @@
         (call $task.cancel)
         (i32.const 0 (; EXIT ;))
       )
+
+      (func $g (export "g") (param $futr i32) (result i32)
+        (local $ret i32)
+        (local $event_code i32)
+
+        ;; perform a future.read which will block, waiting for the caller to write
+        (local.set $ret (call $future.read (local.get $futr) (i32.const 0xdeadbeef)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+        (call $waitable.join (local.get $futr) (global.get $ws))
+
+        ;; wait on $ws synchronously, don't expect cancellation
+        (local.set $event_code (call $waitable-set.wait (global.get $ws) (i32.const 0)))
+        (if (i32.ne (i32.const 4 (; FUTURE_READ ;)) (local.get $event_code))
+          (then unreachable))
+
+        ;; finish returning a value
+        (i32.const 42)
+      )
     )
+    (type $FT (future))
     (canon task.cancel (core func $task.cancel))
+    (canon future.read $FT async (memory $memory "mem") (core func $future.read))
     (canon waitable.join (core func $waitable.join))
     (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory $memory "mem") (core func $waitable-set.wait))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.cancel" (func $task.cancel))
+      (export "future.read" (func $future.read))
       (export "waitable.join" (func $waitable.join))
       (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
     ))))
     (func (export "f") (result u32) (canon lift
       (core func $cm "f")
       async (callback (func $cm "f_cb"))
     ))
+    (func (export "g") (param "fut" $FT) (result u32) (canon lift
+      (core func $cm "g")
+    ))
   )
 
   (component $D
+    (type $FT (future))
     (import "f" (func $f (result u32)))
+    (import "g" (func $g (param "fut" $FT) (result u32)))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))
@@ -59,12 +90,21 @@
       (import "" "mem" (memory 1))
       (import "" "subtask.cancel" (func $subtask.cancel (param i32) (result i32)))
       (import "" "subtask.drop" (func $subtask.drop (param i32)))
+      (import "" "future.new" (func $future.new (result i64)))
+      (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
       (import "" "f" (func $f (param i32) (result i32)))
+      (import "" "g" (func $g (param i32 i32) (result i32)))
 
       (func $run (export "run") (result i32)
-        (local $ret i32) (local $retp i32)
+        (local $ret i32) (local $ret64 i64)
+        (local $retp i32) (local $retp1 i32) (local $retp2 i32)
         (local $subtask i32)
         (local $event_code i32)
+        (local $futr i32) (local $futw i32)
+        (local $ws i32)
 
         ;; call 'f'; it should block
         (local.set $retp (i32.const 4))
@@ -85,24 +125,77 @@
 
         (call $subtask.drop (local.get $subtask))
 
+        ;; create future that g will wait on
+        (local.set $ret64 (call $future.new))
+        (local.set $futr (i32.wrap_i64 (local.get $ret64)))
+        (local.set $futw (i32.wrap_i64 (i64.shr_u (local.get $ret64) (i64.const 32))))
+
+        ;; call 'g'; it should block
+        (local.set $retp1 (i32.const 4))
+        (local.set $retp2 (i32.const 8))
+        (i32.store (local.get $retp1) (i32.const 0xbad0bad0))
+        (i32.store (local.get $retp2) (i32.const 0xbad0bad0))
+        (local.set $ret (call $g (local.get $futr) (local.get $retp1)))
+        (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
+          (then unreachable))
+        (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))
+
+        ;; cancel 'g'; it should block
+        (local.set $ret (call $subtask.cancel (local.get $subtask)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; future.write, unblocking 'g'
+        (local.set $ret (call $future.write (local.get $futw) (i32.const 0xdeadbeef)))
+        (if (i32.ne (i32.const 0 (; COMPLETED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; wait to see 'g' finish and check its return value
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $subtask) (local.get $ws))
+        (local.set $event_code (call $waitable-set.wait (local.get $ws) (local.get $retp2)))
+        (if (i32.ne (i32.const 1 (; SUBTASK ;)) (local.get $event_code))
+          (then unreachable))
+        (if (i32.ne (local.get $subtask) (i32.load (local.get $retp2)))
+          (then unreachable))
+        (if (i32.ne (i32.const 2 (; RETURNED=2 | (0<<4) ;)) (i32.load offset=4 (local.get $retp2)))
+          (then unreachable))
+        (if (i32.ne (i32.const 42) (i32.load (local.get $retp1)))
+          (then unreachable))
+
         ;; return to the top-level assert_return
         (i32.const 42)
       )
     )
     (canon subtask.cancel (core func $subtask.cancel))
     (canon subtask.drop (core func $subtask.drop))
+    (canon future.new $FT (core func $future.new))
+    (canon future.write $FT async (memory $memory "mem") (core func $future.write))
+    (canon waitable.join (core func $waitable.join))
+    (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory $memory "mem") (core func $waitable-set.wait))
     (canon lower (func $f) async (memory $memory "mem") (core func $f'))
+    (canon lower (func $g) async (memory $memory "mem") (core func $g'))
     (core instance $dm (instantiate $DM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "subtask.cancel" (func $subtask.cancel))
       (export "subtask.drop" (func $subtask.drop))
+      (export "future.new" (func $future.new))
+      (export "future.write" (func $future.write))
+      (export "waitable.join" (func $waitable.join))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
       (export "f" (func $f'))
+      (export "g" (func $g'))
     ))))
     (func (export "run") (result u32) (canon lift (core func $dm "run")))
   )
 
   (instance $c (instantiate $C))
-  (instance $d (instantiate $D (with "f" (func $c "f"))))
+  (instance $d (instantiate $D
+    (with "f" (func $c "f"))
+    (with "g" (func $c "g"))
+  ))
   (func (export "run") (alias export $d "run"))
 )
 (assert_return (invoke "run") (u32.const 42))


### PR DESCRIPTION
Currently, if a caller tries to cancel an async callee while the callee is in the middle of executing a synchronous call to `subtask.cancel` or `{stream,future}.{,cancel-}{read,write}`, the synchronous call completes normally and the request-for-cancellation is recorded in the task's state, to be delivered at the next turn of the `callback` event loop or `async` `waitable-set.{poll,wait}` or `yield` (which are required to expect and handle "cancelled" as a result).  The reason for this is that these synchronous calls may happen in the middle of some library/dependency that isn't aware of async or connected to the caller's async runtime and thus doesn't know what to do with being "cancelled", leading to the notification being dropped on the floor instead of propagated to the async runtime.  However, synchronous calls to `yield` or `waitable-set.{poll,wait}` *may* return cancellation (if the caller cancels).  But it seems like these synchronous calls are in the same boat as the other synchronous calls and thus the "dropped on the floor" hazard is the same.

To fix this, this PR changes synchronous `yield` and `waitable-set.{poll,wait}` to have the same non-cancellable behavior as the other synchronous calls mentioned above.  The PR also adds a `.wast` test for this new behavior.