### PR TITLE
Replace 'sync' with 'cancellable' in wait/poll/yield

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -295,7 +295,7 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x05                                                => (canon task.cancel (core func)) 🔀
            | 0x0a 0x7f i:<u32>                                   => (canon context.get i32 i (core func)) 🔀
            | 0x0b 0x7f i:<u32>                                   => (canon context.set i32 i (core func)) 🔀
-           | 0x0c async?:<async>?                                => (canon yield async? (core func)) 🔀
+           | 0x0c cancel?:<cancel?>                              => (canon yield cancel? (core func)) 🔀
            | 0x06 async?:<async?>                                => (canon subtask.cancel async? (core func)) 🔀
            | 0x0d                                                => (canon subtask.drop (core func)) 🔀
            | 0x0e t:<typeidx>                                    => (canon stream.new t (core func)) 🔀
@@ -316,8 +316,8 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x1d opts:<opts>                                    => (canon error-context.debug-message opts (core func)) 📝
            | 0x1e                                                => (canon error-context.drop (core func)) 📝
            | 0x1f                                                => (canon waitable-set.new (core func)) 🔀
-           | 0x20 async?:<async>? m:<core:memidx>                => (canon waitable-set.wait async? (memory m) (core func)) 🔀
-           | 0x21 async?:<async>? m:<core:memidx>                => (canon waitable-set.poll async? (memory m) (core func)) 🔀
+           | 0x20 cancel?:<cancel?> m:<core:memidx>              => (canon waitable-set.wait cancel? (memory m) (core func)) 🔀
+           | 0x21 cancel?:<cancel?> m:<core:memidx>              => (canon waitable-set.poll cancel? (memory m) (core func)) 🔀
            | 0x22                                                => (canon waitable-set.drop (core func)) 🔀
            | 0x23                                                => (canon waitable.join (core func)) 🔀
            | 0x40 ft:<typeidx>                                   => (canon thread.spawn_ref ft (core func)) 🧵
@@ -325,6 +325,8 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x42                                                => (canon thread.available_parallelism (core func)) 🧵
 async?   ::= 0x00                                                =>
            | 0x01                                                => async
+cancel?  ::= 0x00                                                =>
+           | 0x01                                                => cancellable 🚟
 opts     ::= opt*:vec(<canonopt>)                                => opt*
 canonopt ::= 0x00                                                => string-encoding=utf8
            | 0x01                                                => string-encoding=utf16
@@ -505,6 +507,8 @@ named once.
 * The `0x00` variant of `importname'` and `exportname'` will be removed. Any
   remaining variant(s) will be renumbered or the prefix byte will be removed or
   repurposed.
+* Most built-ins should have a `<canonopt>*` immediate instead of an ad hoc
+  subset of `canonopt`s.
 
 
 [`core:byte`]: https://webassembly.github.io/spec/core/binary/values.html#binary-byte

--- a/test/async/cancel-subtask.wast
+++ b/test/async/cancel-subtask.wast
@@ -9,8 +9,10 @@
     (core module $CM
       (import "" "mem" (memory 1))
       (import "" "task.cancel" (func $task.cancel))
+      (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
 
       ;; $ws is waited on by 'f'
       (global $ws (mut i32) (i32.const 0))
@@ -34,24 +36,53 @@
         (call $task.cancel)
         (i32.const 0 (; EXIT ;))
       )
+
+      (func $g (export "g") (param $futr i32) (result i32)
+        (local $ret i32)
+        (local $event_code i32)
+
+        ;; perform a future.read which will block, waiting for the caller to write
+        (local.set $ret (call $future.read (local.get $futr) (i32.const 0xdeadbeef)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+        (call $waitable.join (local.get $futr) (global.get $ws))
+
+        ;; wait on $ws synchronously, don't expect cancellation
+        (local.set $event_code (call $waitable-set.wait (global.get $ws) (i32.const 0)))
+        (if (i32.ne (i32.const 4 (; FUTURE_READ ;)) (local.get $event_code))
+          (then unreachable))
+
+        ;; finish returning a value
+        (i32.const 42)
+      )
     )
+    (type $FT (future))
     (canon task.cancel (core func $task.cancel))
+    (canon future.read $FT async (memory $memory "mem") (core func $future.read))
     (canon waitable.join (core func $waitable.join))
     (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory $memory "mem") (core func $waitable-set.wait))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.cancel" (func $task.cancel))
+      (export "future.read" (func $future.read))
       (export "waitable.join" (func $waitable.join))
       (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
     ))))
     (func (export "f") (result u32) (canon lift
       (core func $cm "f")
       async (callback (func $cm "f_cb"))
     ))
+    (func (export "g") (param "fut" $FT) (result u32) (canon lift
+      (core func $cm "g")
+    ))
   )
 
   (component $D
+    (type $FT (future))
     (import "f" (func $f (result u32)))
+    (import "g" (func $g (param "fut" $FT) (result u32)))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))
@@ -59,12 +90,21 @@
       (import "" "mem" (memory 1))
       (import "" "subtask.cancel" (func $subtask.cancel (param i32) (result i32)))
       (import "" "subtask.drop" (func $subtask.drop (param i32)))
+      (import "" "future.new" (func $future.new (result i64)))
+      (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
       (import "" "f" (func $f (param i32) (result i32)))
+      (import "" "g" (func $g (param i32 i32) (result i32)))
 
       (func $run (export "run") (result i32)
-        (local $ret i32) (local $retp i32)
+        (local $ret i32) (local $ret64 i64)
+        (local $retp i32) (local $retp1 i32) (local $retp2 i32)
         (local $subtask i32)
         (local $event_code i32)
+        (local $futr i32) (local $futw i32)
+        (local $ws i32)
 
         ;; call 'f'; it should block
         (local.set $retp (i32.const 4))
@@ -85,24 +125,77 @@
 
         (call $subtask.drop (local.get $subtask))
 
+        ;; create future that g will wait on
+        (local.set $ret64 (call $future.new))
+        (local.set $futr (i32.wrap_i64 (local.get $ret64)))
+        (local.set $futw (i32.wrap_i64 (i64.shr_u (local.get $ret64) (i64.const 32))))
+
+        ;; call 'g'; it should block
+        (local.set $retp1 (i32.const 4))
+        (local.set $retp2 (i32.const 8))
+        (i32.store (local.get $retp1) (i32.const 0xbad0bad0))
+        (i32.store (local.get $retp2) (i32.const 0xbad0bad0))
+        (local.set $ret (call $g (local.get $futr) (local.get $retp1)))
+        (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
+          (then unreachable))
+        (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))
+
+        ;; cancel 'g'; it should block
+        (local.set $ret (call $subtask.cancel (local.get $subtask)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; future.write, unblocking 'g'
+        (local.set $ret (call $future.write (local.get $futw) (i32.const 0xdeadbeef)))
+        (if (i32.ne (i32.const 0 (; COMPLETED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; wait to see 'g' finish and check its return value
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $subtask) (local.get $ws))
+        (local.set $event_code (call $waitable-set.wait (local.get $ws) (local.get $retp2)))
+        (if (i32.ne (i32.const 1 (; SUBTASK ;)) (local.get $event_code))
+          (then unreachable))
+        (if (i32.ne (local.get $subtask) (i32.load (local.get $retp2)))
+          (then unreachable))
+        (if (i32.ne (i32.const 2 (; RETURNED=2 | (0<<4) ;)) (i32.load offset=4 (local.get $retp2)))
+          (then unreachable))
+        (if (i32.ne (i32.const 42) (i32.load (local.get $retp1)))
+          (then unreachable))
+
         ;; return to the top-level assert_return
         (i32.const 42)
       )
     )
     (canon subtask.cancel (core func $subtask.cancel))
     (canon subtask.drop (core func $subtask.drop))
+    (canon future.new $FT (core func $future.new))
+    (canon future.write $FT async (memory $memory "mem") (core func $future.write))
+    (canon waitable.join (core func $waitable.join))
+    (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory $memory "mem") (core func $waitable-set.wait))
     (canon lower (func $f) async (memory $memory "mem") (core func $f'))
+    (canon lower (func $g) async (memory $memory "mem") (core func $g'))
     (core instance $dm (instantiate $DM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "subtask.cancel" (func $subtask.cancel))
       (export "subtask.drop" (func $subtask.drop))
+      (export "future.new" (func $future.new))
+      (export "future.write" (func $future.write))
+      (export "waitable.join" (func $waitable.join))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
       (export "f" (func $f'))
+      (export "g" (func $g'))
     ))))
     (func (export "run") (result u32) (canon lift (core func $dm "run")))
   )
 
   (instance $c (instantiate $C))
-  (instance $d (instantiate $D (with "f" (func $c "f"))))
+  (instance $d (instantiate $D
+    (with "f" (func $c "f"))
+    (with "g" (func $c "g"))
+  ))
   (func (export "run") (alias export $d "run"))
 )
 (assert_return (invoke "run") (u32.const 42))


### PR DESCRIPTION
This PR offers a better solution to the issue described in #546 (in which dependency code doesn't want to receive cancellation events it doesn't know what to do with).  Instead of coupling "cancellable" to "async", this PR splits them into two separate immediates, replacing the optional `async` immediate on `yield`/`wait`/`poll` with `cancellable`.  Since this immediate was not included in the 0.3.0 release, but rather as part of a later 🚟 stackful async release, this shouldn't require any change to 0.3.0 implementations (other than perhaps s/`async`/`cancellable`/ in not-yet-implemented validation errors).

A more subtle change in this PR that also doesn't change observable behavior in 0.3.0, but does for the later 🚟 stackful async release, is that synchronous builtins and `canon lower` no longer have "suspend the component instance" semantics.  Instead, the desired "non-reentrancy of sync and `async callback` core wasm code" invariant is achieved far more directly as part of the semantics of `canon lift`.

Some advantages of these changes (in the stackful async / cooperative threads timeframe):
* The synchronous and `async` ABI options are no longer overloaded and decoupled from (1) cancellability, (2) serialization.
* We can over time add `cancellable` to more built-ins and even `canon lower` for both sync and `async`, allowing cancellation to be delivered promptly in more cases.
* Cooperative threads will work just like stackful async exports in that they avoid the non-reentrancy locking entirely, progressing at their own (cooperative) pace, relying on the producer toolchain to handle multiple linear memory stacks etc.