### PR TITLE
Fix Explainer.md/Binary.md definition of outer aliases

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -126,12 +126,14 @@ Notes:
 * For `export` aliases, `i` is validated to refer to an instance in the
   instance index space that exports `n` with the specified `sort`.
 * For `outer` aliases, `ct` is validated to be *less or equal than* the number
-  of enclosing components and `i` is validated to be a valid
-  index in the `sort` index space of the `i`th enclosing component (counting
-  outward, starting with `0` referring to the current component).
-* For `outer` aliases, validation restricts the `sort` to one
-  of `type`, `module` or `component` and additionally requires that the
-  outer-aliased type is not a `resource` type (which is generative).
+  of enclosing `component`s and `type`s and `i` is validated to be a valid index
+  in the `sort` index space of the targeted `component`/`type` (counting
+  outward, starting with `0` referring to the current `component`/`type`).
+* For `outer` aliases, validation restricts the `sort` to one of `type`,
+  `module` or `component`.
+* For `outer` aliases that reach across a `component` boundary (as opposed to
+  a `type` boundary), validation additionally requires that any outer-aliased
+  `type` is not a `resource` type.
 
 
 ## Type Definitions

--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -133,7 +133,7 @@ Notes:
   `module` or `component`.
 * For `outer` aliases that reach across a `component` boundary (as opposed to
   a `type` boundary), validation additionally requires that any outer-aliased
-  `type` is not a `resource` type.
+  `type` does not transitively refer to a `resource` type.
 
 
 ## Type Definitions

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -344,11 +344,11 @@ and can be used anywhere a normal `id` can be used.
 In the case of `export` aliases, validation ensures `name` is an export in the
 target instance and has a matching sort.
 
-In the case of `outer` aliases, the `u32` pair serves as a [de Bruijn
-index], with first `u32` being the number of enclosing `component`s or `type`s
-to skip and the second `u32` being an index into the target's sort's index
-space. In particular, the first `u32` can be `0`, in which case the outer alias
-refers to the current `component`/`type`. To maintain the acyclicity of module
+In the case of `outer` aliases, the `u32` pair serves as a [de Bruijn index],
+with the first `u32` being the number of enclosing `component`s or `type`s to
+skip and the second `u32` being an index into the target's sort's index space.
+In particular, the first `u32` can be `0`, in which case the outer alias refers
+to the current `component`/`type`. To maintain the acyclicity of module
 instantiation, outer aliases are only allowed to refer to *preceding* outer
 definitions.
 
@@ -356,24 +356,27 @@ Components containing outer aliases effectively produce a [closure] at
 instantiation time, including a copy of the outer-aliased definitions. Because
 components, like modules, are pure values, outer aliases that reach across
 `component` boundaries are restricted to only refer to pure definitions:
-non-resource types, modules and components. (As described in the next section,
-resource types are *generative* and thus not pure.) For example, in the
-following component, `$alias{1,2,3,4}` are allowed (b/c they only reach across a
-`type` boundary) while `$alias5` is disallowed (b/c it reaches across a
-`component` boundary to reach a `resource` type).
+modules, components, and types that do not transitively refer to a `resource`
+type. (As described in the next section, resource types are *generative* and
+thus not pure.) For example, in the following component, `$alias{1,2,3,4,5}` are
+allowed (b/c they only reach across a `type` boundary) while `$alias{6,7}` are
+disallowed (b/c they reach across a `component` boundary):
 ```wat
 (component $C
   (component $D)
   (type $T (record (field "x" u32) (field "y" u32)))
   (type $R (resource (rep i32)))
+  (type $B (borrow $R))
   (type (component
     (alias outer $C $T (type $alias1))
     (alias outer $C $R (type $alias2))
+    (alias outer $C $B (type $alias3))
   ))
   (component
-    (alias outer $C $D (component $alias3))
-    (alias outer $C $T (type $alias4))
-    ;; (alias outer $C $R (type $alias5) ❌
+    (alias outer $C $D (component $alias4))
+    (alias outer $C $T (type $alias5))
+    ;; (alias outer $C $R (type $alias6)) ❌
+    ;; (alias outer $C $B (type $alias7)) ❌
   )
 )
 ```

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -345,19 +345,38 @@ In the case of `export` aliases, validation ensures `name` is an export in the
 target instance and has a matching sort.
 
 In the case of `outer` aliases, the `u32` pair serves as a [de Bruijn
-index], with first `u32` being the number of enclosing components/modules to
-skip and the second `u32` being an index into the target's sort's index space.
-In particular, the first `u32` can be `0`, in which case the outer alias refers
-to the current component. To maintain the acyclicity of module instantiation,
-outer aliases are only allowed to refer to *preceding* outer definitions.
+index], with first `u32` being the number of enclosing `component`s or `type`s
+to skip and the second `u32` being an index into the target's sort's index
+space. In particular, the first `u32` can be `0`, in which case the outer alias
+refers to the current `component`/`type`. To maintain the acyclicity of module
+instantiation, outer aliases are only allowed to refer to *preceding* outer
+definitions.
 
 Components containing outer aliases effectively produce a [closure] at
 instantiation time, including a copy of the outer-aliased definitions. Because
-of the prevalent assumption that components are immutable values, outer aliases
-are restricted to only refer to immutable definitions: non-resource types,
-modules and components. (In the future, outer aliases to all sorts of
-definitions could be allowed by recording the statefulness of the resulting
-component in its type via some kind of "`stateful`" type attribute.)
+components, like modules, are pure values, outer aliases that reach across
+`component` boundaries are restricted to only refer to pure definitions:
+non-resource types, modules and components. (As described in the next section,
+resource types are *generative* and thus not pure.) For example, in the
+following component, `$alias{1,2,3,4}` are allowed (b/c they only reach across a
+`type` boundary) while `$alias5` is disallowed (b/c it reaches across a
+`component` boundary to reach a `resource` type).
+```wat
+(component $C
+  (component $D)
+  (type $T (record (field "x" u32) (field "y" u32)))
+  (type $R (resource (rep i32)))
+  (type (component
+    (alias outer $C $T (type $alias1))
+    (alias outer $C $R (type $alias2))
+  ))
+  (component
+    (alias outer $C $D (component $alias3))
+    (alias outer $C $T (type $alias4))
+    ;; (alias outer $C $R (type $alias5) ❌
+  )
+)
+```
 
 Both kinds of aliases come with syntactic sugar for implicitly declaring them
 inline:


### PR DESCRIPTION
This PR intends to address the first issue in [this comment](https://github.com/WebAssembly/component-model/issues/621#issuecomment-4506120636), bringing the spec in line with the implementation (and logic).

(cc @zherczeg and @alexcrichton)