### PR TITLE
Change validation to reject stream<char> (for now)

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -253,6 +253,8 @@ Notes:
   rejects any transitive use of `borrow` in an exported value type.
 * Validation of `stream` and `future` rejects element types that transitively
   contain a `borrow`.
+* Validation of `stream` rejects `(stream char)` as a temporary
+  [TODO](Concurrency.md#TODO).
 * Validation of `resourcetype` requires the destructor (if present) to have
   type `[i32] -> []`.
 * Validation of `instancedecl` (currently) only allows the `type` and

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -4212,8 +4212,11 @@ Then a readable or writable buffer is created which (in `Buffer`'s constructor)
 eagerly checks the alignment and bounds of (`i`, `n`). (In the future, the
 restriction on futures/streams containing `borrow`s could be relaxed by
 maintaining sufficient bookkeeping state to ensure that borrowed handles *or
-streams/futures of borrowed handles* could not outlive their originating call.)
+streams/futures of borrowed handles* could not outlive their originating call.
+Additionally, `stream<char>` will be allowed and defined to encode and decode
+according to the `string-encoding`.)
 ```python
+  assert(not isinstance(stream_t, CharType))
   assert(not contains_borrow(stream_t))
   cx = LiftLowerContext(opts, thread.task.inst, borrow_scope = None)
   buffer = BufferT(stream_t.t, cx, ptr, n)

--- a/design/mvp/Concurrency.md
+++ b/design/mvp/Concurrency.md
@@ -1259,6 +1259,8 @@ comes after:
 * remove the temporary trap mentioned above that occurs when a `read` and
   `write` of a stream/future happen from within the same component instance
 * zero-copy forwarding/splicing
+* allow the `stream<char>` type to validate; make it use `string-encoding`
+  and not split code points
 * some way to say "no more elements are coming for a while"
 * add an `async` effect on `component` type definitions allowing a component
   type to block during instantiation
@@ -1270,8 +1272,6 @@ comes after:
 * add a `strict-callback` option that adds extra trapping conditions to
   provide the semantic guarantees needed for engines to statically avoid
   fiber creation at component-to-component `async` call boundaries
-* add `stringstream` specialization of `stream<char>` (just like `string` is
-  a specialization of `list<char>`)
 * allow pipelining multiple `stream.read`/`write` calls
 * allow chaining multiple async calls together ("promise pipelining")
 * integrate with `shared`: define how to lift and lower functions `async` *and*

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -753,6 +753,9 @@ empty futures and streams can be useful for timing-related APIs.
 Currently, validation rejects `(stream T)` and `(future T)` when `T`
 transitively contains a `borrow`. This restriction could be relaxed in the
 future by extending the call-scoping rules of `borrow` to streams and futures.
+Additionally, `(stream char)` is temporarily rejected with a future
+[TODO](Concurrency.md) to allow and properly use the `string-encoding`,
+taking care to not split code points.
 
 #### Specialized value types
 

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -2362,6 +2362,7 @@ def stream_copy(EndT, BufferT, event_code, stream_t, opts, thread, i, ptr, n):
   trap_if(e.shared.t != stream_t.t)
   trap_if(e.state != CopyState.IDLE)
 
+  assert(not isinstance(stream_t, CharType))
   assert(not contains_borrow(stream_t))
   cx = LiftLowerContext(opts, thread.task.inst, borrow_scope = None)
   buffer = BufferT(stream_t.t, cx, ptr, n)


### PR DESCRIPTION
Right now, because `elem_size(char) == 4`, if you use `stream<char>` you're effectively using UTF-32 which is not great.  Now that's also the case for `list<char>` but everyone uses `string` instead which is encoded/decoded using `string-encoding`, which is one of `utf8`, `utf16` or `latin1+utf16`.  Symmetrically, we could add a `string-stream` and indeed there's currently a bullet in Concurrency.md#TODO to add such a thing.

However, in retrospect, `list<char>` should've probably been special-cased in the ABI lift/lower rules to use `string-encoding` so that `string` is pure sugar for `list<char>` (and if we ever actually needed UTF-32, it could be a new `string-encoding=utf32`... but probably not).  Once we add an opt-in `canonopt` for #383, we can piggyback other pending breaking ABI changes (e.g., bumping `MAX_FLAT_RESULTS` to be greater than `1`), so we could actually fix this (or not; it bears discussion in the future).  But in the *meantime*, for the upcoming 0.3.0 release, given that if you use `stream<char>` you're going to have a bad time and we don't necessarily want to add `string-stream`, the conservative thing to do seems to be to just reject `stream<char>` at validation time and then we can figure out what we want later w/o breaking anyone.