### PR TITLE
Relax the temporary same-instance copying limitation

### DIFF
--- a/design/mvp/Concurrency.md
+++ b/design/mvp/Concurrency.md
@@ -411,8 +411,9 @@ signalled by performing a `0`-length read or write (see the [Stream State]
 section in the Canonical ABI explainer for details).
 
 As a temporary limitation, if a `read` and `write` for a single stream or
-future occur from within the same component and the element type is non-empty,
-there is a trap. In the future this limitation will be removed.
+future occur from within the same component and the element type is a
+non-empty, non-number type, there is a trap. In the future this limitation will
+be removed.
 
 The `T` element type of streams and futures is optional, such that `future` and
 `stream` can be written in WIT without a trailing `<T>`. In this case, the

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -851,7 +851,7 @@ class SharedStreamImpl(ReadableStream, WritableStream):
       self.set_pending(inst, dst_buffer, on_copy, on_copy_done)
     else:
       assert(self.t == dst_buffer.t == self.pending_buffer.t)
-      trap_if(inst is self.pending_inst and self.t is not None) # temporary
+      trap_if(inst is self.pending_inst and not none_or_number_type(self.t)) # temporary
       if self.pending_buffer.remain() > 0:
         if dst_buffer.remain() > 0:
           n = min(dst_buffer.remain(), self.pending_buffer.remain())
@@ -869,7 +869,7 @@ class SharedStreamImpl(ReadableStream, WritableStream):
       self.set_pending(inst, src_buffer, on_copy, on_copy_done)
     else:
       assert(self.t == src_buffer.t == self.pending_buffer.t)
-      trap_if(inst is self.pending_inst and self.t is not None) # temporary
+      trap_if(inst is self.pending_inst and not none_or_number_type(self.t)) # temporary
       if self.pending_buffer.remain() > 0:
         if src_buffer.remain() > 0:
           n = min(src_buffer.remain(), self.pending_buffer.remain())
@@ -881,6 +881,11 @@ class SharedStreamImpl(ReadableStream, WritableStream):
       else:
         self.reset_and_notify_pending(CopyResult.COMPLETED)
         self.set_pending(inst, src_buffer, on_copy, on_copy_done)
+
+def none_or_number_type(t):
+  return t is None or isinstance(t, U8Type | U16Type | U32Type | U64Type |
+                                    S8Type | S16Type | S32Type | S64Type |
+                                    F32Type | F64Type)
 
 class CopyState(Enum):
   IDLE = 1
@@ -983,7 +988,7 @@ class SharedFutureImpl(ReadableFuture, WritableFuture):
     if not self.pending_buffer:
       self.set_pending(inst, dst_buffer, on_copy_done)
     else:
-      trap_if(inst is self.pending_inst and self.t is not None) # temporary
+      trap_if(inst is self.pending_inst and not none_or_number_type(self.t)) # temporary
       dst_buffer.write(self.pending_buffer.read(1))
       self.reset_and_notify_pending(CopyResult.COMPLETED)
       on_copy_done(CopyResult.COMPLETED)
@@ -995,7 +1000,7 @@ class SharedFutureImpl(ReadableFuture, WritableFuture):
     elif not self.pending_buffer:
       self.set_pending(inst, src_buffer, on_copy_done)
     else:
-      trap_if(inst is self.pending_inst and self.t is not None) # temporary
+      trap_if(inst is self.pending_inst and not none_or_number_type(self.t)) # temporary
       self.pending_buffer.write(src_buffer.read(1))
       self.reset_and_notify_pending(CopyResult.COMPLETED)
       on_copy_done(CopyResult.COMPLETED)


### PR DESCRIPTION
This PR relaxes the temporary limitation that same-instance stream/future reads/writes trap if the element type is not empty to also allow the integral and floating-point number types.  The reason for the limitation is that, for more-complex types, specifying and implementing the exact behavior in the case where the source and destination linear-memory overlap (which is only possible when the readable and writable ends are same-instance) is pretty tricky.  However, @dicej points out that the behavior is still quite simple when the element types are plain copyable numbers (it's as-if you read all elements and then wrote all elements, i.e., `memmove`, not `memcpy`), and allowing these (esp. `stream<u8>`) will address a common use case.  (FWIW, lazy-lowering avoids the complexity for the complex types and makes it easy to remove the trap.)  I'll add a `.wast` test once there's an impl draft I can test on.