### PR TITLE
Simplify CABI async code

### DIFF
--- a/design/mvp/Async.md
+++ b/design/mvp/Async.md
@@ -233,10 +233,9 @@ by Core WebAssembly code, it is meaningful for the built-in to work in terms
 
 The "current task" is modelled in the Canonical ABI's Python code
 by implicitly threading the `Task` object created by [`canon_lift`] through all
-the `async def` Python functions transitively called by `canon_lift`. Thus,
-although there can be multiple live `Task` objects in a component instance,
-"the current one" is always clear: it's the one passed to the current function
-as a parameter.
+the Python functions transitively called by `canon_lift`. Thus, although there
+can be multiple live `Task` objects in a component instance, "the current one"
+is always clear: it's the one passed to the current function as a parameter.
 
 ### Context-Local Storage
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1345,9 +1345,7 @@ type. For example, with Core WebAssembly [exception-handling] and
 an `i32`, throw, suspend or trap. In contrast, a component function with type
 `(func (result string))` may only return a `string` or trap. To express
 failure, component functions can return `result` and languages with exception
-handling can bind exceptions to the `error` case. Similarly, the forthcoming
-addition of [future and stream types] would explicitly declare patterns of
-stack-switching in component function signatures.
+handling can bind exceptions to the `error` case.
 
 Similar to the `import` and `alias` abbreviations shown above, `canon`
 definitions can also be written in an inverted form that puts the sort first:


### PR DESCRIPTION
This PR is just refactoring and shouldn't change the specified behavior.  The PR reimplements how async works to be based on Python threads (`threading.Thread`), using locks to emulate fibers and cooperative switching instead of the current approach of using Python `async`/`asyncio`.  This spun out of work to add cooperative threads, but it ended up being a significant simplification (kindof embarrassingly so) on its own, so I thought I'd spin it out into its own PR that could merge earlier.

The PR also adds a new top-level "Embedding" section to `CanonicalABI.md` (in the same spirit as [core wasm's](https://webassembly.github.io/spec/core/appendix/embedding.html)) that describes the top-level interaction between the embedder and wasm runtime which, with the asyncio impl, was rather ambiguous.

I'll leave the PR open for a while in case anyone who's familiar with the current Python code wants to take a look, review or comment, but if not that's fine too.