### PR TITLE
Add tags to core:sort

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -69,6 +69,7 @@ core:sort           ::= 0x00                                               => fu
                       | 0x01                                               => table
                       | 0x02                                               => memory
                       | 0x03                                               => global
+                      | 0x04                                               => tag
                       | 0x10                                               => type
                       | 0x11                                               => module
                       | 0x12                                               => instance

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -169,21 +169,22 @@ executing a component, there are 5 component-level index spaces:
 * component instances
 * components
 
-5 core index spaces that also exist in WebAssembly 1.0:
+6 core index spaces that also exist in the Core WebAssembly specification:
 * (core) functions
 * (core) tables
 * (core) memories
 * (core) globals
+* (core) tags
 * (core) types
 
 and 2 additional core index spaces that contain core definition introduced by
-the Component Model that are not in WebAssembly 1.0 (yet: the [module-linking]
+the Component Model that are not in Core WebAssembly (yet: the [module-linking]
 proposal would add them):
 * module instances
 * modules
 
-for a total of 12 index spaces that need to be maintained by an implementation
-when, e.g., validating a component. These 12 index spaces correspond 1:1 with
+for a total of 13 index spaces that need to be maintained by an implementation
+when, e.g., validating a component. These 13 index spaces correspond 1:1 with
 the terminals of the `sort` production defined below and thus "sort" and
 "index space" can be used interchangeably.
 
@@ -236,6 +237,7 @@ core:sort           ::= func
                       | table
                       | memory
                       | global
+                      | tag
                       | type
                       | module
                       | instance


### PR DESCRIPTION
This was seemingly an oversight, as I can't think of any reason why it should be impossible to import and export tags during linking.