### PR TITLE
Allow feature gates on resource methods

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1811,11 +1811,14 @@ desugar to an owned return value.
 Specifically, the syntax for a `resource` definition is:
 ```ebnf
 resource-item ::= 'resource' id ';'
-                | 'resource' id '{' ( external-id? resource-method )* '}'
+                | 'resource' id '{' ( gate external-id? resource-method )* '}'
 resource-method ::= func-item
                   | id ':' 'static' func-type ';'
                   | 'constructor' param-list ';'
 ```
+
+As with the items of a `world` or an `interface`, the methods of a `resource`
+can be individually gated, as described [above](#feature-gates).
 
 The optional `async` on `static` functions has the same meaning as in a
 non-`static` `func-item`.


### PR DESCRIPTION
The `resource-item` production does not permit a `gate` on resource methods, but WASI 0.3 already relies on being able to gate them individually. For example, [`resource descriptor`](https://github.com/WebAssembly/wasi-filesystem/blob/main/wit-0.3.0-draft/types.wit) carries `@since` on each of its methods, and `wasm-tools` parses and round-trips that today.

So this is the spec text lagging behind both the tooling and the WASI proposals rather than a feature request. The fix places `gate` on the containing item list, matching how `world-items ::= gate world-definition` and `interface-items ::= gate interface-definition` already do it.

Record fields, enum cases, variant cases and flags are deliberately left alone; `wasm-tools` rejects gates on those, so the grammar is already correct there.