### PR TITLE
update trap messages in `wasmtime` tests

### DIFF
--- a/test/wasmtime/fused.wast
+++ b/test/wasmtime/fused.wast
@@ -502,7 +502,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "r" (func $c1 "r"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; caller retptr misaligned
 (assert_trap
@@ -538,7 +538,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "r" (func $c1 "r"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; callee argptr misaligned
 (assert_trap
@@ -586,7 +586,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "r" (func $c1 "r"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; caller argptr misaligned
 (assert_trap
@@ -635,7 +635,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "r" (func $c1 "r"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; simple variant translation
 (component
@@ -722,7 +722,7 @@
       (with "r" (func $c1 "r"))
     ))
   )
-  "unreachable")
+  "invalid variant discriminant")
 
 ;; invalid variant discriminant in a result
 (assert_trap
@@ -757,7 +757,7 @@
       (with "r" (func $c1 "r"))
     ))
   )
-  "unreachable")
+  "invalid variant discriminant")
 
 
 ;; extra bits are chopped off
@@ -1160,7 +1160,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "a" (instance $c1))))
   )
-  "unreachable")
+  "invalid `char` bit pattern")
 (assert_trap
   (component
     (component $c1
@@ -1181,7 +1181,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "a" (instance $c1))))
   )
-  "unreachable")
+  "invalid `char` bit pattern")
 (assert_trap
   (component
     (component $c1
@@ -1202,7 +1202,7 @@
     (instance $c1 (instantiate $c1))
     (instance $c2 (instantiate $c2 (with "a" (instance $c1))))
   )
-  "unreachable")
+  "invalid `char` bit pattern")
 
 ;; test that flags get their upper bits all masked off
 (component

--- a/test/wasmtime/resources.wast
+++ b/test/wasmtime/resources.wast
@@ -476,7 +476,7 @@
   (func (export "f") (canon lift (core func $i "f")))
 )
 
-(assert_trap (invoke "f") "unknown handle index 1")
+(assert_trap (invoke "f") "index 1 is not a resource")
 
 ;; Each instantiation of a component generates a unique resource type, so
 ;; allocating in one component and deallocating in another should fail.

--- a/test/wasmtime/strings.wast
+++ b/test/wasmtime/strings.wast
@@ -34,7 +34,7 @@
     (instance $c (instantiate $c))
     (instance $c2 (instantiate $c2 (with "a" (func $c "a"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; unaligned latin1+utf16 string, even with the latin1 encoding
 (assert_trap
@@ -70,7 +70,7 @@
     (instance $c (instantiate $c))
     (instance $c2 (instantiate $c2 (with "a" (func $c "a"))))
   )
-  "unreachable")
+  "unaligned pointer")
 
 ;; out of bounds utf8->utf8 string
 (assert_trap
@@ -107,4 +107,4 @@
     (instance $c (instantiate $c))
     (instance $c2 (instantiate $c2 (with "a" (func $c "a"))))
   )
-  "unreachable")
+  "string content out-of-bounds")


### PR DESCRIPTION
This anticipates an upcoming PR which addresses
https://github.com/bytecodealliance/wasmtime/issues/11683.