### PR TITLE
Remove defunct backpressure.set built-in

### DIFF
--- a/design/mvp/Binary.md
+++ b/design/mvp/Binary.md
@@ -298,7 +298,6 @@ canon    ::= 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx> => (canon lift 
            | 0x02 rt:<typeidx>                                   => (canon resource.new rt (core func))
            | 0x03 rt:<typeidx>                                   => (canon resource.drop rt (core func))
            | 0x04 rt:<typeidx>                                   => (canon resource.rep rt (core func))
-           | 0x08                                                => (canon backpressure.set (core func)) 🔀✕
            | 0x24                                                => (canon backpressure.inc (core func)) 🔀
            | 0x25                                                => (canon backpressure.dec (core func)) 🔀
            | 0x09 rs:<resultlist> opts:<opts>                    => (canon task.return rs opts (core func)) 🔀

--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -43,7 +43,6 @@ specified here.
   * [`canon resource.rep`](#canon-resourcerep)
   * [`canon context.get`](#-canon-contextget) 🔀
   * [`canon context.set`](#-canon-contextset) 🔀
-  * [`canon backpressure.set`](#-canon-backpressureset) 🔀✕
   * [`canon backpressure.{inc,dec}`](#-canon-backpressureincdec) 🔀
   * [`canon task.return`](#-canon-taskreturn) 🔀
   * [`canon task.cancel`](#-canon-taskcancel) 🔀
@@ -4133,30 +4132,6 @@ def canon_context_set(t, i, v):
   return []
 ```
 
-
-### 🔀✕ `canon backpressure.set`
-
-> This built-in is deprecated in favor of `backpressure.{inc,dec}` and will be
-> removed once producer tools have transitioned. Producer tools should avoid
-> emitting calls to both `set` and `inc`/`dec` since `set` will clobber the
-> counter.
-
-For a canonical definition:
-```wat
-(canon backpressure.set (core func $f))
-```
-validation specifies:
-* `$f` is given type `(func (param $enabled i32))`
-
-Calling `$f` invokes the following function, which sets the `backpressure`
-counter to `1` or `0`. `Task.enter_implicit_thread` waits for `backpressure` to
-be `0` before allowing new `async`-typed tasks to start.
-```python
-def canon_backpressure_set(flat_args):
-  assert(len(flat_args) == 1)
-  current_instance().backpressure = int(bool(flat_args[0]))
-  return []
-```
 
 ### 🔀 `canon backpressure.{inc,dec}`
 

--- a/design/mvp/Explainer.md
+++ b/design/mvp/Explainer.md
@@ -1540,7 +1540,6 @@ canon ::= ...
         | (canon resource.rep <typeidx> (core func <id>?))
         | (canon context.get <valtype> <u32> (core func <id>?)) 🔀
         | (canon context.set <valtype> <u32> (core func <id>?)) 🔀
-        | (canon backpressure.set (core func <id>?)) 🔀✕
         | (canon backpressure.inc (core func <id>?)) 🔀
         | (canon backpressure.dec (core func <id>?)) 🔀
         | (canon task.return (result <valtype>)? <canonopt>* (core func <id>?)) 🔀
@@ -1703,23 +1702,6 @@ another.
 
 For details, see [Thread-Local Storage] in the concurrency explainer and
 [`canon_context_set`] in the Canonical ABI explainer.
-
-###### 🔀✕ `backpressure.set`
-
-> This built-in is deprecated in favor of `backpressure.{inc,dec}` and will be
-> removed once producer tools have transitioned.
-
-| Synopsis                   |                       |
-| -------------------------- | --------------------- |
-| Approximate WIT signature  | `func(enable: bool)`  |
-| Canonical ABI signature    | `[enable:i32] -> []`  |
-
-The `backpressure.set` built-in allows the async-lifted callee to toggle a
-per-component-instance flag that, when set, prevents new incoming export calls
-to the component (until the flag is unset). This allows the component to exert
-[backpressure].
-
-For details, see [`canon_backpressure_set`] in the Canonical ABI explainer.
 
 ###### 🔀 `backpressure.inc` and `backpressure.dec`
 
@@ -3360,7 +3342,6 @@ For some use-case-focused, worked examples, see:
 [Canonical ABI explainer]: CanonicalABI.md
 [`canon_context_get`]: CanonicalABI.md#-canon-contextget
 [`canon_context_set`]: CanonicalABI.md#-canon-contextset
-[`canon_backpressure_set`]: CanonicalABI.md#-canon-backpressureset
 [`canon_backpressure_{inc,dec}`]: CanonicalABI.md#-canon-backpressureincdec
 [`canon_task_return`]: CanonicalABI.md#-canon-taskreturn
 [`canon_task_cancel`]: CanonicalABI.md#-canon-taskcancel


### PR DESCRIPTION
`backpressure.set` was replaced with `backpressure.{inc,dec}` and was removed from the implementation a while ago.