### PR TITLE
fix: only check component definition for memory64 test

### DIFF
--- a/test/wasm-tools/memory64.wast
+++ b/test/wasm-tools/memory64.wast
@@ -42,7 +42,7 @@
   (core instance (instantiate $B (with "" (instance (export "" (table $m))))))
 )
 
-(component
+(component definition
   (import "x" (func $x (param "x" string)))
   (core module $A
     (memory (export "m") i64 1)


### PR DESCRIPTION
With https://github.com/bytecodealliance/wasmtime/pull/13851 we'll actually run this test in `wasmtime` and it currently fails, because `x` is not an actually provided import. This test just wants to test validation in wasm-tools, so I weakened it to `component definition`