### PR TITLE
Add a 'map<K,V>' type

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -207,6 +207,7 @@ defvaltype    ::= pvt:<primvaltype>                       => pvt
                 | 0x68 i:<typeidx>                        => (borrow i)
                 | 0x66 t?:<valtype>?                      => (stream t?) 🔀
                 | 0x65 t?:<valtype>?                      => (future t?) 🔀
+                | 0x63 k:<valtype> v:<valtype>            => (map k v) (if k is in <keytype>) 🗺️
 labelvaltype  ::= l:<label'> t:<valtype>                  => l t
 case          ::= l:<label'> t?:<valtype>? 0x00           => (case l t?)
 label'        ::= len:<u32> l:<label>                     => l    (if len = |l|)

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -2051,6 +2051,7 @@ def despecialize(t):
     case EnumType(labels)    : return VariantType([ CaseType(l, None) for l in labels ])
     case OptionType(t)       : return VariantType([ CaseType("none", None), CaseType("some", t) ])
     case ResultType(ok, err) : return VariantType([ CaseType("ok", ok), CaseType("error", err) ])
+    case MapType(k, v)       : return ListType(despecialize(TupleType([k, v])))
     case _                   : return t
 ```
 The specialized value types `string` and `flags` are missing from this list

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -792,12 +792,14 @@ this can sometimes allow values to be represented differently. For example,
 of boolean fields uses a sequence of boolean-valued bytes.
 
 Since a `map` is a specialization of a list of (key, value) pairs without any
-additional semantic guarantee of key uniqueness, the Component Model does not
-forcibly prevent duplicate keys from appearing in the list. In the case of
-duplicate keys, the expectation for bindings generators is that for any given
-key, the *last* (key, value) pair in the list defines the value of the key in
-the map. To simplify bindings generation, `<keytype>`s is a conservative subset
-of `<valtype>`, but this subset could be expanded over time based on use cases.
+additional semantic guarantee of key uniqueness or ordering, the Component Model
+does not prevent duplicate keys from appearing in the list. Bindings generators
+*may* deduplicate and reorder keys as long as the *last* (key, value) pair in the
+original list defines the final value of the key. However, bindings generators
+are not *required* to deduplicate keys and may instead simply present the
+original list to guest code. To simplify bindings generation, `<keytype>` is a
+conservative subset of `<valtype>`, but this subset could be expanded over time
+based on use cases.
 
 Note that, at least initially, variants must have a non-empty list of
 cases. This could be relaxed in the future to allow an empty list of cases, with

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -58,6 +58,7 @@ implemented, considered stable and included in a future milestone:
 * 📝: the `error-context` type
 * 🔗: canonical interface names
 * 🐘: [memory64]
+* 🗺️: the `map` type
 
 (Based on the previous [scoping and layering] proposal to the WebAssembly CG,
 this repo merges and supersedes the [module-linking] and [interface-types]
@@ -563,12 +564,14 @@ defvaltype    ::= bool
                 | (enum "<label>"+)
                 | (option <valtype>)
                 | (result <valtype>? (error <valtype>)?)
+                | (map <keytype> <valtype>) 🗺️
                 | (own <typeidx>)
                 | (borrow <typeidx>)
                 | (stream <valtype>?) 🔀
                 | (future <valtype>?) 🔀
 valtype       ::= <typeidx>
                 | <defvaltype>
+keytype       ::= bool | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64 | char | string 🗺️
 resourcetype  ::= (resource (rep i32) (dtor <core:funcidx>)?)
                 | (resource (rep i32) (dtor async <core:funcidx> (callback <core:funcidx>)?)?) 🚝
                 | (resource (rep i64) (dtor <core:funcidx>)?) 🐘
@@ -772,6 +775,7 @@ defined by the following mapping:
                     (option <valtype>) ↦ (variant (case "none") (case "some" <valtype>))
 (result <valtype>? (error <valtype>)?) ↦ (variant (case "ok" <valtype>?) (case "error" <valtype>?))
                                 string ↦ (list char)
+             (map <keytype> <valtype>) ↦ (list (tuple <keytype> <valtype>))
 ```
 
 Specialized value types have the same set of semantic values as their
@@ -786,6 +790,14 @@ this can sometimes allow values to be represented differently. For example,
 `list<char>` uses a sequence of 4-byte `char` code points.  Similarly,
 `flags` in the Canonical ABI uses a bit-vector while an equivalent record
 of boolean fields uses a sequence of boolean-valued bytes.
+
+Since a `map` is a specialization of a list of (key, value) pairs without any
+additional semantic guarantee of key uniqueness, the Component Model does not
+forcibly prevent duplicate keys from appearing in the list. In the case of
+duplicate keys, the expectation for bindings generators is that for any given
+key, the *last* (key, value) pair in the list defines the value of the key in
+the map. To simplify bindings generation, `<keytype>`s is a conservative subset
+of `<valtype>`, but this subset could be expanded over time based on use cases.
 
 Note that, at least initially, variants must have a non-empty list of
 cases. This could be relaxed in the future to allow an empty list of cases, with
@@ -3036,6 +3048,7 @@ At a high level, the additional coercions would be:
 | `enum` | same as [`enum`] | same as [`enum`] |
 | `option` | same as [`T?`] | same as [`T?`] |
 | `result` | same as `variant`, but coerce a top-level `error` return value to a thrown exception | same as `variant`, but coerce uncaught exceptions to top-level `error` return values |
+| `map` | `new Map(_)` | `Map`s directly or other objects via `Object.entries(_)` |
 | `own`, `borrow` | see below | see below |
 | `future` | to a `Promise` | from a `Promise` |
 | `stream` | to a `ReadableStream` | from a `ReadableStream` |

--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1021,6 +1021,7 @@ keyword ::= 'as'
           | 'include'
           | 'interface'
           | 'list'
+          | 'map'
           | 'option'
           | 'own'
           | 'package'
@@ -1715,6 +1716,7 @@ ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | list
      | option
      | result
+     | map
      | handle
      | future
      | stream
@@ -1735,6 +1737,11 @@ result ::= 'result' '<' ty ',' ty '>'
          | 'result' '<' '_' ',' ty '>'
          | 'result' '<' ty '>'
          | 'result'
+
+map ::= 'map' '<' kt ',' ty '>'
+kt ::= 'u8' | 'u16' | 'u32' | 'u64'
+     | 's8' | 's16' | 's32' | 's64'
+     | 'char' | 'bool' | 'string'
 
 future ::= 'future' '<' ty '>'
          | 'future'
@@ -1774,6 +1781,11 @@ variant result {
 
 These types are so frequently used and frequently have language-specific
 meanings though so they're also provided as first-class types.
+
+🗺️ The `map` type is semantically equivalent to a list of pairs of keys and
+values but is meant to be represented by bindings generators in the source
+language as a mapping from keys to values (e.g., as an associative array or or
+hash table) where, in the case of duplicate keys, the last key's value is used.
 
 The `future` and `stream` types are described as part of the [concurrency
 explainer](Concurrency.md#streams-and-futures).

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -160,6 +160,11 @@ class ResultType(ValType):
   error: Optional[ValType]
 
 @dataclass
+class MapType(ValType):
+  k: ValType # <keytype>
+  v: ValType
+
+@dataclass
 class FlagsType(ValType):
   labels: list[str]
 
@@ -1114,6 +1119,7 @@ def despecialize(t):
     case EnumType(labels)    : return VariantType([ CaseType(l, None) for l in labels ])
     case OptionType(t)       : return VariantType([ CaseType("none", None), CaseType("some", t) ])
     case ResultType(ok, err) : return VariantType([ CaseType("ok", ok), CaseType("error", err) ])
+    case MapType(k, v)       : return ListType(despecialize(TupleType([k, v])))
     case _                   : return t
 
 ## Type Predicates

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -389,7 +389,9 @@ t = ListType(FlagsType([str(i) for i in range(32)]))
 v = [{ str(i):b for i in range(32) } for b in [True,False]]
 test_heap(t, v, [0,2],
           [0xff,0xff,0xff,0xff, 0,0,0,0])
-
+t = MapType(U8Type(), U16Type())
+test_heap(t, [{'0':42, '1':83}, {'0':43, '1':84}], [0, 2],
+          [42,0xff,83,0, 43,0xff,84,0])
 
 def test_flatten(t, params, results, addr_type='i32'):
   opts = mk_opts(MemInst(bytearray(), addr_type))


### PR DESCRIPTION
This PR adds a `map<K,V>` to the set of Component Model and WIT value types as discussed in #125, specifically based on [this design](https://github.com/WebAssembly/component-model/issues/125#issuecomment-3129960033) by @yordis.  With the approach of treating `map<K,V>` as just a specialization of `list<tuple<K,V>>`, the addition is pretty small and most of the work will be in the bindings generators.  I'm not in a particular rush to add this, but given the interest in #125, it seems useful to have a detailed proposal that can be prototyped and then potentially merged.