### PR TITLE
update tests to match new reentrance rules

### DIFF
--- a/test/wasmtime/adapter.wast
+++ b/test/wasmtime/adapter.wast
@@ -112,7 +112,7 @@
       (with "" (instance (export "" (func $f2))))
     ))
   )
-  "degenerate component adapter called")
+  "cannot enter component instance")
 
 ;; fiddling with 0-sized lists
 (component $c


### PR DESCRIPTION
Recent discussions [^1] regarding optimizing reentrance checks in fused adapters have resulted in a plan to disallow lowering a lift where the lowering instance is an ancestor of the lifting instance or vice-versa.  A bunch of tests in `fused.wast` were doing that, so I've updated them to not do that.

In addition, I'm about to open a Wasmtime PR to enforce the new rule and subsume existing code that created "degenerate adapter" functions for self-to-self lift/lower pairs.  Consequently, I've updated `adapter.wast` to expect a "cannot enter component instance" trap instead of a "degenerate component adapter" one.

[^1]: https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Wasmtime.20sync.3C-.3Esync.20adapter.20optimizability