### PR TITLE
Fix 'canon lower' validation rule inconsistency

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -3795,7 +3795,7 @@ validation is performed where `$callee` has type `$ft`:
 * requires options [based on `lower(param)`](#canonopt-validation) for all parameters in `ft`
 * requires options [based on `lift(result)`](#canonopt-validation) if `ft` has a result
 * if `len(flatten_types(ft.param_types())) > max_flat_params`, `memory` is required
-* if `len(flatten_types(ft.result_type())) > max_flat_results`, `realloc` is required
+* if `len(flatten_types(ft.result_type())) > max_flat_results`, `memory` is required
 * 🔀 if `async` is specified, `memory` must be present
 
 When instantiating a component instance, the runtime calls `Store.lower` (defined

--- a/test/validation/abi.wast
+++ b/test/validation/abi.wast
@@ -1,0 +1,31 @@
+(assert_invalid
+  (component
+    (import "foo" (func $foo (result (tuple u64 u64 u64 u64 u64 u64 u64 u64))))
+    (canon lower (func $foo) (core func $foo'))
+  )
+  "canonical option `memory` is required"
+)
+(assert_invalid
+  (component
+    (import "foo" (func $foo (result (tuple u64 u64 u64 u64 u64 u64 u64 u64))))
+    (core module $M
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) unreachable)
+    )
+    (core instance $i (instantiate $M))
+    (canon lower (func $foo) (realloc (func $i "realloc")) (core func $foo'))
+  )
+  "canonical option `realloc` requires `memory` to also be specified"
+)
+(component
+  (component
+    (import "foo" (func $foo (result (tuple u64 u64 u64 u64 u64 u64 u64 u64))))
+    (core module $M
+      (memory (export "mem") 1)
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) unreachable)
+    )
+    (core instance $i (instantiate $M))
+    (canon lower (func $foo) (memory $i "mem") (core func $foo1))
+    ;; realloc superfluous but allowed:
+    (canon lower (func $foo) (memory $i "mem") (realloc (func $i "realloc")) (core func $foo2))
+  )
+)


### PR DESCRIPTION
As pointed out in #669, this brings the bulleted list of validation rules in sync with what actually happens (elsewhere in the spec and matching the current impl as tested by the new WAST in this par), which is that `canon lower`'s results go into a caller-supplied outparam, not a `realloc`ed buffer.