### PR TITLE
update expected trap message in `passing-resources.wast`

### DIFF
--- a/test/async/passing-resources.wast
+++ b/test/async/passing-resources.wast
@@ -173,4 +173,4 @@
   (func (export "fail-accessing-res1") (alias export $producer "fail-accessing-res1"))
 )
 (assert_return (invoke "run") (u32.const 42))
-(assert_trap (invoke "fail-accessing-res1") "unknown handle index")
+(assert_trap (invoke "fail-accessing-res1") "index is not a resource")


### PR DESCRIPTION
I'm preparing a Wasmtime PR which ensures that a thread and task is allocated every time a component is entered, regardless of whether the export is sync or async typed, sync or async lifted.  Consequently, we get a slightly different trap in `passing-resources.wast` such that the passed handle is valid but not of the correct kind (i.e. it's a thread handle rather than a resource handle).