### PR TITLE
Add 3 test/async/during-sync-call-* tests

### DIFF
--- a/test/async/during-sync-call-may-block-if-other-ready-threads.wast
+++ b/test/async/during-sync-call-may-block-if-other-ready-threads.wast
@@ -1,0 +1,115 @@
+;; Whether a thread may synchronously call an async-typed function does not
+;; depend on the thread's task's function type (since threads can arbitrarily
+;; switch to any other thread running in the same component instance). Rather,
+;; it depends on whether, at the point of blocking, there are any other
+;; threads that are ready to run and able to use the stack.
+;;
+;; To test this, the tester below has two non-async-typed exports, so both
+;; run their bodies inside a dynamic scope where the "cannot block before
+;; returning" requirement is active, and both synchronously call the same
+;; eagerly-completing async-typed import, but from different threads which
+;; belong to different tasks.
+(component definition $Tester
+  (component $C
+    (core module $CM
+      (func (export "eager-async-func") (result i32)
+        (i32.const 43))
+    )
+    (core instance $cm (instantiate $CM))
+    ;; async-typed, but completes eagerly (sync-lifted, returns immediately)
+    (func (export "eager-async-func") async (result u32)
+      (canon lift (core func $cm "eager-async-func")))
+  )
+  (component $D
+    (import "c" (instance $c
+      (export "eager-async-func" (func async (result u32)))
+    ))
+    (core module $Table
+      (table (export "__indirect_function_table") 2 funcref))
+    (core instance $table (instantiate $Table))
+    (core module $Core
+      (import "" "eager-async-func" (func $eager-async-func (result i32)))
+      (import "" "task.return" (func $task.return (param i32)))
+      (import "" "thread.new-indirect" (func $thread.new-indirect (param i32 i32) (result i32)))
+      (import "" "thread.resume-later" (func $thread.resume-later (param i32)))
+      (import "" "thread.suspend-then-resume" (func $thread.suspend-then-resume (param i32) (result i32)))
+      (import "" "thread.index" (func $thread.index (result i32)))
+      (import "" "__indirect_function_table" (table $indirect-function-table 2 funcref))
+
+      (global $x-index (mut i32) (i32.const 0xdead))
+      (global $i-index (mut i32) (i32.const 0xdead))
+      (global $result (mut i32) (i32.const 0xdead))
+
+      (func (export "never-cb") (param i32 i32 i32) (result i32)
+        unreachable)
+
+      (func $thread-start-noop (param i32))
+      (elem (table $indirect-function-table) (i32.const 0) func $thread-start-noop)
+
+      ;; shared body: arm a ready cooperative thread, then sync-call the
+      ;; async-typed import (which completes eagerly)
+      (func $arm-and-call (result i32)
+        (call $thread.resume-later (call $thread.new-indirect (i32.const 0) (i32.const 0)))
+        (call $eager-async-func))
+
+      ;; X: run the shared body on a thread of the async-typed "setup" task,
+      ;; then switch back to the non-async-typed call's implicit thread
+      (func $thread-start-call (param i32)
+        (global.set $result (call $arm-and-call))
+        (drop (call $thread.suspend-then-resume (global.get $i-index))))
+      (elem (table $indirect-function-table) (i32.const 1) func $thread-start-call)
+
+      ;; async-typed callback task spawns X (left suspended) and resolves
+      (func (export "setup") (result i32)
+        (global.set $x-index (call $thread.new-indirect (i32.const 1) (i32.const 0)))
+        (call $task.return (i32.const 1))
+        (i32.const 0 (; EXIT ;)))
+
+      ;; non-async-typed: the shared body runs on this task's own thread
+      (func (export "sync-task-thread-caller") (result i32)
+        (call $arm-and-call))
+
+      ;; non-async-typed: the shared body runs on X, switched-to mid-call
+      (func (export "async-task-thread-caller") (result i32)
+        (global.set $i-index (call $thread.index))
+        (drop (call $thread.suspend-then-resume (global.get $x-index)))
+        (global.get $result))
+    )
+    (core type $start-func-ty (func (param i32)))
+    (alias core export $table "__indirect_function_table" (core table $indirect-function-table))
+    (core func $thread.new-indirect
+      (canon thread.new-indirect $start-func-ty (core table $indirect-function-table)))
+    (canon task.return (result u32) (core func $task.return))
+    (canon thread.resume-later (core func $thread.resume-later))
+    (canon thread.suspend-then-resume (core func $thread.suspend-then-resume))
+    (canon thread.index (core func $thread.index))
+    (canon lower (func $c "eager-async-func") (core func $eager-async-func'))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "eager-async-func" (func $eager-async-func'))
+      (export "task.return" (func $task.return))
+      (export "thread.new-indirect" (func $thread.new-indirect))
+      (export "thread.resume-later" (func $thread.resume-later))
+      (export "thread.suspend-then-resume" (func $thread.suspend-then-resume))
+      (export "thread.index" (func $thread.index))
+      (export "__indirect_function_table" (table $indirect-function-table))
+    ))))
+    (func (export "setup") async (result u32)
+      (canon lift (core func $core "setup") async (callback (core func $core "never-cb"))))
+    (func (export "sync-task-thread-caller") (result u32)
+      (canon lift (core func $core "sync-task-thread-caller")))
+    (func (export "async-task-thread-caller") (result u32)
+      (canon lift (core func $core "async-task-thread-caller")))
+  )
+  (instance $c (instantiate $C))
+  (instance $d (instantiate $D (with "c" (instance $c))))
+  (func (export "setup") (alias export $d "setup"))
+  (func (export "sync-task-thread-caller") (alias export $d "sync-task-thread-caller"))
+  (func (export "async-task-thread-caller") (alias export $d "async-task-thread-caller"))
+)
+
+(component instance $i $Tester)
+(assert_return (invoke "setup") (u32.const 1))
+(assert_return (invoke "async-task-thread-caller") (u32.const 43))
+
+(component instance $i $Tester)
+(assert_return (invoke "sync-task-thread-caller") (u32.const 43))

--- a/test/async/during-sync-call-no-exclusive-resume.wast
+++ b/test/async/during-sync-call-no-exclusive-resume.wast
@@ -1,0 +1,146 @@
+;; While a non-async-typed export call is in progress, the runtime must only
+;; ever resume threads that can use the stack: in particular, the implicit
+;; threads of async-typed tasks that need exclusive use of the stack must never
+;; be resumed, even when they are ready and in the same component instance. To
+;; test this, a number of ready-but-excluded threads are created, all of which
+;; trap if ever resumed, and the sync call must instead make progress through
+;; one valid resumable thread.
+(component
+  (component $Inner
+    (core module $Table
+      (table (export "__indirect_function_table") 1 funcref))
+    (core instance $table (instantiate $Table))
+    (core module $Core
+      (import "" "task.return" (func $task.return (param i32)))
+      (import "" "thread.new-indirect" (func $thread.new-indirect (param i32 i32) (result i32)))
+      (import "" "thread.suspend-then-resume" (func $thread.suspend-then-resume (param i32) (result i32)))
+      (import "" "thread.resume-later" (func $thread.resume-later (param i32)))
+      (import "" "thread.suspend" (func $thread.suspend (result i32)))
+      (import "" "thread.index" (func $thread.index (result i32)))
+      (import "" "__indirect_function_table" (table $indirect-function-table 1 funcref))
+
+      (global $setup-thread-index (mut i32) (i32.const 0xdead))
+      (global $implicit-thread-index (mut i32) (i32.const 0xdead))
+
+      (func $thread-start (param i32)
+        (local $r i32)
+        (loop $rounds
+          (call $thread.resume-later (global.get $implicit-thread-index))
+          (drop (call $thread.suspend))
+          (local.set $r (i32.add (local.get $r) (i32.const 1)))
+          (br_if $rounds (i32.lt_u (local.get $r) (i32.const 4))))
+        unreachable)
+      (elem (table $indirect-function-table) (i32.const 0) func $thread-start)
+
+      (func (export "setup") (result i32)
+        (global.set $setup-thread-index (call $thread.new-indirect (i32.const 0) (i32.const 0)))
+        (call $task.return (i32.const 1))
+        (i32.const 0 (; EXIT ;)))
+
+      ;; async callback task resolves, then parks its implicit thread, ready,
+      ;; in its event loop by returning YIELD, but must never be resumed.
+      (func (export "arm") (result i32)
+        (call $task.return (i32.const 1))
+        (i32.const 1 (; YIELD ;)))
+
+      (func (export "never-cb") (param i32 i32 i32) (result i32)
+        unreachable)
+
+      ;; non-async-typed: 4 rounds of switching to $thread-start and being made ready
+      ;; again by it
+      (func (export "sync-block") (result i32)
+        (local $r i32)
+        (global.set $implicit-thread-index (call $thread.index))
+        (loop $rounds
+          (drop (call $thread.suspend-then-resume (global.get $setup-thread-index)))
+          (local.set $r (i32.add (local.get $r) (i32.const 1)))
+          (br_if $rounds (i32.lt_u (local.get $r) (i32.const 4))))
+        (i32.const 42))
+    )
+    (core type $start-func-ty (func (param i32)))
+    (alias core export $table "__indirect_function_table" (core table $indirect-function-table))
+    (core func $thread.new-indirect
+      (canon thread.new-indirect $start-func-ty (core table $indirect-function-table)))
+    (canon task.return (result u32) (core func $task.return))
+    (canon thread.suspend-then-resume (core func $thread.suspend-then-resume))
+    (canon thread.resume-later (core func $thread.resume-later))
+    (canon thread.suspend (core func $thread.suspend))
+    (canon thread.index (core func $thread.index))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "task.return" (func $task.return))
+      (export "thread.new-indirect" (func $thread.new-indirect))
+      (export "thread.suspend-then-resume" (func $thread.suspend-then-resume))
+      (export "thread.resume-later" (func $thread.resume-later))
+      (export "thread.suspend" (func $thread.suspend))
+      (export "thread.index" (func $thread.index))
+      (export "__indirect_function_table" (table $indirect-function-table))
+    ))))
+    (func (export "setup") async (result u32)
+      (canon lift (core func $core "setup") async (callback (core func $core "never-cb"))))
+    (func (export "arm") async (result u32)
+      (canon lift (core func $core "arm") async (callback (core func $core "never-cb"))))
+    (func (export "sync-block") (result u32)
+      (canon lift (core func $core "sync-block")))
+  )
+  (component $Driver
+    (import "inner" (instance $inner
+      (export "sync-block" (func (result u32)))
+    ))
+    (core module $Core
+      (import "" "sync-block" (func $sync-block (result i32)))
+      (func (export "run") (result i32)
+        (call $sync-block)))
+    (canon lower (func $inner "sync-block") (core func $sync-block'))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "sync-block" (func $sync-block'))
+    ))))
+    (func (export "run") (result u32)
+      (canon lift (core func $core "run")))
+  )
+  (instance $inner (instantiate $Inner))
+  (instance $driver (instantiate $Driver (with "inner" (instance $inner))))
+  (func (export "setup") (alias export $inner "setup"))
+  (func (export "arm") (alias export $inner "arm"))
+  (func (export "run") (alias export $driver "run"))
+)
+(assert_return (invoke "setup") (u32.const 1))
+(assert_return (invoke "arm") (u32.const 1))
+(assert_return (invoke "arm") (u32.const 1))
+(assert_return (invoke "arm") (u32.const 1))
+(assert_return (invoke "run") (u32.const 42))
+
+;; A ready-but-excluded thread does not allow the sync call to block: when
+;; the only other thread in the instance needs exclusive use of the stack,
+;; blocking must trap immediately rather than resume that thread.
+(component
+  (core module $Core
+    (import "" "task.return" (func $task.return (param i32)))
+    (import "" "thread.suspend" (func $thread.suspend (result i32)))
+
+    ;; async callback task resolves, then parks its implicit thread, ready,
+    ;; in its event loop by returning YIELD, but must never be resumed.
+    (func (export "arm") (result i32)
+      (call $task.return (i32.const 1))
+      (i32.const 1 (; YIELD ;)))
+
+    (func (export "never-cb") (param i32 i32 i32) (result i32)
+      unreachable)
+
+    ;; non-async-typed: suspend with no valid thread to switch to
+    (func (export "sync-block")
+      (drop (call $thread.suspend))
+      unreachable)
+  )
+  (canon task.return (result u32) (core func $task.return))
+  (canon thread.suspend (core func $thread.suspend))
+  (core instance $core (instantiate $Core (with "" (instance
+    (export "task.return" (func $task.return))
+    (export "thread.suspend" (func $thread.suspend))
+  ))))
+  (func (export "arm") async (result u32)
+    (canon lift (core func $core "arm") async (callback (core func $core "never-cb"))))
+  (func (export "sync-block")
+    (canon lift (core func $core "sync-block")))
+)
+(assert_return (invoke "arm") (u32.const 1))
+(assert_trap (invoke "sync-block") "deadlock detected: event loop cannot make further progress")

--- a/test/async/during-sync-call-no-sibling-resume.wast
+++ b/test/async/during-sync-call-no-sibling-resume.wast
@@ -1,0 +1,215 @@
+;; While a non-async-typed export call is in progress, the runtime must only
+;; ever resume threads of that call's own component instance (which is necessary
+;; to prevent accidental and unexpected reentrance). To test this behavior, the
+;; following test creates a bunch of ready-but-excluded threads which sit in a
+;; sibling instance and must not be resumed when a sync call in the primary
+;; component instance blocks.
+;;
+;; In particular:
+;;   1. "setup" spawns thread X inside $Inner (X belongs to a resolved
+;;      async-typed task, so it may block).
+;;   2. "run" ($Driver, non-async-typed, called by the host):
+;;      a. calls $Sibling.arm(8), leaving 8 ready-but-excluded threads;
+;;      b. sync-calls $Inner.inner-block (non-async-typed), which runs 4
+;;         rounds: each round suspend-then-resumes X, and X makes the
+;;         implicit thread ready again (thread.resume-later) and suspends.
+(component
+  (component $Inner
+    (core module $Table
+      (table (export "__indirect_function_table") 1 funcref))
+    (core instance $table (instantiate $Table))
+    (core module $Core
+      (import "" "task.return" (func $task.return (param i32)))
+      (import "" "thread.new-indirect" (func $thread.new-indirect (param i32 i32) (result i32)))
+      (import "" "thread.suspend-then-resume" (func $thread.suspend-then-resume (param i32) (result i32)))
+      (import "" "thread.resume-later" (func $thread.resume-later (param i32)))
+      (import "" "thread.suspend" (func $thread.suspend (result i32)))
+      (import "" "thread.index" (func $thread.index (result i32)))
+      (import "" "__indirect_function_table" (table $indirect-function-table 1 funcref))
+
+      (global $setup-thread-index (mut i32) (i32.const 0xdead))
+      (global $implicit-thread-index (mut i32) (i32.const 0xdead))
+      (global $pinned (mut i32) (i32.const 0))
+
+      (func (export "never-cb") (param i32 i32 i32) (result i32)
+        unreachable)
+
+      ;; X: each round, make the pinned call's implicit thread ready again,
+      ;; then suspend, giving the scheduler a choice between the implicit thread
+      ;; (same instance) and the armed sibling threads.
+      (func $thread-start-block (param i32)
+        (local $r i32)
+        (loop $rounds
+          (call $thread.resume-later (global.get $implicit-thread-index))
+          (drop (call $thread.suspend))
+          (local.set $r (i32.add (local.get $r) (i32.const 1)))
+          (br_if $rounds (i32.lt_u (local.get $r) (i32.const 4))))
+        unreachable)
+      (elem (table $indirect-function-table) (i32.const 0) func $thread-start-block)
+
+      ;; async callback task spawns X (left suspended) and resolves
+      (func (export "setup") (result i32)
+        (global.set $setup-thread-index (call $thread.new-indirect (i32.const 0) (i32.const 0)))
+        (call $task.return (i32.const 1))
+        (i32.const 0 (; EXIT ;)))
+
+      ;; non-async-typed: 4 rounds of switching to X and being made ready
+      ;; again by it
+      (func (export "inner-block") (result i32)
+        (local $r i32)
+        (global.set $implicit-thread-index (call $thread.index))
+        (global.set $pinned (i32.const 1))
+        (loop $rounds
+          (drop (call $thread.suspend-then-resume (global.get $setup-thread-index)))
+          (local.set $r (i32.add (local.get $r) (i32.const 1)))
+          (br_if $rounds (i32.lt_u (local.get $r) (i32.const 4))))
+        (global.set $pinned (i32.const 0))
+        (i32.const 42))
+    )
+    (core type $start-func-ty (func (param i32)))
+    (alias core export $table "__indirect_function_table" (core table $indirect-function-table))
+    (core func $thread.new-indirect
+      (canon thread.new-indirect $start-func-ty (core table $indirect-function-table)))
+    (canon task.return (result u32) (core func $task.return))
+    (canon thread.suspend-then-resume (core func $thread.suspend-then-resume))
+    (canon thread.resume-later (core func $thread.resume-later))
+    (canon thread.suspend (core func $thread.suspend))
+    (canon thread.index (core func $thread.index))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "task.return" (func $task.return))
+      (export "thread.new-indirect" (func $thread.new-indirect))
+      (export "thread.suspend-then-resume" (func $thread.suspend-then-resume))
+      (export "thread.resume-later" (func $thread.resume-later))
+      (export "thread.suspend" (func $thread.suspend))
+      (export "thread.index" (func $thread.index))
+      (export "__indirect_function_table" (table $indirect-function-table))
+    ))))
+    (func (export "setup") async (result u32)
+      (canon lift (core func $core "setup") async (callback (core func $core "never-cb"))))
+    (func (export "inner-block") (result u32)
+      (canon lift (core func $core "inner-block")))
+  )
+  (component $Sibling
+    (core module $Table
+      (table (export "__indirect_function_table") 1 funcref))
+    (core instance $table (instantiate $Table))
+    (core module $Core
+      (import "" "thread.new-indirect" (func $thread.new-indirect (param i32 i32) (result i32)))
+      (import "" "thread.resume-later" (func $thread.resume-later (param i32)))
+      (import "" "__indirect_function_table" (table $indirect-function-table 1 funcref))
+
+      (func $thread-start-func (param i32)
+        unreachable)
+      (elem (table $indirect-function-table) (i32.const 0) func $thread-start-func)
+
+      ;; spawns $count ready-but-must-not-resume threads
+      (func (export "arm") (param $count i32)
+        (loop $again
+          (call $thread.resume-later (call $thread.new-indirect (i32.const 0) (i32.const 0)))
+          (local.set $count (i32.sub (local.get $count) (i32.const 1)))
+          (br_if $again (i32.gt_u (local.get $count) (i32.const 0)))))
+    )
+    (core type $start-func-ty (func (param i32)))
+    (alias core export $table "__indirect_function_table" (core table $indirect-function-table))
+    (core func $thread.new-indirect
+      (canon thread.new-indirect $start-func-ty (core table $indirect-function-table)))
+    (canon thread.resume-later (core func $thread.resume-later))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "thread.new-indirect" (func $thread.new-indirect))
+      (export "thread.resume-later" (func $thread.resume-later))
+      (export "__indirect_function_table" (table $indirect-function-table))
+    ))))
+    (func (export "arm") (param "count" u32)
+      (canon lift (core func $core "arm")))
+  )
+  (component $Driver
+    (import "sibling" (instance $sibling
+      (export "arm" (func (param "count" u32)))
+    ))
+    (import "inner" (instance $inner
+      (export "inner-block" (func (result u32)))
+    ))
+    (core module $Core
+      (import "" "arm" (func $arm (param i32)))
+      (import "" "inner-block" (func $inner-block (result i32)))
+      (func (export "run") (result i32)
+        (call $arm (i32.const 8))
+        (call $inner-block)))
+    (canon lower (func $sibling "arm") (core func $arm'))
+    (canon lower (func $inner "inner-block") (core func $inner-block'))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "arm" (func $arm'))
+      (export "inner-block" (func $inner-block'))
+    ))))
+    (func (export "run") (result u32)
+      (canon lift (core func $core "run")))
+  )
+  (instance $inner (instantiate $Inner))
+  (instance $sibling (instantiate $Sibling (with "inner" (instance $inner))))
+  (instance $driver (instantiate $Driver
+    (with "sibling" (instance $sibling))
+    (with "inner" (instance $inner))))
+  (func (export "setup") (alias export $inner "setup"))
+  (func (export "run") (alias export $driver "run"))
+)
+(assert_return (invoke "setup") (u32.const 1))
+(assert_return (invoke "run") (u32.const 42))
+
+;; A ready thread in a sibling instance does not allow the sync call to
+;; block: even though the sibling's thread could use the stack, it does not
+;; belong to the sync call's component instance, so blocking must trap
+;; immediately rather than resume it.
+(component
+  (component $Inner
+    (core module $Core
+      (import "" "thread.suspend" (func $thread.suspend (result i32)))
+
+      ;; non-async-typed: suspend with no thread of this instance to switch to
+      (func (export "sync-block")
+        (drop (call $thread.suspend))
+        unreachable)
+    )
+    (canon thread.suspend (core func $thread.suspend))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "thread.suspend" (func $thread.suspend))
+    ))))
+    (func (export "sync-block")
+      (canon lift (core func $core "sync-block")))
+  )
+  (component $Sibling
+    (core module $Table
+      (table (export "__indirect_function_table") 1 funcref))
+    (core instance $table (instantiate $Table))
+    (core module $Core
+      (import "" "thread.new-indirect" (func $thread.new-indirect (param i32 i32) (result i32)))
+      (import "" "thread.resume-later" (func $thread.resume-later (param i32)))
+      (import "" "__indirect_function_table" (table $indirect-function-table 1 funcref))
+
+      (func $thread-start-func (param i32)
+        unreachable)
+      (elem (table $indirect-function-table) (i32.const 0) func $thread-start-func)
+
+      ;; spawns one ready-but-must-not-resume thread
+      (func (export "arm")
+        (call $thread.resume-later (call $thread.new-indirect (i32.const 0) (i32.const 0))))
+    )
+    (core type $start-func-ty (func (param i32)))
+    (alias core export $table "__indirect_function_table" (core table $indirect-function-table))
+    (core func $thread.new-indirect
+      (canon thread.new-indirect $start-func-ty (core table $indirect-function-table)))
+    (canon thread.resume-later (core func $thread.resume-later))
+    (core instance $core (instantiate $Core (with "" (instance
+      (export "thread.new-indirect" (func $thread.new-indirect))
+      (export "thread.resume-later" (func $thread.resume-later))
+      (export "__indirect_function_table" (table $indirect-function-table))
+    ))))
+    (func (export "arm")
+      (canon lift (core func $core "arm")))
+  )
+  (instance $inner (instantiate $Inner))
+  (instance $sibling (instantiate $Sibling))
+  (func (export "arm") (alias export $sibling "arm"))
+  (func (export "sync-block") (alias export $inner "sync-block"))
+)
+(assert_return (invoke "arm"))
+(assert_trap (invoke "sync-block") "deadlock detected: event loop cannot make further progress")

--- a/test/nyi.txt
+++ b/test/nyi.txt
@@ -1,1 +1,4 @@
 # See README.md
+./async/during-sync-call-may-block-if-other-ready-threads.wast
+./async/during-sync-call-no-exclusive-resume.wast
+./async/during-sync-call-no-sibling-resume.wast


### PR DESCRIPTION
This PR adds some new WAST tests focusing on blocking and thread switching during sync-typed function calls.  They currently fail, so they are added to test/nyi.txt.