### PR TITLE
update handle indexes in `resource.wast` test

### DIFF
--- a/test/wasmtime/resources.wast
+++ b/test/wasmtime/resources.wast
@@ -492,10 +492,10 @@
       (import "" "drop" (func $drop (param i32)))
 
       (func (export "alloc")
-        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 1)) (then (unreachable)))
+        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 2)) (then (unreachable)))
       )
       (func (export "dealloc")
-        (call $drop (i32.const 1))
+        (call $drop (i32.const 2))
       )
     )
     (core instance $i (instantiate $m
@@ -552,10 +552,10 @@
       (import "" "drop" (func $drop (param i32)))
 
       (func (export "alloc")
-        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 1)) (then (unreachable)))
+        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 2)) (then (unreachable)))
       )
       (func (export "dealloc")
-        (call $drop (i32.const 1))
+        (call $drop (i32.const 2))
       )
     )
     (core instance $i (instantiate $m
@@ -1025,8 +1025,8 @@
         (local.set $r1 (call $ctor (i32.const 100)))
         (local.set $r2 (call $ctor (i32.const 200)))
 
-        (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
-        (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
+        (if (i32.ne (local.get $r1) (i32.const 2)) (then (unreachable)))
+        (if (i32.ne (local.get $r2) (i32.const 3)) (then (unreachable)))
 
         (call $assert-borrow (local.get $r2) (i32.const 200))
         (call $assert-borrow (local.get $r1) (i32.const 100))
@@ -1086,6 +1086,6 @@
 )
 
 (component instance $C1 $C)
-(assert_trap (invoke "drop-r1-as-r2") "handle index 1 used with the wrong type, expected guest-defined resource but found a different guest-defined resource")
+(assert_trap (invoke "drop-r1-as-r2") "handle index 2 used with the wrong type, expected guest-defined resource but found a different guest-defined resource")
 (component instance $C1 $C)
-(assert_trap (invoke "return-r1-as-r2") "handle index 1 used with the wrong type, expected guest-defined resource but found a different guest-defined resource")
+(assert_trap (invoke "return-r1-as-r2") "handle index 2 used with the wrong type, expected guest-defined resource but found a different guest-defined resource")


### PR DESCRIPTION
Now that each host->guest call implicitly creates a thread handle, the first handle we expect to receive from the host when creating a resource is 2, not 1.