### PR TITLE
Emoji-gate synchronous future/stream read/write

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -4356,6 +4356,7 @@ specifies:
   * [`lower($t)` above](#canonopt-validation) defines required options for `stream.write`
   * [`lift($t)` above](#canonopt-validation) defines required options for `stream.read`
   * `memory` is required to be present
+* 🚝 - `async` is allowed to be omitted, otherwise it must be present
 
 The implementation of these built-ins funnels down to a single `stream_copy`
 function that is parameterized by the direction of the copy:
@@ -4478,6 +4479,7 @@ specifies:
   * [`lift($t)` above](#canonopt-validation) defines required options for `future.read`
   * [`lower($t)` above](#canonopt-validation) defines required options for `future.write`
   * `memory` is required to be present
+* 🚝 - `async` is allowed to be omitted, otherwise it must be present
 
 The implementation of these built-ins funnels down to a single `future_copy`
 function that is parameterized by the direction of the copy:

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -50,7 +50,7 @@ implemented, considered stable and included in a future milestone:
 * 🪙: value imports/exports and component-level start function
 * 🪺: nested namespaces and packages in import/export names
 * 🔀: async
-  * 🚝: marking some builtins as `async`
+  * 🚝: enabling more canonical ABI options on more async-related builtins
   * 🚟: using `async` with `canon lift` without `callback` (stackful lift)
 * 🧵: threading built-ins
   * 🧵②: [shared-everything-threads]-based threading built-ins


### PR DESCRIPTION
I understand that this change is "late in the game" for component-model-async things with WASIp3 around the corner, but in light of bytecodealliance/wasmtime#13212 I'd like to try to at least propose gating the ability to use `{future,stream}.{read,write}` synchronously for the initial WASIp3 0.3.0 release. I'm not aware of any preexisting language bindings actually using these functions, for example all `wit-bindgen` languages are using the `async` version. Given that lack of use, and now-cropping-up interesting questions, I'd like to ideally gate these to be sure to have enough time to come back in the future and thoroughly consider the interleavings and repurcussions here.

Specifically this change proposes moving the non-`async` functionality of these intrinsics behind the 🚝 feature gate. This preexisting feature gate mostly gated async-related builtins but it's generalized now to basically be "more options on more builtins" as a sort of grab-bag for now.