### PR TITLE
Disallow trailing commas in tuple types

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1721,8 +1721,7 @@ ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | id
 
 tuple ::= 'tuple' '<' tuple-list '>'
-tuple-list ::= ty
-             | ty ',' tuple-list?
+tuple-list ::= ty ( ',' ty )*
 
 list ::= 'list' '<' ty '>'
        | 'list' '<' ty ',' uint '>' 🔧


### PR DESCRIPTION
Trailing commas are not allowed in any of the analogous generic types or function parameter lists.