### PR TITLE
Use <core:funcidx> in resource type definitions

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -214,10 +214,12 @@ label'        ::= len:<u32> l:<label>                     => l    (if len = |l|)
                 | 0x01 t:<T>                              => t
 valtype       ::= i:<typeidx>                             => i
                 | pvt:<primvaltype>                       => pvt
-resourcetype  ::= 0x3f 0x7f f?:<funcidx>?                 => (resource (rep i32) (dtor f)?)
-                | 0x3e 0x7f f:<funcidx> cb?:<funcidx>?    => (resource (rep i32) (dtor async f (callback cb)?)) 🚝
-                | 0x3f 0x7e f?:<funcidx>?                 => (resource (rep i64) (dtor f)?) 🐘
-                | 0x3e 0x7e f:<funcidx> cb?:<funcidx>?    => (resource (rep i64) (dtor async f (callback cb)?)) 🚝🐘
+resourcetype  ::= 0x3f 0x7f f?:<core:funcidx>?            => (resource (rep i32) (dtor f)?)
+                | 0x3e 0x7f f:<core:funcidx>
+                            cb?:<core:funcidx>?           => (resource (rep i32) (dtor async f (callback cb)?)) 🚝
+                | 0x3f 0x7e f?:<core:funcidx>?            => (resource (rep i64) (dtor f)?) 🐘
+                | 0x3e 0x7e f:<core:funcidx>
+                            cb?:<core:funcidx>?           => (resource (rep i64) (dtor async f (callback cb)?)) 🚝🐘
 functype      ::= 0x40 ps:<paramlist> rs:<resultlist>     => (func ps rs)
                 | 0x43 ps:<paramlist> rs:<resultlist>     => (func async ps rs)
 paramlist     ::= lt*:vec(<labelvaltype>)                 => (param lt)*

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -569,10 +569,10 @@ defvaltype    ::= bool
                 | (future <valtype>?) 🔀
 valtype       ::= <typeidx>
                 | <defvaltype>
-resourcetype  ::= (resource (rep i32) (dtor <funcidx>)?)
-                | (resource (rep i32) (dtor async <funcidx> (callback <funcidx>)?)?) 🚝
-                | (resource (rep i64) (dtor <funcidx>)?) 🐘
-                | (resource (rep i64) (dtor async <funcidx> (callback <funcidx>)?)?) 🚝🐘
+resourcetype  ::= (resource (rep i32) (dtor <core:funcidx>)?)
+                | (resource (rep i32) (dtor async <core:funcidx> (callback <core:funcidx>)?)?) 🚝
+                | (resource (rep i64) (dtor <core:funcidx>)?) 🐘
+                | (resource (rep i64) (dtor async <core:funcidx> (callback <core:funcidx>)?)?) 🚝🐘
 functype      ::= (func async? (param "<label>" <valtype>)* (result <valtype>)?)
 componenttype ::= (component <componentdecl>*)
 instancetype  ::= (instance <instancedecl>*)


### PR DESCRIPTION
As noticed in #648, the function indices in resource type definition are *core* function indices, so should use a `<core:funcidx>` in the text/binary format grammars.