### PR TITLE
use `async` type as necessary in `sync-streams.wast`

### DIFF
--- a/test/async/sync-streams.wast
+++ b/test/async/sync-streams.wast
@@ -87,18 +87,18 @@
       (export "stream.drop-readable" (func $stream.drop-readable))
       (export "stream.drop-writable" (func $stream.drop-writable))
     ))))
-    (func (export "get") (result (stream u8)) (canon lift
+    (func (export "get") async (result (stream u8)) (canon lift
       (core func $cm "get")
       async (memory $memory "mem") (callback (func $cm "get_cb"))
     ))
-    (func (export "set") (param "in" (stream u8)) (canon lift
+    (func (export "set") async (param "in" (stream u8)) (canon lift
       (core func $cm "set")
       async (memory $memory "mem") (callback (func $cm "set_cb"))
     ))
   )
   (component $D
-    (import "get" (func $get (result (stream u8))))
-    (import "set" (func $set (param "in" (stream u8))))
+    (import "get" (func $get async (result (stream u8))))
+    (import "set" (func $set async (param "in" (stream u8))))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))
@@ -165,7 +165,7 @@
       (export "get" (func $get'))
       (export "set" (func $set'))
     ))))
-    (func (export "run") (result u32) (canon lift (core func $dm "run")))
+    (func (export "run") async (result u32) (canon lift (core func $dm "run")))
   )
 
   (instance $c (instantiate $C))


### PR DESCRIPTION
Previously, Wasmtime wasn't catching all cases of blocking-in-sync-contexts, but I'm about to push a PR which fixes that.