### PR TITLE
Fix some cooperative thread limitations

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -64,8 +64,10 @@ specified here.
   * [`canon thread.resume-later`](#-canon-threadresume-later) 🧵
   * [`canon thread.suspend`](#-canon-threadsuspend) 🧵
   * [`canon thread.yield`](#-canon-threadyield) 🧵
-  * [`canon thread.switch-to`](#-canon-threadswitch-to) 🧵
-  * [`canon thread.yield-to`](#-canon-threadyield-to) 🧵
+  * [`canon thread.suspend-then-resume`](#-canon-threadsuspend-then-resume) 🧵
+  * [`canon thread.yield-then-resume`](#-canon-threadyield-then-resume) 🧵
+  * [`canon thread.suspend-then-promote`](#-canon-threadsuspend-then-promote) 🧵
+  * [`canon thread.yield-then-promote`](#-canon-threadyield-then-promote) 🧵
   * [`canon error-context.new`](#-canon-error-contextnew) 📝
   * [`canon error-context.debug-message`](#-canon-error-contextdebug-message) 📝
   * [`canon error-context.drop`](#-canon-error-contextdrop) 📝
@@ -640,7 +642,7 @@ here. `Thread.suspend` first attempts to deliver any pending cancellation
 requests and then otherwise simply [blocks].
 ```python
   def suspend(self, cancellable) -> Cancelled:
-    assert(self.running() and self.task.may_block())
+    assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     return self.block_internal(cancellable)
@@ -648,16 +650,20 @@ requests and then otherwise simply [blocks].
 
 The `Thread.wait_until` method is used by all the synchronous blocking
 built-ins, as well as auto-backpressure and the `callback` event loop, to wait
-until a particular readiness condition is met:
+until a particular readiness condition is met. Given `wait_until`, "yielding"
+can simply be defined as waiting on a readiness condition that is already met.
 ```python
   def wait_until(self, ready_func, cancellable = False) -> Cancelled:
-    assert(self.running() and self.task.may_block())
+    assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     if ready_func() and not DETERMINISTIC_PROFILE and random.randint(0,1):
       return Cancelled.FALSE
     self.start_waiting_internal(ready_func)
     return self.block_internal(cancellable)
+
+  def yield_(self, cancellable) -> Cancelled:
+    return self.wait_until(lambda: True, cancellable)
 ```
 As with `Thread.suspend`, before anything else, `wait_until` reports any pending
 cancellation requests if the caller is `cancellable`. The `randomint` conjunct
@@ -668,51 +674,49 @@ a caller makes an `async` call to a callee which `wait_until`s a condition
 that's already met (e.g. in the case of `yield`), the embedder can use
 scheduling heuristics to decide whether or not to block the current thread.
 
-The `Thread.yield_until` method modifies the generic `Thread.wait_until` method
-for the `thread.yield` built-in (and `callback`s returning the `YIELD` code) so
-that, when executing in a non-blocking context, yielding does not trap and
-simply continues executing. This behavior allows `thread.yield` calls to be
-scattered liberally throughout code, possibly via automatic code generation
-emulating preemptive multi-threading.
+The `Thread.suspend_then_resume` and `Thread.yield_then_resume` methods
+immediately resume execution of some `other` `suspended` thread in the same
+component instance, leaving the original thread in either a `suspended` or
+`ready` `waiting` state, resp. Like other `Thread` methods, these methods first
+report any pending cancellation if the caller is `cancellable`.
 ```python
-  def yield_until(self, ready_func, cancellable) -> Cancelled:
-    assert(self.running())
-    if self.task.may_block():
-      return self.wait_until(ready_func, cancellable)
-    else:
-      assert(ready_func())
-      return Cancelled.FALSE
-
-  def yield_(self, cancellable) -> Cancelled:
-    return self.yield_until(lambda: True, cancellable)
-```
-
-The `Thread.switch_to` method is used by the `thread.switch-to` built-in to
-suspend the current thread and immediately transfer execution to some other
-`suspended` thread in the same component instance. Like other `Thread` methods,
-`Thread.switch_to` first reports any pending cancellation if the caller is
-`cancellable`. Then the current thread transfers control flow to the `other`
-thread using the `Thread.switch_to_internal` helper method defined above.
-```python
-  def switch_to(self, cancellable, other: Thread) -> Cancelled:
+  def suspend_then_resume(self, cancellable, other: Thread) -> Cancelled:
     assert(self.running() and other.suspended())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     return self.switch_to_internal(cancellable, other)
-```
 
-Lastly, the `Thread.yield_to` method is used by the `thread.yield-to` built-in
-to switch execution to some other thread, leaving the current thread in a
-`ready` `waiting` state so that it can nondeterministically `resume` execution
-at the next `Store.tick`. Like other `Thread` methods, `Thread.yield_to` first
-reports any pending cancellation if the caller is `cancellable`.
-```python
-  def yield_to(self, cancellable, other: Thread) -> Cancelled:
+  def yield_then_resume(self, cancellable, other: Thread) -> Cancelled:
     assert(self.running() and other.suspended())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     self.start_waiting_internal(lambda: True)
     return self.switch_to_internal(cancellable, other)
+```
+
+Lastly, the `Thread.suspend_then_promote` and `Thread.yield_then_promote`
+methods *attempt* to immediately resume execution of some `other` thread in the
+same component instance *if* the `other` thread is in a `ready` `waiting` state.
+If so, control flow is transferred directly and the current thread is left
+`suspended` or in a `ready` `waiting` state, resp. If the `other` thread is
+*not* ready to run, then these operations fall back to plain `suspend` or
+`yield_` behavior, resp.
+```python
+  def suspend_then_promote(self, cancellable, other: Thread) -> Cancelled:
+    assert(self.running())
+    if other.ready():
+      other.stop_waiting_internal(cancelled = False)
+      return self.suspend_then_resume(cancellable, other)
+    else:
+      return self.suspend(cancellable)
+
+  def yield_then_promote(self, cancellable, other: Thread) -> Cancelled:
+    assert(self.running())
+    if other.ready():
+      other.stop_waiting_internal(cancelled = False)
+      return self.yield_then_resume(cancellable, other)
+    else:
+      return self.yield_(cancellable)
 ```
 
 
@@ -804,14 +808,6 @@ holding the lock.
   def needs_exclusive(self):
     assert(self.ft.async_)
     return not self.opts.async_ or self.opts.callback
-```
-
-The `Task.may_block` predicate returns whether the [current task]'s function's
-type is allowed to [block]. Specifically, functions that do not declare the
-`async` effect that have not yet returned a value may not block.
-```python
-  def may_block(self):
-    return self.ft.async_ or self.state == Task.State.RESOLVED
 ```
 
 The `Task.enter_implicit_thread` method implements [backpressure] between when
@@ -1259,6 +1255,11 @@ class Table:
   def __init__(self):
     self.array = [None]
     self.free = []
+
+  def __iter__(self):
+    for e in self.array:
+      if e is not None:
+        yield e
 
   def get(self, i):
     trap_if(i >= len(self.array))
@@ -3664,13 +3665,12 @@ function (specified as a `funcidx` immediate in `canon lift`) until the
       inst.exclusive_thread = None
       match code:
         case CallbackCode.YIELD:
-          cancelled = thread.yield_until(lambda: not inst.exclusive_thread, cancellable = True)
+          cancelled = thread.wait_until(lambda: not inst.exclusive_thread, cancellable = True)
           if cancelled:
             event = (EventCode.TASK_CANCELLED, 0, 0)
           else:
             event = (EventCode.NONE, 0, 0)
         case CallbackCode.WAIT:
-          trap_if(not task.may_block())
           wset = inst.handles.get(si)
           trap_if(not isinstance(wset, WaitableSet))
           event = wset.wait_for_event_and(lambda: not inst.exclusive_thread, cancellable = True)
@@ -3684,16 +3684,12 @@ function (specified as a `funcidx` immediate in `canon lift`) until the
     task.exit_implicit_thread()
     return
 ```
-The `Thread.yield_until` and `WaitableSet.wait_for_event_and` methods called by
+The `Thread.wait_until` and `WaitableSet.wait_for_event_and` methods called by
 the event loop are the same methods called by the `thread.yield` and
 `waitable-set.wait` built-ins. Thus, the main difference between stackful and
 stackless async is whether these suspending operations are performed from an
 empty or non-empty core wasm callstack (with the former allowing additional
 engine optimization).
-
-If a `Task` is not allowed to block (because it was created for a non-`async`-
-typed function call and has not yet returned a value), `YIELD` is always a
-no-op and `WAIT` always traps.
 
 The event loop releases `ComponentInstance.exclusive_thread` (which was acquired
 by `Task.enter_implicit_thread`) before potentially blocking the thread to allow
@@ -3709,16 +3705,34 @@ The end of `canon_lift` creates a new task/thread pair for the call and then
 calls `Thread.resume` on the new thread to synchronously transfer control flow
 to it (jumping to the top of `thread_func` above). The new thread executes until
 it either returns from `thread_func` or [blocks] by (transitively) calling
-`Thread.block_internal`. Thus, in all cases, `canon_lift` never blocks the
-caller, as required by the `FuncInst` calling contract. Lastly, `canon_lift`
-returns `Task.request_cancellation`, bound to the call's new task, as the
-required `OnCancel` value.
+`Thread.block_internal`. If a non-`async`-typed call blocks before the implicit
+thread has returned a value and there are no other `ready` threads in the same
+component instance, `canon_lift` traps, since non-`async`-typed calls may not
+block. Otherwise, `canon_lift` switches to a thread (nondeterministically, if
+multiple are `ready`), as if the guest code had done so itself using a built-in
+like `thread.suspend-then-promote`. This allows fully-synchronous components to
+still use cooperative pthreads that interleave via threading built-ins (e.g.,
+`thread.yield`) and *even perform blocking I/O* as long as the blocking I/O does
+not transitively block returning a value to the caller (as would also be
+expressible with a CPS transform like [Asyncify]). Lastly, `canon_lift` returns
+`Task.request_cancellation`, bound to the call's new task, as the `OnCancel`
+return value of `FuncInst`.
 ```python
   task = Task(ft, opts, inst, on_start, on_resolve, caller)
   thread = Thread(task, thread_func)
   thread.resume()
+  if not ft.async_:
+    while task.state != Task.State.RESOLVED:
+      candidates = { t for t in inst.threads if t.ready() and t is not inst.exclusive_thread }
+      trap_if(not candidates)
+      random.choice(list(candidates)).resume()
   return task.request_cancellation
 ```
+The special case that excludes any thread (created by a previous blocked `async`
+call) holding the instance's `exclusive_thread` lock is necessary to preserve
+[Component Invariant] #3, which might otherwise be violated if the current
+synchronous call is using the single global linear memory shadow stack.
+
 Note that, because non-`async`-typed functions can't block, they do not actually
 require a separate thread/fiber/stack to implement the above specified behavior
 and a normal synchronous native function call can be used instead. Even if the
@@ -3788,26 +3802,16 @@ along with the component instance being instantiated. These are then passed into
 `canon_lower` every time the generated `CoreFuncInst` is called, along with the
 runtime Core WebAssembly arguments.
 
-Based on this, `canon_lower` is defined in chunks as follows:
+Based on this, `canon_lower` is defined in chunks as follows. First, each call
+to `canon_lower` creates a new `Subtask`. However, this `Subtask` is only added
+to the current component instance's `handles` table (below) if `async` is
+specified *and* `callee` blocks. In any case, this `Subtask` is used as the
+`LiftLowerContext.borrow_scope` for `borrow` arguments, ensuring that owned
+handles are not dropped before `Subtask.deliver_resolve` is called (below).
 ```python
 def canon_lower(callee, ft, opts, flat_args: list[CoreValType]) -> list[CoreValType]:
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and ft.async_ and not opts.async_)
-```
-A non-`async`-typed function export that has not yet returned a value
-unconditionally traps if it transitively attempts to make a synchronous call to
-an `async`-typed function import (even if the callee wouldn't have actually
-blocked at runtime). It is however fine to make an `async`-lowered call to an
-`async`-typed function import, since this never blocks (only a subsequent call
-to, e.g., `waitable-set.wait` would block).
-
-Each call to `canon_lower` creates a new `Subtask`. However, this `Subtask` is
-only added to the current component instance's `handles` table (below) if
-`async` is specified *and* `callee` blocks. In any case, this `Subtask` is used
-as the `LiftLowerContext.borrow_scope` for `borrow` arguments, ensuring that
-owned handles are not dropped before `Subtask.deliver_resolve` is called (below).
-```python
   subtask = Subtask()
   cx = LiftLowerContext(opts, thread.task.inst, subtask)
 ```
@@ -4251,7 +4255,6 @@ returning its `EventCode` and writing the payload values into linear memory:
 def canon_waitable_set_wait(cancellable, mem, si, ptr):
   task = current_task()
   trap_if(not task.inst.may_leave)
-  trap_if(not task.may_block())
   wset = task.inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
   event = wset.wait_for_event(cancellable)
@@ -4264,10 +4267,6 @@ def unpack_event(mem, inst, ptr, e: EventTuple):
   store(cx, p2, U32Type(), ptr + 4)
   return [event]
 ```
-A non-`async`-typed function export that has not yet returned a value
-unconditionally traps if it transitively attempts to call `wait` (regardless of
-whether there are any waitables with pending events).
-
 If `cancellable` is set, then `waitable-set.wait` will return whether the
 supertask has already or concurrently requested cancellation.
 `waitable-set.wait` (and other cancellable operations) will only indicate
@@ -4404,7 +4403,6 @@ BLOCKED = 0xffff_ffff
 def canon_subtask_cancel(async_, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not async_)
   subtask = thread.task.inst.handles.get(i)
   trap_if(not isinstance(subtask, Subtask))
   trap_if(subtask.resolve_delivered())
@@ -4425,13 +4423,9 @@ def canon_subtask_cancel(async_, i):
   assert(subtask.resolve_delivered())
   return [subtask.state]
 ```
-A non-`async`-typed function export that has not yet returned a value
-unconditionally traps if it transitively attempts to make a synchronous call to
-`subtask.cancel` (regardless of whether the cancellation would have succeeded
-without blocking). The other traps disallow calling `subtask.cancel` twice for
-the same subtask or after the supertask has already been notified that the
-subtask has returned or if the subtask is already being asynchronously waited
-on via waitable set.
+`subtask.cancel` starts by trapping if called twice for the same subtask or if
+the supertask has already been notified that the subtask has returned or if the
+subtask is already being asynchronously waited on via waitable set.
 
 A race condition handled by the above code is that it's possible for a subtask
 to have already resolved (by calling `task.return` or `task.cancel`) and
@@ -4533,23 +4527,16 @@ def canon_stream_write(stream_t, opts, i, ptr, n):
                      stream_t, opts, i, ptr, n)
 ```
 
-Introducing the `stream_copy` function in chunks, a non-`async`-typed function
-export that has not yet returned a value unconditionally traps if it
-transitively attempts to perform a synchronous `read` or `write` (regardless of
-whether the operation would have succeeded eagerly without blocking).
+Introducing the `stream_copy` function in chunks, first, the element at index
+`i` is checked to be of the right type and allowed to start a new copy. (In the
+future, the "trap if not `IDLE`" condition could be relaxed to allow multiple
+pipelined reads or writes.) There is also a trap if attempting to synchronously
+read or write from a stream that is already being asynchronously waited on via
+waitable set.
 ```python
 def stream_copy(EndT, BufferT, event_code, stream_t, opts, i, ptr, n):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not opts.async_)
-```
-
-Next, `stream_copy` checks that the element at index `i` is of the right type
-and allowed to start a new copy. (In the future, the "trap if not `IDLE`"
-condition could be relaxed to allow multiple pipelined reads or writes.)
-There is also a trap if attempting to synchronously read or write from a
-stream that is already being asynchronously waited on via waitable set.
-```python
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != stream_t.t)
@@ -4660,21 +4647,23 @@ def canon_future_write(future_t, opts, i, ptr):
 ```
 
 Introducing the `future_copy` function in chunks, `future_copy` starts with the
-same set of guards as `stream_copy` regarding whether suspension is allowed and
-parameters `i` and `ptr`. The only difference is that, with futures, the
-`Buffer` length is fixed to `1`.
+same set of guards on the element `i` as `stream_copy`, except checking for a
+*future* end instead of a *stream* end:
 ```python
 def future_copy(EndT, BufferT, event_code, future_t, opts, i, ptr):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not opts.async_)
-
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != future_t.t)
   trap_if(e.state != CopyState.IDLE)
   trap_if(e.in_waitable_set() and not opts.async_)
+```
 
+Next, a readable or writable buffer is created, as with streams, except that the
+buffer length is fixed to `1` and there is no validation-time prohibition on
+`future<char>`:
+```python
   assert(not contains_borrow(future_t))
   cx = LiftLowerContext(opts, thread.task.inst, borrow_scope = None)
   buffer = BufferT(future_t.t, cx, ptr, 1)
@@ -4754,7 +4743,6 @@ def canon_future_cancel_write(future_t, async_, i):
 def cancel_copy(EndT, event_code, stream_or_future_t, async_, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not async_)
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != stream_or_future_t.t)
@@ -4772,15 +4760,12 @@ def cancel_copy(EndT, event_code, stream_or_future_t, async_, i):
   assert(not e.copying() and code == event_code and index == i)
   return [payload]
 ```
-A non-`async`-typed function export that has not yet returned a value
-unconditionally traps if it transitively attempts to make a synchronous call to
-`cancel-read` or `cancel-write` (regardless of whether the cancellation would
-have completed without blocking). There is also a trap if there is not
-currently an async copy in progress (sync copies do not expect or check for
-cancellation and thus cannot be cancelled, and repeatedly cancelling the same
-async copy after the first call blocked is not allowed). Lastly, there is a
-trap if attempting to synchronously cancel a stream operation when the stream
-end is already being asynchronously waited on by a waitable set.
+Cancellation traps if there is not currently an async copy in progress (sync
+copies do not expect or check for cancellation and thus cannot be cancelled, and
+repeatedly cancelling the same async copy after the first call blocked is not
+allowed). There is also a trap if attempting to synchronously cancel a stream
+operation when the stream end is already being asynchronously waited on by a
+waitable set.
 
 The *first* check for `e.has_pending_event()` catches the case where the copy has
 already racily finished, in which case we must *not* call `cancel()`. Calling
@@ -4950,13 +4935,9 @@ calling component.
 def canon_thread_suspend(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block())
   cancelled = thread.suspend(cancellable)
   return [cancelled]
 ```
-A non-`async`-typed function export that has not yet returned a value traps if
-it transitively attempts to call `thread.suspend`.
-
 If `cancellable` is set, then `thread.suspend` will return a `Cancelled`
 value to indicate whether the supertask has already or concurrently requested
 cancellation. `thread.suspend` (and other cancellable operations) will only
@@ -4986,13 +4967,6 @@ def canon_thread_yield(cancellable):
   cancelled = thread.yield_(cancellable)
   return [cancelled]
 ```
-If a non-`async`-typed function export that has not yet returned a value
-transitively calls `thread.yield`, it returns immediately without blocking
-(instead of trapping, as with other possibly-blocking operations like
-`waitable-set.wait`). This is because, unlike other built-ins, `thread.yield`
-may be scattered liberally throughout code that might show up in the transitive
-call tree of a synchronous function call.
-
 If `cancellable` is set, then `thread.yield` will return a `Cancelled`
 value indicating whether the supertask has already or concurrently requested
 cancellation. `thread.yield` (and other cancellable operations) will only
@@ -5001,65 +4975,124 @@ cancellation, they can omit `cancellable` so that cancellation is instead
 delivered at a later `cancellable` call.
 
 
-### 🧵 `canon thread.switch-to`
+### 🧵 `canon thread.suspend-then-resume`
 
 For a canonical definition:
 ```wat
-(canon thread.switch-to $cancellable? (core func $switch-to))
+(canon thread.suspend-then-resume $cancellable? (core func $suspend-then-resume))
 ```
 validation specifies:
-* `$switch-to` is given type `(func (param $i i32) (result i32))`
+* `$suspend-then-resume` is given type `(func (param $i i32) (result i32))`
 
-Calling `$switch-to` invokes the following function which loads a thread at
-index `$i` from the current component instance's `threads` table, traps if it's
-not [suspended], and then switches to that thread, leaving the [current thread]
-suspended.
+Calling `$suspend-then-resume` invokes the following function which loads a
+thread at index `$i` from the current component instance's `threads` table,
+traps if it's not [suspended], and then switches to that thread, leaving the
+[current thread] suspended.
 ```python
-def canon_thread_switch_to(cancellable, i):
+def canon_thread_suspend_then_resume(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.switch_to(cancellable, other_thread)
+  cancelled = thread.suspend_then_resume(cancellable, other_thread)
   return [cancelled]
 ```
-If `cancellable` is set, then `thread.switch-to` will return a `Cancelled`
-value to indicate whether the supertask has already or concurrently requested
-cancellation. `thread.switch-to` (and other cancellable operations) will only
-indicate cancellation once and thus, if a caller is not prepared to propagate
-cancellation, they can omit `cancellable` so that cancellation is instead
-delivered at a later `cancellable` call.
+If `cancellable` is set, then `thread.suspend-then-resume` will return a
+`Cancelled` value to indicate whether the supertask has already or concurrently
+requested cancellation. `thread.suspend-then-resume` (and other cancellable
+operations) will only indicate cancellation once and thus, if a caller is not
+prepared to propagate cancellation, they can omit `cancellable` so that
+cancellation is instead delivered at a later `cancellable` call.
 
 
-### 🧵 `canon thread.yield-to`
+### 🧵 `canon thread.yield-then-resume`
 
 For a canonical definition:
 ```wat
-(canon thread.yield-to $cancellable? (core func $yield-to))
+(canon thread.yield-then-resume $cancellable? (core func $yield-then-resume))
 ```
 validation specifies:
-* `$yield-to` is given type `(func (param $i i32) (result i32))`
+* `$yield-then-resume` is given type `(func (param $i i32) (result i32))`
 
-Calling `$yield-to` invokes the following function which loads a thread at
-index `$i` from the current component instance's `threads` table, traps if it's
-not [suspended], and then switches to that thread, leaving the [current thread]
-ready to run at some nondeterministic point in the future chosen by the
+Calling `$yield-then-resume` invokes the following function which loads a thread
+at index `$i` from the current component instance's `threads` table, traps if
+it's not [suspended], and then switches to that thread, leaving the [current
+thread] ready to run at some nondeterministic point in the future chosen by the
 embedder.
 ```python
-def canon_thread_yield_to(cancellable, i):
+def canon_thread_yield_then_resume(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.yield_to(cancellable, other_thread)
+  cancelled = thread.yield_then_resume(cancellable, other_thread)
   return [cancelled]
 ```
-If `cancellable` is set, then `thread.yield-to` will return a `Cancelled`
-value indicating whether the supertask has already or concurrently requested
-cancellation. `thread.yield-to` (and other cancellable operations) will only
-indicate cancellation once and thus, if a caller is not prepared to propagate
-cancellation, they can omit `cancellable` so that cancellation is instead
-delivered at a later `cancellable` call.
+If `cancellable` is set, then `thread.yield-then-resume` will return a
+`Cancelled` value indicating whether the supertask has already or concurrently
+requested cancellation. `thread.yield-then-resume` (and other cancellable
+operations) will only indicate cancellation once and thus, if a caller is not
+prepared to propagate cancellation, they can omit `cancellable` so that
+cancellation is instead delivered at a later `cancellable` call.
+
+
+### 🧵 `canon thread.suspend-then-promote`
+
+For a canonical definition:
+```wat
+(canon thread.suspend-then-promote $cancellable? (core func $suspend-then-promote))
+```
+validation specifies:
+* `$suspend-then-promote` is given type `(func (param $i i32) (result i32))`
+
+Calling `$suspend-then-promote` invokes the following function which loads a
+thread at index `$i` from the current component instance's `threads` table and
+then calls `Thread.suspend_then_resume` to resume the `other_thread` if it's
+`ready` and, in any case, leave the [current thread] suspended.
+```python
+def canon_thread_suspend_then_promote(cancellable, i):
+  thread = current_thread()
+  trap_if(not thread.task.inst.may_leave)
+  other_thread = thread.task.inst.threads.get(i)
+  cancelled = thread.suspend_then_promote(cancellable, other_thread)
+  return [cancelled]
+```
+If `cancellable` is set, then `thread.suspend-then-promote` will return a
+`Cancelled` value indicating whether the supertask has already or concurrently
+requested cancellation. `thread.suspend-then-promote` (and other cancellable
+operations) will only indicate cancellation once and thus, if a caller is not
+prepared to propagate cancellation, they can omit `cancellable` so that
+cancellation is instead delivered at a later `cancellable` call.
+
+
+### 🧵 `canon thread.yield-then-promote`
+
+For a canonical definition:
+```wat
+(canon thread.yield-then-promote $cancellable? (core func $yield-then-promote))
+```
+validation specifies:
+* `$yield-then-promote` is given type `(func (param $i i32) (result i32))`
+
+Calling `$yield-then-promote` invokes the following function which loads a
+thread at index `$i` from the current component instance's `threads` table and
+then calls `Thread.yield_then_resume` to resume the `other_thread` if it's
+`ready` and, in any case, leave the [current thread] ready to run at some
+nondeterministic point in the future chosen by the embedder.
+```python
+def canon_thread_yield_then_promote(cancellable, i):
+  thread = current_thread()
+  trap_if(not thread.task.inst.may_leave)
+  other_thread = thread.task.inst.threads.get(i)
+  cancelled = thread.yield_then_promote(cancellable, other_thread)
+  return [cancelled]
+```
+If `cancellable` is set, then `thread.yield-then-promote` will return a
+`Cancelled` value indicating whether the supertask has already or concurrently
+requested cancellation. `thread.yield-then-promote` (and other cancellable
+operations) will only indicate cancellation once and thus, if a caller is not
+prepared to propagate cancellation, they can omit `cancellable` so that
+cancellation is instead delivered at a later `cancellable` call.
 
 
 ### 📝 `canon error-context.new`

--- a/design/mvp/Concurrency.md
+++ b/design/mvp/Concurrency.md
@@ -388,32 +388,44 @@ learn its own index by calling the [`thread.index`] built-in.
 
 A suspended thread (identified by thread-table index) can be resumed at some
 nondeterministic point in future via the [`thread.resume-later`] built-in. In
-contrast, the [`thread.yield-to`] built-in switches execution to the given
-thread immediately, leaving the *calling* thread to be resumed at some
-nondeterministic point in the future. Lastly, the [`thread.switch-to`]
-built-in switches execution to the given thread immediately, like `yield-to`,
-but leaves the calling thread in the "suspended" state. These three functions
-can be used to resume both newly-created threads as well as threads that
-executed and then suspended.
+contrast, the [`thread.yield-then-resume`] built-in switches execution to the
+given thread immediately, leaving the *calling* thread to be resumed at some
+nondeterministic point in the future. Lastly, the [`thread.suspend-then-resume`]
+built-in switches execution to the given thread immediately, like
+`thread.yield-then-resume`, but leaves the calling thread in the "suspended"
+state. These three functions can be used to resume both newly-created threads as
+well as threads that executed and then suspended.
 
-In addition to threads entering the suspended state via `thread.new-indirect`
-and `thread.switch-to`, threads can also explicitly suspend themselves via the
-[`thread.suspend`] built-in. Thus, there are three ways a thread *enters* the
-suspended state and three ways a thread *exits* the suspended state (with
-`thread.switch-to` serving in both categories). Together, these 5 thread
-built-ins support both the "green thread" [use cases](#goals) where Core
-WebAssembly code running inside the component wants to fully control thread
-scheduling (via `thread.switch-to` and `thread.suspend`) as well as the "host
-thread" use cases where the Core WebAssembly code wants to let the containing
-runtime nondeterministically schedule threads (via `thread.resume-later` or
-`thread.yield-to`).
+Threads can also explicitly put themselves in the "suspended" state without
+specifying the other thread to run by calling the [`thread.suspend`] built-in.
+This is useful if a thread needs to wait on some condition that will be met by
+some unknown thread in the future (which will resume the suspended thread).
+Similarly, threads can explicitly put themselves in the "ready to run" state
+without specifying the other thread to run by calling [`thread.yield`]. This is
+useful if a thread has a long-running computation without I/O but still needs to
+allow other cooperative threads to make progress concurrently.
 
-Lastly, since threads are cooperative, there is a [`thread.yield`] built-in
-that can be called in the middle of long-running computations to allow the
-runtime to nondeterministically switch execution to another thread.
-`thread.yield` is equivalent to (but obviously more efficient than) creating a
-new thread with a no-op function (via `thread.new-indirect`) and then yielding
-to it (via `thread.yield-to`).
+Lastly, in addition to being able to switch to "suspended" threads, threads can
+also switch to threads that are in a "ready to run" state by calling the
+[`thread.suspend-then-promote`] and [`thread.yield-then-promote`] built-ins
+which, like the `thread.{suspend,yield}-then-resume` built-ins, leave the
+calling thread in a "suspended" or "ready to run" state, resp. The calling
+thread *may* know that the target thread is ready to run (e.g., because the
+target thread is known to have yielded or to be waiting on a future/stream
+operation that the calling thread just completed). However, in general,
+readiness may depend on nondeterministic external I/O and the calling thread may
+just want to yield its timeslice to the target thread *if* it's ready as a
+scheduling optimization. Thus, if the target thread is *not* "ready to run",
+these built-ins are defined to gracefully fall back to the behavior of the
+`thread.{suspend,yield}` built-ins.
+
+Together, these thread built-ins support both the "green thread" [use
+cases](#goals), where Core WebAssembly code running inside the component wants
+to fully control thread scheduling (via suspending and resuming built-ins),
+and the "host thread" use cases, where the Core WebAssembly code wants to let
+the containing runtime nondeterministically schedule threads (via yielding
+built-ins) with hints (via the promoting built-ins) — or a mixture of both.
+
 
 ### Thread-Local Storage
 
@@ -467,47 +479,70 @@ For more information, see [`context.get`] in the AST explainer.
 ### Blocking
 
 When a thread calls an import using the async ABI, the Component Model
-guarantees that if the callee **blocks**, control flow is immediately returned
-back to the caller. When the callee is implemented by the *host*, what counts as
-"blocking" is up to the host; e.g., the host can arbitrarily determine whether
-file I/O "blocks" or not depending on whether the host is implemented using
-traditional synchronous OS syscalls or an asynchronous `io_uring`. However,
-when the callee is implemented by another component, the Component Model
-defines exactly what counts as "blocking".
+guarantees that if the callee [task](#threads-and-tasks) **blocks**, control
+flow is immediately returned back to the caller's thread. When the callee is
+implemented by the *host*, what counts as "blocking" is up to the host; e.g.,
+the host can arbitrarily determine whether file I/O "blocks" or not depending on
+whether the host is implemented using traditional synchronous OS syscalls or an
+asynchronous `io_uring`. However, when the callee is implemented by another
+component, the Component Model defines what counts as "blocking".
 
-At a high level, there are six ways for a call to a component export to block,
-all of which are described above or below in more detail:
-* calling an `async`-typed function import using the sync ABI
+There are several ways for a task to potentially "block":
+* synchronously calling an `async` function that transitively blocks
+  or hits [backpressure](#backpressure)
 * suspending the current thread via the
-  [`thread.suspend`](#thread-built-ins) built-in
+  [`thread.suspend{,-then-promote}`](#thread-built-ins) built-ins
 * cooperatively yielding (e.g., during a long-running computation) via the
-  [`thread.yield`](#thread-built-ins) built-in
+  [`thread.yield{,-then-promote}`](#thread-built-ins) built-ins or, when
+  using the stackless `callback` ABI, returning with the `YIELD` code
 * waiting for one of a set of concurrent operations to complete via the
-  [`waitable-set.wait`](#waitables-and-waitable-sets) built-in
-* waiting for a stream or future operation to complete via the
+  [`waitable-set.wait`](#waitables-and-waitable-sets) built-in or, when
+  using the stackless `callback` ABI, returning with the `WAIT` code
+* synchronously waiting for a stream or future operation to complete via the
   [`{stream,future}.{,cancel-}{read,write}`](#streams-and-futures) built-ins
-* waiting for a subtask to cooperatively cancel itself via the
+* synchronously waiting for a subtask to cooperatively cancel itself via the
   [`subtask.cancel`](#cancellation) built-in
 
-At each of these points, the [current thread](#current-thread-and-task) will be
-suspended. Execution transfers to a caller's thread if there is one, or
-otherwise back to the runtime, which may invoke new component exports or
-nondeterministically resume a cooperative thread that is ready to run. Thus,
-each of these represents **cooperative yield points**.
+Since Component Model concurrency is [specified in terms of] the Core WebAssembly
+[stack-switching] proposal, each of the above represents a point where the
+[current thread](#current-thread-and-task) may suspend with the `$block` effect.
+Each of these points also serves as a **cooperative yield point** where
+[Component Invariant] #2 allows reentrance. However, just because the current
+thread *suspends* doesn't mean that the *task* has officially "blocked": what
+happens next depends on the state of the task and the declared function type:
 
-Additionally, each of these potentially-blocking operations will trap if the
-[current task's function type](#current-thread-and-task) does not declare the
-`async` effect, since only `async`-typed functions are allowed to block. As an
-exception, to allow it to be called arbitrarily from anywhere, `thread.yield`
-does not trap but instead behaves as a no-op if the current task's function
-type does not contain `async`.
+If the task has already [returned](#returning) a value to the caller, then
+control flow returns to the caller and, from the caller's perspective, the call
+returns normally without blocking. The callee's threads can continue executing,
+but what happens with these threads no longer matters to the caller.
 
-"Blocking" is [specified in terms of] stack-switching, with a `block` effect
-that suspends the current thread to produce a continuation that can be resumed
-once the reason for blocking is addressed.
+If instead the task has *not* yet returned a value and the callee's function
+type declares the `async` effect, control flow returns directly to the
+caller. If the caller used the *async* ABI, then control flow returns to Core
+WebAssembly, indicating that the call "blocked" by returning the non-zero index
+of a new [subtask](#subtasks-and-supertasks). If the caller used the *sync* ABI,
+then the caller immediately suspends with the `$block` effect and this process
+repeats recursively up the stack.
 
-The [Canonical ABI explainer] defines the above behavior more precisely; search
-for `may_block` to see all the relevant points.
+Lastly, if the task has not yet returned a value and the callee's function type
+does *not* declare the `async` effect, then the task is not allowed to "block"
+and will trap if it ends up blocking. However, just because the *current thread*
+has suspended doesn't mean that the overall *task* is blocked: if there are any
+other threads in the callee's component instance that are in the ["ready to
+run"](#thread-built-ins) state, progressing them may unblock returning a value
+(e.g., by releasing a lock or computing a dependency) and so the Component Model
+repeatedly resumes threads that are ready to run until either the task returns a
+value or there are no more eligible ready threads (and the call traps).
+See the end of [`canon_lift`] in the Canonical ABI Explainer for more details.
+
+These rules achieve expressive parity with what would otherwise be possible
+using a CPS transform like [Asyncify] to implement a synchronous function. For
+example, they allow synchronous functions to be implemented by pthreads that
+switch and make progress at cooperative yield points. And if there is only a
+single pthread, since `thread.yield` always leaves the calling thread in a
+"ready to run" state, `thread.yield` effectively becomes a no-op (until a value
+is returned).
+
 
 ### Waitables and Waitable Sets
 
@@ -713,9 +748,7 @@ the readable end passed for `in`) and `stream.write`s (of the writable end it
 `stream.new`ed) before exiting the task.
 
 Once `task.return` is called, the task is in the "returned" state. Calling
-`task.return` when not in the "started" state traps. Once in a "returned" state,
-non-`async` functions may block using cooperative threads that were created
-before the synchronous task's implicit thread returned.
+`task.return` when not in the "started" state traps.
 
 ### Borrows
 
@@ -1538,13 +1571,15 @@ comes after:
 [`waitable-set.wait`]: Explainer.md#-waitable-setwait
 [`waitable-set.poll`]: Explainer.md#-waitable-setpoll
 [`waitable.join`]: Explainer.md#-waitablejoin
-[`thread.new-indirect`]: Explainer.md#-threadnew-indirect
 [`thread.index`]: Explainer.md#-threadindex
-[`thread.suspend`]: Explainer.md#-threadsuspend
-[`thread.switch-to`]: Explainer.md#-threadswitch-to
+[`thread.new-indirect`]: Explainer.md#-threadnew-indirect
 [`thread.resume-later`]: Explainer.md#-threadresume-later
-[`thread.yield-to`]: Explainer.md#-threadyield-to
+[`thread.suspend`]: Explainer.md#-threadsuspend
 [`thread.yield`]: Explainer.md#-threadyield
+[`thread.suspend-then-resume`]: Explainer.md#-threadsuspend-then-resume
+[`thread.yield-then-resume`]: Explainer.md#-threadyield-then-resume
+[`thread.suspend-then-promote`]: Explainer.md#-threadsuspend-then-promote
+[`thread.yield-then-promote`]: Explainer.md#-threadyield-then-promote
 [`{stream,future}.new`]: Explainer.md#-streamnew-and-futurenew
 [`{stream,future}.{read,write}`]: Explainer.md#-streamread-and-streamwrite
 [`stream.cancel-write`]: Explainer.md#-streamcancel-read-streamcancel-write-futurecancel-read-and-futurecancel-write

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1468,8 +1468,10 @@ canon ::= ...
         | (canon thread.resume-later (core func <id>?)) 🧵
         | (canon thread.suspend cancellable? (core func <id>?)) 🧵
         | (canon thread.yield cancellable? (core func <id>?)) 🔀
-        | (canon thread.switch-to cancellable? (core func <id>?)) 🧵
-        | (canon thread.yield-to cancellable? (core func <id>?)) 🧵
+        | (canon thread.suspend-then-resume cancellable? (core func <id>?)) 🧵
+        | (canon thread.yield-then-resume cancellable? (core func <id>?)) 🧵
+        | (canon thread.suspend-then-promote cancellable? (core func <id>?)) 🧵
+        | (canon thread.yield-then-promote cancellable? (core func <id>?)) 🧵
         | (canon error-context.new <canonopt>* (core func <id>?)) 📝
         | (canon error-context.debug-message <canonopt>* (core func <id>?)) 📝
         | (canon error-context.drop (core func <id>?)) 📝
@@ -2089,8 +2091,9 @@ extended for [GC].
 
 As explained in the [concurrency explainer], a thread created by
 `thread.new-indirect` is initially in a suspended state and must be resumed
-eagerly or lazily by [`thread.yield-to`](#-threadyield-to) or
-[`thread.resume-later`](#-threadresume-later), resp., to begin execution.
+eagerly by [`thread.suspend-then-resume`](#-threadsuspend-then-resume) or
+[`thread.yield-then-resume`](#-threadyield-then-resume) or lazily by
+[`thread.resume-later`](#-threadresume-later) to begin execution.
 
 For details, see [Thread Built-ins] in the concurrency explainer and
 [`canon_thread_new_indirect`] in the Canonical ABI explainer.
@@ -2122,9 +2125,6 @@ explicitly resumed by some other thread calling a built-in such as
 the current task was [cancelled] by the caller; otherwise, `thread.suspend`
 always returns `false`.
 
-A non-`async`-typed function export that has not yet returned a value traps if
-it transitively attempts to call `thread.suspend`.
-
 For details, see [Thread Built-ins] in the concurrency explainer and
 [`canon_thread_suspend`] in the Canonical ABI explainer.
 
@@ -2138,52 +2138,77 @@ For details, see [Thread Built-ins] in the concurrency explainer and
 The `thread.yield` built-in allows the runtime to potentially switch to any
 other thread in the "ready" state, enabling a long-running computation to
 cooperatively interleave execution without specifically requesting another
-thread to be resumed (as with `thread.yield-to`). If `cancellable` is set,
-`thread.yield` returns whether the current task was [cancelled] by the caller;
-otherwise, `thread.yield` always returns `false`.
-
-If `thread.yield` is called from a synchronous- or `async callback`-lifted
-export, it returns immediately without blocking (instead of trapping, as with
-other possibly-blocking operations like `waitable-set.wait`). This is because,
-unlike other built-ins, `thread.yield` may be scattered liberally throughout
-code that might show up in the transitive call tree of a synchronous function
-call.
+thread to be resumed (as with `thread.yield-then-resume`). If `cancellable` is
+set, `thread.yield` returns whether the current task was [cancelled] by the
+caller; otherwise, `thread.yield` always returns `false`.
 
 For details, see [Thread Built-ins] in the concurrency explainer and
 [`canon_thread_yield`] in the Canonical ABI explainer.
 
-###### 🧵 `thread.switch-to`
+###### 🧵 `thread.suspend-then-resume`
 
 | Synopsis                   |                                         |
 | -------------------------- | --------------------------------------- |
 | Approximate WIT signature  | `func<cancellable?>(t: thread) -> bool` |
 | Canonical ABI signature    | `[t:i32] -> [i32]`                      |
 
-The `thread.switch-to` built-in suspends the [current thread] and immediately
-resumes execution of the thread `t`, trapping if `t` is not in a "suspended"
-state. If `cancellable` is set, `thread.switch-to` returns whether the current
-task was [cancelled] by the caller; otherwise, `thread.switch-to` always returns
-`false`.
+The `thread.suspend-then-resume` built-in suspends the [current thread] and
+immediately resumes execution of the thread `t`, trapping if `t` is not in a
+"suspended" state. If `cancellable` is set, `thread.suspend-then-resume` returns
+whether the current task was [cancelled] by the caller; otherwise,
+`thread.suspend-then-resume` always returns `false`.
 
 For details, see [Thread Built-ins] in the concurrency explainer and
-[`canon_thread_switch_to`] in the Canonical ABI explainer.
+[`canon_thread_suspend_then_resume`] in the Canonical ABI explainer.
 
-###### 🧵 `thread.yield-to`
+###### 🧵 `thread.yield-then-resume`
 
 | Synopsis                   |                                         |
 | -------------------------- | --------------------------------------- |
 | Approximate WIT signature  | `func<cancellable?>(t: thread) -> bool` |
 | Canonical ABI signature    | `[t:i32] -> [i32]`                      |
 
-The `thread.yield-to` built-in immediately resumes execution of the thread `t`,
-(trapping if `t` is not in a "suspended" state) leaving the [current thread] in
-a "ready" state so that the runtime can nondeterministically resume the current
-thread at some point in the future. If `cancellable` is set, `thread.yield-to`
+The `thread.yield-then-resume` built-in immediately resumes execution of the
+thread `t` (trapping if `t` is not in a "suspended" state), leaving the [current
+thread] in a "ready" state so that the runtime can nondeterministically resume
+the current thread at some point in the future. If `cancellable` is set,
+`thread.yield-then-resume` returns whether the current task was [cancelled] by
+the caller; otherwise, `thread.yield-then-resume` always returns `false`.
+
+For details, see [Thread Built-ins] in the concurrency explainer and
+[`canon_thread_yield_then_resume`] in the Canonical ABI explainer.
+
+###### 🧵 `thread.suspend-then-promote`
+
+| Synopsis                   |                                         |
+| -------------------------- | --------------------------------------- |
+| Approximate WIT signature  | `func<cancellable?>(t: thread) -> bool` |
+| Canonical ABI signature    | `[t:i32] -> [i32]`                      |
+
+The `thread.suspend-then-promote` built-in immediately resumes execution of the
+thread `t` if `t` is in a "ready" state, in any case leaving the current thread
+in a "suspended" state. If `cancellable` is set, `thread.suspend-then-promote`
 returns whether the current task was [cancelled] by the caller; otherwise,
-`thread.yield-to` always returns `false`.
+`thread.suspend-then-promote` always returns `false`.
 
 For details, see [Thread Built-ins] in the concurrency explainer and
-[`canon_thread_yield_to`] in the Canonical ABI explainer.
+[`canon_thread_suspend_then_promote`] in the Canonical ABI explainer.
+
+###### 🧵 `thread.yield-then-promote`
+
+| Synopsis                   |                                         |
+| -------------------------- | --------------------------------------- |
+| Approximate WIT signature  | `func<cancellable?>(t: thread) -> bool` |
+| Canonical ABI signature    | `[t:i32] -> [i32]`                      |
+
+The `thread.yield-then-promote` built-in immediately resumes execution of the
+thread `t` if `t` is in a "ready" state, in any case leaving the current thread
+in a "ready" state. If `cancellable` is set, `thread.yield-then-promote` returns
+whether the current task was [cancelled] by the caller; otherwise,
+`thread.yield-then-promote` always returns `false`.
+
+For details, see [Thread Built-ins] in the concurrency explainer and
+[`canon_thread_yield_then_promote`] in the Canonical ABI explainer.
 
 ###### 🧵② `thread.spawn-ref`
 
@@ -3283,11 +3308,13 @@ For some use-case-focused, worked examples, see:
 [`canon_error_context_drop`]: CanonicalABI.md#-canon-error-contextdrop
 [`canon_thread_index`]: CanonicalABI.md#-canon-threadindex
 [`canon_thread_new_indirect`]: CanonicalABI.md#-canon-threadnew-indirect
-[`canon_thread_suspend`]: CanonicalABI.md#-canon-threadsuspend
-[`canon_thread_switch_to`]: CanonicalABI.md#-canon-threadswitch-to
 [`canon_thread_resume_later`]: CanonicalABI.md#-canon-threadresume-later
-[`canon_thread_yield_to`]: CanonicalABI.md#-canon-threadyield-to
+[`canon_thread_suspend`]: CanonicalABI.md#-canon-threadsuspend
 [`canon_thread_yield`]: CanonicalABI.md#-canon-threadyield
+[`canon_thread_suspend_then_resume`]: CanonicalABI.md#-canon-threadsuspend-then-resume
+[`canon_thread_yield_then_resume`]: CanonicalABI.md#-canon-threadyield-then-resume
+[`canon_thread_suspend_then_promote`]: CanonicalABI.md#-canon-threadsuspend-then-promote
+[`canon_thread_yield_then_promote`]: CanonicalABI.md#-canon-threadyield-then-promote
 [`canon_thread_spawn_ref`]: CanonicalABI.md#-canon-threadspawn-ref
 [`canon_thread_spawn_indirect`]: CanonicalABI.md#-canon-threadspawn-indirect
 [`canon_thread_available_parallelism`]: CanonicalABI.md#-canon-threadavailable_parallelism

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -388,13 +388,13 @@ class Thread:
     return cancelled
 
   def suspend(self, cancellable) -> Cancelled:
-    assert(self.running() and self.task.may_block())
+    assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     return self.block_internal(cancellable)
 
   def wait_until(self, ready_func, cancellable = False) -> Cancelled:
-    assert(self.running() and self.task.may_block())
+    assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     if ready_func() and not DETERMINISTIC_PROFILE and random.randint(0,1):
@@ -402,29 +402,37 @@ class Thread:
     self.start_waiting_internal(ready_func)
     return self.block_internal(cancellable)
 
-  def yield_until(self, ready_func, cancellable) -> Cancelled:
-    assert(self.running())
-    if self.task.may_block():
-      return self.wait_until(ready_func, cancellable)
-    else:
-      assert(ready_func())
-      return Cancelled.FALSE
-
   def yield_(self, cancellable) -> Cancelled:
-    return self.yield_until(lambda: True, cancellable)
+    return self.wait_until(lambda: True, cancellable)
 
-  def switch_to(self, cancellable, other: Thread) -> Cancelled:
+  def suspend_then_resume(self, cancellable, other: Thread) -> Cancelled:
     assert(self.running() and other.suspended())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     return self.switch_to_internal(cancellable, other)
 
-  def yield_to(self, cancellable, other: Thread) -> Cancelled:
+  def yield_then_resume(self, cancellable, other: Thread) -> Cancelled:
     assert(self.running() and other.suspended())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     self.start_waiting_internal(lambda: True)
     return self.switch_to_internal(cancellable, other)
+
+  def suspend_then_promote(self, cancellable, other: Thread) -> Cancelled:
+    assert(self.running())
+    if other.ready():
+      other.stop_waiting_internal(cancelled = False)
+      return self.suspend_then_resume(cancellable, other)
+    else:
+      return self.suspend(cancellable)
+
+  def yield_then_promote(self, cancellable, other: Thread) -> Cancelled:
+    assert(self.running())
+    if other.ready():
+      other.stop_waiting_internal(cancelled = False)
+      return self.yield_then_resume(cancellable, other)
+    else:
+      return self.yield_(cancellable)
 
 ### Tasks
 
@@ -467,9 +475,6 @@ class Task:
   def needs_exclusive(self):
     assert(self.ft.async_)
     return not self.opts.async_ or self.opts.callback
-
-  def may_block(self):
-    return self.ft.async_ or self.state == Task.State.RESOLVED
 
   def enter_implicit_thread(self):
     assert(self.state == Task.State.INITIAL)
@@ -677,6 +682,11 @@ class Table:
   def __init__(self):
     self.array = [None]
     self.free = []
+
+  def __iter__(self):
+    for e in self.array:
+      if e is not None:
+        yield e
 
   def get(self, i):
     trap_if(i >= len(self.array))
@@ -2151,13 +2161,12 @@ def canon_lift(callee, ft, opts, inst, on_start, on_resolve, caller) -> OnCancel
       inst.exclusive_thread = None
       match code:
         case CallbackCode.YIELD:
-          cancelled = thread.yield_until(lambda: not inst.exclusive_thread, cancellable = True)
+          cancelled = thread.wait_until(lambda: not inst.exclusive_thread, cancellable = True)
           if cancelled:
             event = (EventCode.TASK_CANCELLED, 0, 0)
           else:
             event = (EventCode.NONE, 0, 0)
         case CallbackCode.WAIT:
-          trap_if(not task.may_block())
           wset = inst.handles.get(si)
           trap_if(not isinstance(wset, WaitableSet))
           event = wset.wait_for_event_and(lambda: not inst.exclusive_thread, cancellable = True)
@@ -2174,6 +2183,11 @@ def canon_lift(callee, ft, opts, inst, on_start, on_resolve, caller) -> OnCancel
   task = Task(ft, opts, inst, on_start, on_resolve, caller)
   thread = Thread(task, thread_func)
   thread.resume()
+  if not ft.async_:
+    while task.state != Task.State.RESOLVED:
+      candidates = { t for t in inst.threads if t.ready() and t is not inst.exclusive_thread }
+      trap_if(not candidates)
+      random.choice(list(candidates)).resume()
   return task.request_cancellation
 
 class CallbackCode(IntEnum):
@@ -2201,8 +2215,6 @@ def call_and_trap_on_throw(callee, args):
 def canon_lower(callee, ft, opts, flat_args: list[CoreValType]) -> list[CoreValType]:
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and ft.async_ and not opts.async_)
-
   subtask = Subtask()
   cx = LiftLowerContext(opts, thread.task.inst, subtask)
 
@@ -2383,7 +2395,6 @@ def canon_waitable_set_new():
 def canon_waitable_set_wait(cancellable, mem, si, ptr):
   task = current_task()
   trap_if(not task.inst.may_leave)
-  trap_if(not task.may_block())
   wset = task.inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
   event = wset.wait_for_event(cancellable)
@@ -2439,7 +2450,6 @@ BLOCKED = 0xffff_ffff
 def canon_subtask_cancel(async_, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not async_)
   subtask = thread.task.inst.handles.get(i)
   trap_if(not isinstance(subtask, Subtask))
   trap_if(subtask.resolve_delivered())
@@ -2501,8 +2511,6 @@ def canon_stream_write(stream_t, opts, i, ptr, n):
 def stream_copy(EndT, BufferT, event_code, stream_t, opts, i, ptr, n):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not opts.async_)
-
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != stream_t.t)
@@ -2557,8 +2565,6 @@ def canon_future_write(future_t, opts, i, ptr):
 def future_copy(EndT, BufferT, event_code, future_t, opts, i, ptr):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not opts.async_)
-
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != future_t.t)
@@ -2611,7 +2617,6 @@ def canon_future_cancel_write(future_t, async_, i):
 def cancel_copy(EndT, event_code, stream_or_future_t, async_, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block() and not async_)
   e = thread.task.inst.handles.get(i)
   trap_if(not isinstance(e, EndT))
   trap_if(e.shared.t != stream_or_future_t.t)
@@ -2695,7 +2700,6 @@ def canon_thread_resume_later(i):
 def canon_thread_suspend(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  trap_if(not thread.task.may_block())
   cancelled = thread.suspend(cancellable)
   return [cancelled]
 
@@ -2707,24 +2711,42 @@ def canon_thread_yield(cancellable):
   cancelled = thread.yield_(cancellable)
   return [cancelled]
 
-### 🧵 `canon thread.switch-to`
+### 🧵 `canon thread.suspend-then-resume`
 
-def canon_thread_switch_to(cancellable, i):
+def canon_thread_suspend_then_resume(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.switch_to(cancellable, other_thread)
+  cancelled = thread.suspend_then_resume(cancellable, other_thread)
   return [cancelled]
 
-### 🧵 `canon thread.yield-to`
+### 🧵 `canon thread.yield-then-resume`
 
-def canon_thread_yield_to(cancellable, i):
+def canon_thread_yield_then_resume(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.yield_to(cancellable, other_thread)
+  cancelled = thread.yield_then_resume(cancellable, other_thread)
+  return [cancelled]
+
+### 🧵 `canon thread.suspend-then-promote`
+
+def canon_thread_suspend_then_promote(cancellable, i):
+  thread = current_thread()
+  trap_if(not thread.task.inst.may_leave)
+  other_thread = thread.task.inst.threads.get(i)
+  cancelled = thread.suspend_then_promote(cancellable, other_thread)
+  return [cancelled]
+
+### 🧵 `canon thread.yield-then-promote`
+
+def canon_thread_yield_then_promote(cancellable, i):
+  thread = current_thread()
+  trap_if(not thread.task.inst.may_leave)
+  other_thread = thread.task.inst.threads.get(i)
+  cancelled = thread.yield_then_promote(cancellable, other_thread)
   return [cancelled]
 
 ### 📝 `canon error-context.new`

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -2332,13 +2332,13 @@ def test_cancel_subtask():
   def thread_func(cancellable, args):
     [mainthreadi] = args
     if cancellable:
-      [ret] = canon_thread_switch_to(True, mainthreadi)
+      [ret] = canon_thread_suspend_then_resume(True, mainthreadi)
       assert(ret == Cancelled.TRUE)
-      [ret] = canon_thread_switch_to(True, mainthreadi)
+      [ret] = canon_thread_suspend_then_resume(True, mainthreadi)
       assert(ret == Cancelled.FALSE)
       [] = canon_task_return([U8Type()], callee_opts, [45])
     else:
-      [ret] = canon_thread_switch_to(False, mainthreadi)
+      [ret] = canon_thread_suspend_then_resume(False, mainthreadi)
       assert(ret == Cancelled.FALSE)
     return []
   cthread_func = partial(thread_func, True)
@@ -2353,15 +2353,15 @@ def test_cancel_subtask():
     [mainthreadi] = canon_thread_index()
 
     [threadi1] = canon_thread_new_indirect(core_ft, core_ftbl, ncfi, mainthreadi)
-    [ret] = canon_thread_switch_to(True, threadi1)
+    [ret] = canon_thread_suspend_then_resume(True, threadi1)
     assert(ret == Cancelled.FALSE)
 
     [threadi2] = canon_thread_new_indirect(core_ft, core_ftbl, cfi, mainthreadi)
-    [ret] = canon_thread_switch_to(True, threadi2)
+    [ret] = canon_thread_suspend_then_resume(True, threadi2)
     assert(ret == Cancelled.FALSE)
 
     [threadi3] = canon_thread_new_indirect(core_ft, core_ftbl, ncfi, mainthreadi)
-    [ret] = canon_thread_switch_to(True, threadi3)
+    [ret] = canon_thread_suspend_then_resume(True, threadi3)
     assert(ret == Cancelled.FALSE)
 
     [ret] = canon_thread_suspend(False)
@@ -2671,7 +2671,7 @@ def test_threads():
 
   def thread_func2(args):
     [mainthreadi] = args
-    [ret] = canon_thread_yield_to(True, mainthreadi)
+    [ret] = canon_thread_yield_then_resume(True, mainthreadi)
     assert(ret == Cancelled.FALSE)
     return []
   fi2 = ftbl.add(CoreFuncRef(ft, thread_func2))
@@ -2699,11 +2699,11 @@ def test_threads():
     [mainthreadi] = canon_thread_index()
 
     [threadi] = canon_thread_new_indirect(ft, ftbl, fi1, 13)
-    [ret] = canon_thread_yield_to(True, threadi)
+    [ret] = canon_thread_yield_then_resume(True, threadi)
     assert(ret == Cancelled.FALSE)
 
     [threadi] = canon_thread_new_indirect(ft, ftbl, fi2, mainthreadi)
-    [ret] = canon_thread_switch_to(True, threadi)
+    [ret] = canon_thread_suspend_then_resume(True, threadi)
     assert(ret == Cancelled.FALSE)
 
     [threadi] = canon_thread_new_indirect(ft, ftbl, fi3, mainthreadi)
@@ -2729,6 +2729,152 @@ def test_threads():
   caller_ft = FuncType([], [U8Type()], async_ = True)
   lift_and_run(opts, inst, caller_ft, core_func, lambda:[], on_resolve)
   assert(result == 42)
+
+def test_sync_threads():
+  store = Store()
+  inst = ComponentInstance(store)
+
+  mem = bytearray(8)
+  opts = mk_opts(memory = MemInst(mem, 'i32'), async_ = True)
+  ftbl = Table()
+  ft = CoreFuncType(['i32'],[])
+
+  ping_count1 = 0
+  pong_count1 = 0
+  threadi2 = None
+  threadi3 = None
+  threadi4_1 = None
+  threadi4_2 = None
+  ping_count5 = 0
+  pong_count5 = 0
+  threadi5_1 = None
+  threadi5_2 = None
+
+  def thread_func1_1(args):
+    assert(args == [131])
+    nonlocal ping_count1
+    while ping_count1 < 3 or pong_count1 < 3:
+      ping_count1 += 1
+      [_] = canon_thread_yield(False)
+    [] = canon_thread_resume_later(threadi2)
+    return []
+  fi1_1 = ftbl.add(CoreFuncRef(ft, thread_func1_1))
+
+  def thread_func1_2(args):
+    assert(args == [132])
+    nonlocal pong_count1
+    while ping_count1 < 3 or pong_count1 < 3:
+      pong_count1 += 1
+      [_] = canon_thread_yield(False)
+    return []
+  fi1_2 = ftbl.add(CoreFuncRef(ft, thread_func1_2))
+
+  def thread_func2(args):
+    assert(args == [14])
+    [] = canon_thread_resume_later(threadi3)
+    return []
+  fi2 = ftbl.add(CoreFuncRef(ft, thread_func2))
+
+  def thread_func3(args):
+    assert(args == [15])
+    [] = canon_thread_resume_later(threadi4_1)
+    [_] = canon_thread_suspend(False)
+    return []
+  fi3 = ftbl.add(CoreFuncRef(ft, thread_func3))
+
+  wsi = None
+  def thread_func4_1(args):
+    assert(args == [161])
+    [] = canon_thread_resume_later(threadi3)
+    [] = canon_thread_resume_later(threadi4_2)
+    nonlocal wsi
+    [wsi] = canon_waitable_set_new()
+    [event] = canon_waitable_set_wait(True, opts.memory, wsi, 0)
+    assert(event == EventCode.FUTURE_READ)
+    [] = canon_thread_resume_later(threadi5_1)
+    return []
+  fi4_1 = ftbl.add(CoreFuncRef(ft, thread_func4_1))
+
+  def thread_func4_2(args):
+    assert(args == [162])
+    [packed] = canon_future_new(FutureType(None))
+    futr,futw = unpack_new_ends(packed)
+    [ret] = canon_future_read(FutureType(None), opts, futr, 0xdeadbeef)
+    assert(ret == definitions.BLOCKED)
+    [] = canon_waitable_join(futr, wsi)
+    [ret] = canon_future_write(FutureType(None), opts, futw, 0xdeadbeef)
+    assert(ret == CopyResult.COMPLETED)
+    return []
+  fi4_2 = ftbl.add(CoreFuncRef(ft, thread_func4_2))
+
+  def thread_func5_1(args):
+    assert(args == [171])
+    nonlocal ping_count5
+    while ping_count5 < 3:
+      assert(ping_count5 == pong_count5)
+      [_] = canon_thread_yield_then_promote(False, threadi5_2)
+      assert(ping_count5 == pong_count5)
+      [] = canon_thread_resume_later(threadi5_2)
+      [_] = canon_thread_yield_then_promote(False, threadi5_2)
+      assert(ping_count5 == pong_count5 - 1)
+      ping_count5 += 1
+    [] = canon_task_return([U8Type()], opts, [42])
+    [] = canon_thread_resume_later(threadi5_2)
+    return []
+  fi5_1 = ftbl.add(CoreFuncRef(ft, thread_func5_1))
+
+  def thread_func5_2(args):
+    assert(args == [172])
+    nonlocal pong_count5
+    while pong_count5 < 3:
+      pong_count5 += 1
+      [_] = canon_thread_suspend_then_promote(False, threadi5_1)
+    return []
+  fi5_2 = ftbl.add(CoreFuncRef(ft, thread_func5_2))
+
+  def core_func(args):
+    assert(not args)
+    nonlocal threadi2, threadi3, threadi4_1, threadi4_2, threadi5_1, threadi5_2
+
+    [threadi1_1] = canon_thread_new_indirect(ft, ftbl, fi1_1, 131)
+    [threadi1_2] = canon_thread_new_indirect(ft, ftbl, fi1_2, 132)
+    [threadi2] = canon_thread_new_indirect(ft, ftbl, fi2, 14)
+    [threadi3] = canon_thread_new_indirect(ft, ftbl, fi3, 15)
+    [threadi4_1] = canon_thread_new_indirect(ft, ftbl, fi4_1, 161)
+    [threadi4_2] = canon_thread_new_indirect(ft, ftbl, fi4_2, 162)
+    [threadi5_1] = canon_thread_new_indirect(ft, ftbl, fi5_1, 171)
+    [threadi5_2] = canon_thread_new_indirect(ft, ftbl, fi5_2, 172)
+    [] = canon_thread_resume_later(threadi1_1)
+    [] = canon_thread_resume_later(threadi1_2)
+    return []
+
+  ready_bit = RacyBool(False)
+  ok_to_run_async = False
+  def async_task_thread(args):
+    assert(not args)
+    current_thread().wait_until(ready_bit.is_set)
+    assert(ok_to_run_async)
+    return [43]
+  async_ft = FuncType([], [U32Type()], async_ = True)
+  other_result = None
+  def on_async_resolve(v):
+    nonlocal other_result
+    [other_result] = v
+  fi = store.lift(async_task_thread, async_ft, CanonicalOptions(), inst)
+  _ = store.invoke(fi, lambda:[], on_async_resolve)
+  assert(other_result is None)
+  ready_bit.set()
+
+  result = None
+  def on_resolve(v):
+    nonlocal result, ok_to_run_async
+    [result] = v
+    ok_to_run_async = True
+
+  caller_ft = FuncType([], [U8Type()])
+  lift_and_run(opts, inst, caller_ft, core_func, lambda:[], on_resolve)
+  assert(result == 42)
+  assert(other_result == 43)
 
 def test_thread_cancel_callback():
   store = Store()
@@ -2825,6 +2971,7 @@ test_self_copy(U8Type())
 test_self_copy(F64Type())
 test_async_flat_params()
 test_threads()
+test_sync_threads()
 test_thread_cancel_callback()
 
 print("All tests passed")


### PR DESCRIPTION
@TartanLlama's work implementing pthreads in wasi-libc highlighted a few limitations with cooperative threads as currently spec'd that this PR intends to address:
* If pthreads are implemented using cooperative threads in sync-typed context, they won't work (due to trapping or no-op yielding) in cases where, if they had instead been implemented via CPS transform (like Asyncify), they could have.
* pthread APIs like `pthread_join`would like to be able to switch to a thread if that thread is ready to run, but not trap if it's not ready-to-run, b/c the current state of the thread isn't known.

The first bullet suggests replacing the strict "`may_block`" traps (and the no-op special case in `thread.yield`) with a more permissive approach where: if a thread blocks (now better-defined after #637) as part of a sync-typed call, but there are other threads in the same component instance that are ready-to-run, they are resumed directly, and repeatedly, until either there are no more ready threads (in which case trap, b/c it's actually blocked) or a value is returned successfully to the caller.  This also implicitly addresses the limitation @badeend just pointed out in #651, since blocking is fine as long as there is some other thread that can make progress.  (E.g., maybe the blocking call was just doing some asynchronous logging off the critical path.)  The "in the same component instance" caveat matches the expressivity of a core wasm CPS transform and is also necessary to maintain the reentrance invariant (re)defined in #650.

This does have the unfortunate side effect of allowing more code to accidentally depend on non-portable behavior (whether various operations actually block in practice), but this is already quite possible when using the `async` ABI and it's sortof just the nature of concurrency.

The second bullet suggests first renaming (but otherwise keeping the exact same behavior):
* `thread.switch-to` => `thread.suspend-then-resume` = resume other thread (trap if it's not "suspended"), leave current thread "suspended"
* `thread.yield-to` => `thread.yield-then-resume` = resume other thread (trap if it's not "suspended"), leave current thread "ready"

and then symmetrically add two new variants:
* `thread.suspend-then-promote` = resume other thread if it's "ready", leave current thread "suspended"
* `thread.yield-then-promote` = resume other thread if it's "ready", leave current thread "ready"

Thus, if the other thread is *not* "ready", `thread.{suspend,yield}-then-promote` behave the same as `thread.{suspend,yield}`.