### PR TITLE
clarify canonopt requirements for async lifts

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3110,7 +3110,12 @@ validation is performed:
 * requires options based on [`lift(param)`](#canonopt-validation) for all parameters in `ft`
 * requires options based on [`lower(result)`](#canonopt-validation) if `ft` has a result
 * if `len(flatten_types(ft.param_types())) > MAX_FLAT_PARAMS`, `realloc` is required
-* if `len(flatten_types(ft.result_type())) > MAX_FLAT_RESULTS`, `memory` is required
+* if `len(flatten_types(ft.result_type())) > max` (where `max = MAX_FLAT_RESULTS` for sync lifts, and `max = MAX_FLAT_PARAMS` for async lifts), `memory` is required
+
+Note that an `async`-lifted function whose result type requires a memory to lift
+(either because it contains lists or strings or because the number of flattened
+types exceeds `MAX_FLAT_PARAMS`) must include a `memory` option, and that option
+must exactly match that of the `task.return` built-in called at runtime.
 
 When instantiating component instance `$inst`, `$f` is defined to be the
 partially-bound closure `canon_lift($opts, $inst, $ft, $callee)` which has 3


### PR DESCRIPTION
I had _thought_ that the spec allowed an async lift to omit the memory canonopt if only the result type (and not the paarameter types) required it, leaving the core function free to call any `task.return` at runtime as long as the type and string encoding matched.  Indeed, that's what we implemented in `wasm-tools` and Wasmtime.

However, it looks like I misremembered, since the spec uses an exact comparison in `LiftOptions.equal`.  That's good news, because allowing the core function to call any of several `task.return` functions, each with a different memory, makes it hard for the runtime to optimize compositions.

So no actual change needed here -- just a clarification.  We'll update `wasm-tools` and `Wasmtime` to match.