### PR TITLE
Fix <interfacename> grammar to match <pkgpath>

### DIFF
--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -2547,8 +2547,8 @@ fragment          ::= <word>
                     | <acronym>
 word              ::= [0-9a-z]+
 acronym           ::= [0-9A-Z]+
-interfacename     ::= <namespace> <label> <projection> <interfaceversion>?
-                    | <namespace>+ <label> <projection>+ <interfaceversion>? 🪺
+interfacename     ::= <namespace> <words> <projection> <interfaceversion>?
+                    | <namespace>+ <words> <projection>+ <interfaceversion>? 🪺
 namespace         ::= <words> ':'
 words             ::= <first-word> ( '-' <word> )*
 projection        ::= '/' <label>


### PR DESCRIPTION
As pointed out in #628, this fixes a discrepancy between `interfacename` and `pkgname`.  There's already a `test/names/kebab.wast` that matches this change and the wasm-tools implementation.