### PR TITLE
test(async): fix sync-streams — $D.run must store 0x89abcdef before its stream.write

### DIFF
--- a/test/async/sync-streams.wast
+++ b/test/async/sync-streams.wast
@@ -139,6 +139,7 @@
 
         ;; (stream.write $tx $bufp 4) will succeed without blocking
         (local.set $bufp (i32.const 16))
+        (i32.store (local.get $bufp) (i32.const 0x89abcdef))
         (local.set $ret (call $stream.write (local.get $tx) (local.get $bufp) (i32.const 4)))
         (if (i32.ne (i32.const 0x40 (; COMPLETED=0 | (4<<4) ;)) (local.get $ret))
           (then unreachable))


### PR DESCRIPTION
The `test/async/sync-streams.wast` test is symmetric, but the second half is missing a store so it cannot pass in any conforming implementation.

**First half** — `$C.get` stores `0x01234567` into its buffer then `stream.write`s it; `$D.run` reads it back and checks `0x01234567`:
```wat
(local.set $bufp (i32.const 16))
(i32.store (local.get $bufp) (i32.const 0x01234567))
(local.set $ret (call $stream.write (local.get $tx) (local.get $bufp) (i32.const 4)))
```

**Second half** — `$D.run` is meant to store `0x89abcdef` then `stream.write` it, so `$C.set` reads it back and checks `0x89abcdef` (`(i32.ne (i32.const 0x89abcdef) (i32.load (local.get $bufp)))`). But `$D.run` had **no `i32.store` before its second `stream.write`**:
```wat
(local.set $bufp (i32.const 16))
;; <-- missing (i32.store (local.get $bufp) (i32.const 0x89abcdef))
(local.set $ret (call $stream.write (local.get $tx) (local.get $bufp) (i32.const 4)))
```
So `$D` writes its zero-initialized memory at offset 16, `$C.set` reads `0x00000000`, and the `0x89abcdef` assertion traps on `unreachable`.

This affects every implementation, including the spec reference in `design/mvp/canonical-abi/definitions.py` (the stream copy transfers the same zero bytes). The fix adds the missing store in `$D.run`, mirroring `$C.get`'s existing store.

Found while running the official async `.wast` suites against an independent Component Model runtime: this was the only one of the async value/stream suites that no correct implementation could pass.