### PR TITLE
Add some more interesting cancellation tests

### DIFF
--- a/design/mvp/CanonicalABI.md
+++ b/design/mvp/CanonicalABI.md
@@ -515,7 +515,7 @@ class Thread:
   cont: Optional[Continuation]
   ready_func: Optional[Callable[[], bool]]
   task: Task
-  cancellable: bool
+  cancellable: Callable[[], bool]
   index: Optional[int]
   storage: tuple[int,int]
 
@@ -545,7 +545,7 @@ state.
     self.cont = cont_new(cont_func)
     self.ready_func = None
     self.task = task
-    self.cancellable = False
+    self.cancellable = lambda: False
     self.index = None
     self.storage = [0,0]
     assert(self.suspended())
@@ -588,7 +588,7 @@ so on, repeatedly, until the continuation either returns or suspends with no
 thread to `switch_to`.
 ```python
   def resume(self, cancelled = Cancelled.FALSE):
-    assert(not self.running() and (self.cancellable or not cancelled))
+    assert(not self.running() and (self.cancellable() or not cancelled))
     if self.waiting():
       self.stop_waiting_internal(cancelled)
     thread = self
@@ -620,20 +620,20 @@ switch to that thread without blocking.
   def block_internal(self, cancellable):
     self.cancellable = cancellable
     cancelled = block(switch_to = None)
-    assert(self.running() and (cancellable or not cancelled))
+    assert(self.running() and (cancellable() or not cancelled))
     return cancelled
 
   def switch_to_internal(self, cancellable, other):
     self.cancellable = cancellable
     cancelled = block(switch_to = other)
-    assert(self.running() and (cancellable or not cancelled))
+    assert(self.running() and (cancellable() or not cancelled))
     return cancelled
 ```
 The `cancellable` parameters in these methods indicate whether the caller is
-prepared to handle cancellation. If `cancellable` is false for all of a task's
+prepared to handle cancellation. If `cancellable()` is false for all of a task's
 threads, the cancellation request will be stored in `Task.state` and delivered
-the next time `Task.deliver_pending_cancel()` is called with `cancellable` set
-by one of the `Thread` methods below.
+the next time `Task.deliver_pending_cancel()` is called when `cancellable()`
+is true.
 
 Once a thread is `Thread.resume()`ed and starts executing, it can suspend its
 execution by calling the `thread.suspend` built-in which calls `Thread.suspend`
@@ -652,26 +652,37 @@ built-ins, as well as auto-backpressure and the `callback` event loop, to wait
 until a particular readiness condition is met. Given `wait_until`, "yielding"
 can simply be defined as waiting on a readiness condition that is already met.
 ```python
-  def wait_until(self, ready_func, cancellable = False) -> Cancelled:
+  def wait_until(self, ready_func, cancellable = lambda: False) -> Cancelled:
     assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     if ready_func() and not DETERMINISTIC_PROFILE and random.randint(0,1):
       return Cancelled.FALSE
-    self.start_waiting_internal(ready_func)
-    return self.block_internal(cancellable)
+    def ready_or_cancelled():
+      return ready_func() or (cancellable() and self.task.has_pending_cancel())
+    self.start_waiting_internal(ready_or_cancelled)
+    cancelled = self.block_internal(cancellable)
+    if self.task.deliver_pending_cancel(cancellable):
+      return Cancelled.TRUE
+    return cancelled
 
   def yield_(self, cancellable) -> Cancelled:
     return self.wait_until(lambda: True, cancellable)
 ```
 As with `Thread.suspend`, before anything else, `wait_until` reports any pending
-cancellation requests if the caller is `cancellable`. The `randomint` conjunct
+cancellation requests if the caller is `cancellable`. The `randint` conjunct
 on the early return if `ready_func()` is already `True` means that, at any
 potential suspension point, the embedder can nondeterministically decide whether
 to switch to another thread or keep running the current one. In particular, when
 a caller makes an `async` call to a callee which `wait_until`s a condition
 that's already met (e.g. in the case of `yield`), the embedder can use
 scheduling heuristics to decide whether or not to block the current thread.
+
+The `ready_or_cancelled` predicate in `Thread.wait_until` allows a `waiting`
+thread to become `ready` if it was not `cancellable` when a pending cancellation
+request was set, but has since become `cancellable`. If this `ready` thread is
+then scheduled, the second call to `deliver_pending_cancel` is needed to produce
+the actual `Cancelled.TRUE` return value.
 
 The `Thread.suspend_then_resume` and `Thread.yield_then_resume` methods
 immediately resume execution of some `other` `suspended` thread in the same
@@ -845,7 +856,8 @@ exports.
                 (self.needs_exclusive() and self.inst.exclusive_thread is not None))
       if has_backpressure() or self.inst.num_waiting_to_enter > 0:
         self.inst.num_waiting_to_enter += 1
-        cancelled = self.implicit_thread.wait_until(lambda: not has_backpressure(), cancellable = True)
+        cancelled = self.implicit_thread.wait_until(lambda: not has_backpressure(),
+                                                    cancellable = lambda: True)
         self.inst.num_waiting_to_enter -= 1
         if cancelled:
           self.cancel()
@@ -920,9 +932,7 @@ multiple), giving the thread the chance to handle cancellation promptly so that
       self.implicit_thread.resume(Cancelled.TRUE)
     else:
       assert(self.state == Task.State.STARTED)
-      candidates = { t for t in self.threads if t.cancellable }
-      if self.needs_exclusive() and self.inst.exclusive_thread not in { None, self.implicit_thread }:
-        candidates.discard(self.implicit_thread)
+      candidates = { t for t in self.threads if t.cancellable() }
       if candidates and self.inst.may_enter_from(caller):
         self.state = Task.State.CANCEL_DELIVERED
         self.inst.enter_from(caller)
@@ -931,19 +941,22 @@ multiple), giving the thread the chance to handle cancellation promptly so that
       else:
         self.state = Task.State.PENDING_CANCEL
 ```
-As handled above, cancellation must additionally avoid resuming a `cancellable`
-thread when doing so would violate [Component Invariant] #2 or #3. In
-particular, invariant #2 requires not resuming any thread while the task's
-containing component instance may not be reentered and invariant #3 requires not
-resuming a `needs_exclusive` task's implicit thread while another task's
-implicit thread is running exclusively.
+Note that `Thread.cancellable` is a first-class function, instead of a boolean
+flag, so that whether a `Thread` is cancellable or not can vary dynamically.
+Concretely, `cancellable` only varies dynamically in one situation: in
+`canon_lift`, when a `callback`-lifted `async` function is waiting in its event
+loop and must not be resumed if some other thread holds the `exclusive_thread`
+lock (to preserve [Component Invariant] #3).
 
 If cancellation cannot be immediately delivered by `Task.request_cancellation`,
 the request is remembered in `Task.state` and delivered at the next opportunity
 by `Task.deliver_pending_cancel`, which is checked at all cancellation points:
 ```python
+  def has_pending_cancel(self):
+    return self.state == Task.State.PENDING_CANCEL
+
   def deliver_pending_cancel(self, cancellable) -> bool:
-    if cancellable and self.state == Task.State.PENDING_CANCEL:
+    if cancellable() and self.has_pending_cancel():
       self.state = Task.State.CANCEL_DELIVERED
       return True
     return False
@@ -1474,7 +1487,7 @@ class Waitable:
   def wait_for_pending_event(self):
     assert(not self.in_waitable_set() and not self.has_sync_waiter)
     self.has_sync_waiter = True
-    current_thread().wait_until(self.has_pending_event, cancellable = False)
+    current_thread().wait_until(self.has_pending_event, cancellable = lambda: False)
     self.has_sync_waiter = False
 
   def get_pending_event(self) -> EventTuple:
@@ -3713,9 +3726,11 @@ function (specified as a `funcidx` immediate in `canon lift`) until the
     while code != CallbackCode.EXIT:
       assert(task.needs_exclusive() and inst.exclusive_thread is task.implicit_thread)
       inst.exclusive_thread = None
+      def lock_available():
+        return inst.exclusive_thread is None
       match code:
         case CallbackCode.YIELD:
-          cancelled = thread.wait_until(lambda: not inst.exclusive_thread, cancellable = True)
+          cancelled = thread.wait_until(lock_available, cancellable = lock_available)
           if cancelled:
             event = (EventCode.TASK_CANCELLED, 0, 0)
           else:
@@ -3723,7 +3738,7 @@ function (specified as a `funcidx` immediate in `canon lift`) until the
         case CallbackCode.WAIT:
           wset = inst.handles.get(si)
           trap_if(not isinstance(wset, WaitableSet))
-          event = wset.wait_for_event_and(lambda: not inst.exclusive_thread, cancellable = True)
+          event = wset.wait_for_event_and(lock_available, cancellable = lock_available)
         case _:
           trap()
       assert(inst.exclusive_thread is None)
@@ -3736,10 +3751,11 @@ function (specified as a `funcidx` immediate in `canon lift`) until the
 ```
 The `Thread.wait_until` and `WaitableSet.wait_for_event_and` methods called by
 the event loop are the same methods called by the `thread.yield` and
-`waitable-set.wait` built-ins. Thus, the main difference between stackful and
-stackless async is whether these suspending operations are performed from an
-empty or non-empty core wasm callstack (with the former allowing additional
-engine optimization).
+`waitable-set.wait` built-ins. The main difference (other than whether they are
+called from an empty vs. non-empty guest call stack, which allows an engine
+to reuse the stack in the former case) is the `lock_available` predicate used
+to additionally gate readiness and cancellability in order to ensure
+[Component Invariant] #3.
 
 The event loop releases `ComponentInstance.exclusive_thread` (which was acquired
 by `Task.enter_implicit_thread`) before potentially blocking the thread to allow
@@ -4287,7 +4303,7 @@ def canon_waitable_set_wait(cancellable, mem, si, ptr):
   trap_if(not inst.may_leave)
   wset = inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
-  event = wset.wait_for_event(cancellable)
+  event = wset.wait_for_event(lambda: cancellable)
   return unpack_event(mem, inst, ptr, event)
 
 def unpack_event(mem, inst, ptr, e: EventTuple):
@@ -4325,7 +4341,7 @@ def canon_waitable_set_poll(cancellable, mem, si, ptr):
   trap_if(not inst.may_leave)
   wset = inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
-  event = wset.poll(cancellable)
+  event = wset.poll(lambda: cancellable)
   return unpack_event(mem, inst, ptr, event)
 ```
 If `cancellable` is set, then `waitable-set.poll` will return whether the
@@ -4966,7 +4982,7 @@ calling component.
 def canon_thread_suspend(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  cancelled = thread.suspend(cancellable)
+  cancelled = thread.suspend(lambda: cancellable)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.suspend` will return a `Cancelled`
@@ -4995,7 +5011,7 @@ other threads in a cooperative setting.
 def canon_thread_yield(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  cancelled = thread.yield_(cancellable)
+  cancelled = thread.yield_(lambda: cancellable)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.yield` will return a `Cancelled`
@@ -5025,7 +5041,7 @@ def canon_thread_suspend_then_resume(cancellable, i):
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.suspend_then_resume(cancellable, other_thread)
+  cancelled = thread.suspend_then_resume(lambda: cancellable, other_thread)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.suspend-then-resume` will return a
@@ -5056,7 +5072,7 @@ def canon_thread_yield_then_resume(cancellable, i):
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.yield_then_resume(cancellable, other_thread)
+  cancelled = thread.yield_then_resume(lambda: cancellable, other_thread)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.yield-then-resume` will return a
@@ -5085,7 +5101,7 @@ def canon_thread_suspend_then_promote(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
-  cancelled = thread.suspend_then_promote(cancellable, other_thread)
+  cancelled = thread.suspend_then_promote(lambda: cancellable, other_thread)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.suspend-then-promote` will return a
@@ -5115,7 +5131,7 @@ def canon_thread_yield_then_promote(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
-  cancelled = thread.yield_then_promote(cancellable, other_thread)
+  cancelled = thread.yield_then_promote(lambda: cancellable, other_thread)
   return [cancelled]
 ```
 If `cancellable` is set, then `thread.yield-then-promote` will return a

--- a/design/mvp/Concurrency.md
+++ b/design/mvp/Concurrency.md
@@ -810,11 +810,12 @@ the subtask's threads which is in a cancellable state, passing it a sentinel
 "cancelled" value. A thread is in a "cancellable" state if it calls one of the
 [blocking](#blocking) built-ins with the `cancellable` immediate set (indicating
 that the caller expects and propagates cancellation appropriately) or, if using
-a `callback`, returns to the event loop (which always waits cancellably). If a
-subtask has no cancellable threads, no thread is resumed and the request for
-cancellation is remembered in the task state, to be delivered immediately at
-the next cancellable wait. In the worst case, though, a component may never
-wait cancellably and thus cancellation may be silently ignored.
+a `callback`, returns to the event loop and no other thread is holding the
+"exclusive" lock. If a subtask has no cancellable threads, no thread is resumed
+and the request for cancellation is remembered in the task state, to be
+delivered at the next cancellable opportunity. In the worst case, though, a
+component may *never* wait cancellably and thus cancellation may be silently
+ignored.
 
 `subtask.cancel` can be called synchronously or asynchronously. If called
 synchronously, `subtask.cancel` blocks until the subtask reaches a resolved

--- a/design/mvp/canonical-abi/definitions.py
+++ b/design/mvp/canonical-abi/definitions.py
@@ -318,7 +318,7 @@ class Thread:
   cont: Optional[Continuation]
   ready_func: Optional[Callable[[], bool]]
   task: Task
-  cancellable: bool
+  cancellable: Callable[[], bool]
   index: Optional[int]
   storage: tuple[int,int]
 
@@ -342,7 +342,7 @@ class Thread:
     self.cont = cont_new(cont_func)
     self.ready_func = None
     self.task = task
-    self.cancellable = False
+    self.cancellable = lambda: False
     self.index = None
     self.storage = [0,0]
     assert(self.suspended())
@@ -364,7 +364,7 @@ class Thread:
     assert(self.ready())
 
   def resume(self, cancelled = Cancelled.FALSE):
-    assert(not self.running() and (self.cancellable or not cancelled))
+    assert(not self.running() and (self.cancellable() or not cancelled))
     if self.waiting():
       self.stop_waiting_internal(cancelled)
     thread = self
@@ -378,13 +378,13 @@ class Thread:
   def block_internal(self, cancellable):
     self.cancellable = cancellable
     cancelled = block(switch_to = None)
-    assert(self.running() and (cancellable or not cancelled))
+    assert(self.running() and (cancellable() or not cancelled))
     return cancelled
 
   def switch_to_internal(self, cancellable, other):
     self.cancellable = cancellable
     cancelled = block(switch_to = other)
-    assert(self.running() and (cancellable or not cancelled))
+    assert(self.running() and (cancellable() or not cancelled))
     return cancelled
 
   def suspend(self, cancellable) -> Cancelled:
@@ -393,14 +393,19 @@ class Thread:
       return Cancelled.TRUE
     return self.block_internal(cancellable)
 
-  def wait_until(self, ready_func, cancellable = False) -> Cancelled:
+  def wait_until(self, ready_func, cancellable = lambda: False) -> Cancelled:
     assert(self.running())
     if self.task.deliver_pending_cancel(cancellable):
       return Cancelled.TRUE
     if ready_func() and not DETERMINISTIC_PROFILE and random.randint(0,1):
       return Cancelled.FALSE
-    self.start_waiting_internal(ready_func)
-    return self.block_internal(cancellable)
+    def ready_or_cancelled():
+      return ready_func() or (cancellable() and self.task.has_pending_cancel())
+    self.start_waiting_internal(ready_or_cancelled)
+    cancelled = self.block_internal(cancellable)
+    if self.task.deliver_pending_cancel(cancellable):
+      return Cancelled.TRUE
+    return cancelled
 
   def yield_(self, cancellable) -> Cancelled:
     return self.wait_until(lambda: True, cancellable)
@@ -487,7 +492,8 @@ class Task:
                 (self.needs_exclusive() and self.inst.exclusive_thread is not None))
       if has_backpressure() or self.inst.num_waiting_to_enter > 0:
         self.inst.num_waiting_to_enter += 1
-        cancelled = self.implicit_thread.wait_until(lambda: not has_backpressure(), cancellable = True)
+        cancelled = self.implicit_thread.wait_until(lambda: not has_backpressure(),
+                                                    cancellable = lambda: True)
         self.inst.num_waiting_to_enter -= 1
         if cancelled:
           self.cancel()
@@ -526,9 +532,7 @@ class Task:
       self.implicit_thread.resume(Cancelled.TRUE)
     else:
       assert(self.state == Task.State.STARTED)
-      candidates = { t for t in self.threads if t.cancellable }
-      if self.needs_exclusive() and self.inst.exclusive_thread not in { None, self.implicit_thread }:
-        candidates.discard(self.implicit_thread)
+      candidates = { t for t in self.threads if t.cancellable() }
       if candidates and self.inst.may_enter_from(caller):
         self.state = Task.State.CANCEL_DELIVERED
         self.inst.enter_from(caller)
@@ -537,8 +541,11 @@ class Task:
       else:
         self.state = Task.State.PENDING_CANCEL
 
+  def has_pending_cancel(self):
+    return self.state == Task.State.PENDING_CANCEL
+
   def deliver_pending_cancel(self, cancellable) -> bool:
-    if cancellable and self.state == Task.State.PENDING_CANCEL:
+    if cancellable() and self.has_pending_cancel():
       self.state = Task.State.CANCEL_DELIVERED
       return True
     return False
@@ -790,7 +797,7 @@ class Waitable:
   def wait_for_pending_event(self):
     assert(not self.in_waitable_set() and not self.has_sync_waiter)
     self.has_sync_waiter = True
-    current_thread().wait_until(self.has_pending_event, cancellable = False)
+    current_thread().wait_until(self.has_pending_event, cancellable = lambda: False)
     self.has_sync_waiter = False
 
   def get_pending_event(self) -> EventTuple:
@@ -2190,9 +2197,11 @@ def canon_lift(callee, ft, opts, inst, on_start, on_resolve) -> OnCancel:
     while code != CallbackCode.EXIT:
       assert(task.needs_exclusive() and inst.exclusive_thread is task.implicit_thread)
       inst.exclusive_thread = None
+      def lock_available():
+        return inst.exclusive_thread is None
       match code:
         case CallbackCode.YIELD:
-          cancelled = thread.wait_until(lambda: not inst.exclusive_thread, cancellable = True)
+          cancelled = thread.wait_until(lock_available, cancellable = lock_available)
           if cancelled:
             event = (EventCode.TASK_CANCELLED, 0, 0)
           else:
@@ -2200,7 +2209,7 @@ def canon_lift(callee, ft, opts, inst, on_start, on_resolve) -> OnCancel:
         case CallbackCode.WAIT:
           wset = inst.handles.get(si)
           trap_if(not isinstance(wset, WaitableSet))
-          event = wset.wait_for_event_and(lambda: not inst.exclusive_thread, cancellable = True)
+          event = wset.wait_for_event_and(lock_available, cancellable = lock_available)
         case _:
           trap()
       assert(inst.exclusive_thread is None)
@@ -2420,7 +2429,7 @@ def canon_waitable_set_wait(cancellable, mem, si, ptr):
   trap_if(not inst.may_leave)
   wset = inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
-  event = wset.wait_for_event(cancellable)
+  event = wset.wait_for_event(lambda: cancellable)
   return unpack_event(mem, inst, ptr, event)
 
 def unpack_event(mem, inst, ptr, e: EventTuple):
@@ -2437,7 +2446,7 @@ def canon_waitable_set_poll(cancellable, mem, si, ptr):
   trap_if(not inst.may_leave)
   wset = inst.handles.get(si)
   trap_if(not isinstance(wset, WaitableSet))
-  event = wset.poll(cancellable)
+  event = wset.poll(lambda: cancellable)
   return unpack_event(mem, inst, ptr, event)
 
 ### 🔀 `canon waitable-set.drop`
@@ -2724,7 +2733,7 @@ def canon_thread_resume_later(i):
 def canon_thread_suspend(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  cancelled = thread.suspend(cancellable)
+  cancelled = thread.suspend(lambda: cancellable)
   return [cancelled]
 
 ### 🧵 `canon thread.yield`
@@ -2732,7 +2741,7 @@ def canon_thread_suspend(cancellable):
 def canon_thread_yield(cancellable):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
-  cancelled = thread.yield_(cancellable)
+  cancelled = thread.yield_(lambda: cancellable)
   return [cancelled]
 
 ### 🧵 `canon thread.suspend-then-resume`
@@ -2742,7 +2751,7 @@ def canon_thread_suspend_then_resume(cancellable, i):
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.suspend_then_resume(cancellable, other_thread)
+  cancelled = thread.suspend_then_resume(lambda: cancellable, other_thread)
   return [cancelled]
 
 ### 🧵 `canon thread.yield-then-resume`
@@ -2752,7 +2761,7 @@ def canon_thread_yield_then_resume(cancellable, i):
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
   trap_if(not other_thread.suspended())
-  cancelled = thread.yield_then_resume(cancellable, other_thread)
+  cancelled = thread.yield_then_resume(lambda: cancellable, other_thread)
   return [cancelled]
 
 ### 🧵 `canon thread.suspend-then-promote`
@@ -2761,7 +2770,7 @@ def canon_thread_suspend_then_promote(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
-  cancelled = thread.suspend_then_promote(cancellable, other_thread)
+  cancelled = thread.suspend_then_promote(lambda: cancellable, other_thread)
   return [cancelled]
 
 ### 🧵 `canon thread.yield-then-promote`
@@ -2770,7 +2779,7 @@ def canon_thread_yield_then_promote(cancellable, i):
   thread = current_thread()
   trap_if(not thread.task.inst.may_leave)
   other_thread = thread.task.inst.threads.get(i)
-  cancelled = thread.yield_then_promote(cancellable, other_thread)
+  cancelled = thread.yield_then_promote(lambda: cancellable, other_thread)
   return [cancelled]
 
 ### 📝 `canon error-context.new`

--- a/design/mvp/canonical-abi/run_tests.py
+++ b/design/mvp/canonical-abi/run_tests.py
@@ -61,7 +61,7 @@ def lift_and_run(opts, inst, ft, callee, on_start, on_resolve):
 def mk_host_func(store, host_func, ft):
   def func_inst(on_start, on_resume, caller) -> OnCancel:
     def thread_func():
-      wait_until = lambda rf: host_thread.wait_until(rf, cancellable = True)
+      wait_until = lambda rf: host_thread.wait_until(rf, cancellable = lambda: True)
       host_func(caller, on_start, on_resume, wait_until)
     inst = ComponentInstance(store)
     task = Task(ft, CanonicalOptions(), inst, on_start, on_resume)
@@ -2961,7 +2961,7 @@ def test_thread_cancel_callback():
     return [CallbackCode.YIELD]
   def core_producer_callback1(args):
     [event,payload1,payload2] = args
-    assert(event == EventCode.NONE and payload1 == 0 and payload2 == 0)
+    assert(event == EventCode.TASK_CANCELLED and payload1 == 0 and payload2 == 0)
     [] = canon_task_return([U32Type()], producer_opts1, [42])
     return [CallbackCode.EXIT]
   producer_opts1.callback = core_producer_callback1

--- a/test/async/cancel-and-exclusive-lock.wast
+++ b/test/async/cancel-and-exclusive-lock.wast
@@ -1,0 +1,196 @@
+;; This test exercises how a component instance's "exclusive" lock interacts
+;; with the delivery of cancellation requests.
+;;
+;; A `callback`-lifted task waiting in its event loop is only cancellable while
+;; the exclusive lock is free, since delivering cancellation resumes the task,
+;; which re-enters core wasm. Cancellation requested while the lock is held by
+;; another task therefore cannot be delivered immediately and is remembered as
+;; pending. It must then be delivered as soon as the lock frees, even if the
+;; waiting task's own readiness condition is never met.
+(component
+  (component $C
+    (core module $Memory (memory (export "mem") 1))
+    (core instance $memory (instantiate $Memory))
+    (core module $CM
+      (import "" "mem" (memory 1))
+      (import "" "task.return" (func $task.return (param i32)))
+      (import "" "task.cancel" (func $task.cancel))
+      (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
+
+      ;; Parks in the event loop by returning WAIT on an empty waitable set.
+      ;; No event can ever arrive on that set, so the only thing that can wake
+      ;; this task is the pending cancellation request itself.
+      (func (export "park") (result i32)
+        (i32.or (i32.const 2 (; WAIT ;))
+                (i32.shl (call $waitable-set.new) (i32.const 4)))
+      )
+      (func (export "park-cb") (param i32 i32 i32) (result i32)
+        (if (i32.ne (i32.const 6 (; TASK_CANCELLED ;)) (local.get 0))
+          (then unreachable))
+        (call $task.cancel)
+        (i32.const 0 (; EXIT ;))
+      )
+
+      ;; Blocks inside its *initial core function*, which means it holds the
+      ;; instance's exclusive lock for as long as it is blocked. It blocks on a
+      ;; future the caller hasn't written yet, so that it blocks deterministically
+      ;; (a bare thread.yield may complete without ever blocking).
+      (func (export "hold-lock") (param $futr i32) (result i32)
+        (local $ws i32)
+        (if (i32.ne (i32.const -1 (; BLOCKED ;))
+                    (call $future.read (local.get $futr) (i32.const 0)))
+          (then unreachable))
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $futr) (local.get $ws))
+        (if (i32.ne (i32.const 4 (; FUTURE_READ ;))
+                    (call $waitable-set.wait (local.get $ws) (i32.const 0)))
+          (then unreachable))
+        (call $task.return (i32.const 43))
+        (i32.const 0 (; EXIT ;))
+      )
+
+      (func (export "unreachable-cb") (param i32 i32 i32) (result i32)
+        unreachable
+      )
+    )
+    (type $FT (future))
+    (canon task.return (result u32) (core func $task.return))
+    (canon task.cancel (core func $task.cancel))
+    (canon future.read $FT async (memory (core memory $memory "mem")) (core func $future.read))
+    (canon waitable.join (core func $waitable.join))
+    (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory (core memory $memory "mem")) (core func $waitable-set.wait))
+    (core instance $cm (instantiate $CM (with "" (instance
+      (export "mem" (memory $memory "mem"))
+      (export "task.return" (func $task.return))
+      (export "task.cancel" (func $task.cancel))
+      (export "future.read" (func $future.read))
+      (export "waitable.join" (func $waitable.join))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
+    ))))
+    (func (export "park") async (result u32) (canon lift
+      (core func $cm "park")
+      async (callback (core func $cm "park-cb"))
+    ))
+    (func (export "hold-lock") async (param "fut" $FT) (result u32) (canon lift
+      (core func $cm "hold-lock")
+      async (callback (core func $cm "unreachable-cb"))
+    ))
+  )
+
+  (component $D
+    (type $FT (future))
+    (import "park" (func $park async (result u32)))
+    (import "hold-lock" (func $hold-lock async (param "fut" $FT) (result u32)))
+
+    (core module $Memory (memory (export "mem") 1))
+    (core instance $memory (instantiate $Memory))
+    (core module $DM
+      (import "" "mem" (memory 1))
+      (import "" "subtask.cancel" (func $subtask.cancel (param i32) (result i32)))
+      (import "" "subtask.drop" (func $subtask.drop (param i32)))
+      (import "" "future.new" (func $future.new (result i64)))
+      (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
+      (import "" "park" (func $park (param i32) (result i32)))
+      (import "" "hold-lock" (func $hold-lock (param i32 i32) (result i32)))
+
+      (func $run (export "run") (result i32)
+        (local $ret i32) (local $ret64 i64)
+        (local $sub-park i32) (local $sub-hold i32)
+        (local $futr i32) (local $futw i32) (local $ws i32)
+
+        ;; start the task that parks in its event loop; returning WAIT releases
+        ;; the exclusive lock, so at this point the lock is free
+        (local.set $ret (call $park (i32.const 0)))
+        (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
+          (then unreachable))
+        (local.set $sub-park (i32.shr_u (local.get $ret) (i32.const 4)))
+
+        ;; start the task that takes the exclusive lock and blocks while holding it
+        (local.set $ret64 (call $future.new))
+        (local.set $futr (i32.wrap_i64 (local.get $ret64)))
+        (local.set $futw (i32.wrap_i64 (i64.shr_u (local.get $ret64) (i64.const 32))))
+        (local.set $ret (call $hold-lock (local.get $futr) (i32.const 4)))
+        (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
+          (then unreachable))
+        (local.set $sub-hold (i32.shr_u (local.get $ret) (i32.const 4)))
+
+        ;; cancellation of the parked task can't be delivered while the lock is
+        ;; held by the other task, so the request is remembered as pending
+        (local.set $ret (call $subtask.cancel (local.get $sub-park)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; release the lock holder; the parked task must now be woken and
+        ;; receive the pending cancellation, even though the waitable set it is
+        ;; waiting on is still empty
+        (if (i32.ne (i32.const 0 (; COMPLETED ;))
+                    (call $future.write (local.get $futw) (i32.const 0)))
+          (then unreachable))
+
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $sub-park) (local.get $ws))
+        (if (i32.ne (i32.const 1 (; SUBTASK ;))
+                    (call $waitable-set.wait (local.get $ws) (i32.const 8)))
+          (then unreachable))
+        (if (i32.ne (local.get $sub-park) (i32.load (i32.const 8)))
+          (then unreachable))
+        (if (i32.ne (i32.const 4 (; CANCELLED_BEFORE_RETURNED ;)) (i32.load offset=4 (i32.const 8)))
+          (then unreachable))
+        (call $subtask.drop (local.get $sub-park))
+
+        ;; the lock holder itself returned normally
+        (call $waitable.join (local.get $sub-hold) (local.get $ws))
+        (if (i32.ne (i32.const 1 (; SUBTASK ;))
+                    (call $waitable-set.wait (local.get $ws) (i32.const 8)))
+          (then unreachable))
+        (if (i32.ne (local.get $sub-hold) (i32.load (i32.const 8)))
+          (then unreachable))
+        (if (i32.ne (i32.const 2 (; RETURNED ;)) (i32.load offset=4 (i32.const 8)))
+          (then unreachable))
+        (if (i32.ne (i32.const 43) (i32.load (i32.const 4)))
+          (then unreachable))
+        (call $subtask.drop (local.get $sub-hold))
+
+        (i32.const 42)
+      )
+    )
+    (canon subtask.cancel async (core func $subtask.cancel))
+    (canon subtask.drop (core func $subtask.drop))
+    (canon future.new $FT (core func $future.new))
+    (canon future.write $FT async (memory (core memory $memory "mem")) (core func $future.write))
+    (canon waitable.join (core func $waitable.join))
+    (canon waitable-set.new (core func $waitable-set.new))
+    (canon waitable-set.wait (memory (core memory $memory "mem")) (core func $waitable-set.wait))
+    (canon lower (func $park) async (memory (core memory $memory "mem")) (core func $park'))
+    (canon lower (func $hold-lock) async (memory (core memory $memory "mem")) (core func $hold-lock'))
+    (core instance $dm (instantiate $DM (with "" (instance
+      (export "mem" (memory $memory "mem"))
+      (export "subtask.cancel" (func $subtask.cancel))
+      (export "subtask.drop" (func $subtask.drop))
+      (export "future.new" (func $future.new))
+      (export "future.write" (func $future.write))
+      (export "waitable.join" (func $waitable.join))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.wait" (func $waitable-set.wait))
+      (export "park" (func $park'))
+      (export "hold-lock" (func $hold-lock'))
+    ))))
+    (func (export "run") async (result u32) (canon lift (core func $dm "run")))
+  )
+
+  (instance $c (instantiate $C))
+  (instance $d (instantiate $D
+    (with "park" (func $c "park"))
+    (with "hold-lock" (func $c "hold-lock"))
+  ))
+  (func (export "run") (alias export $d "run"))
+)
+(assert_return (invoke "run") (u32.const 42))

--- a/test/async/cancellable.wast
+++ b/test/async/cancellable.wast
@@ -7,6 +7,9 @@
 ;;   yield-cancel: yields with cancellable until the caller cancels
 ;;   poll-cancel-pending: blocks on non-cancellable wait, then polls with cancellable
 ;;   yield-cancel-pending: blocks on non-cancellable wait, then yields with cancellable
+;;   pending-survives-nc-yield: blocks on non-cancellable wait, then a
+;;     non-cancellable yield (which must not report the pending cancel), then
+;;     yields with cancellable
 ;;
 ;; Component $D calls each function and cancels it, verifying the cancel is
 ;; delivered correctly through the cancellable built-in in each case.
@@ -24,6 +27,7 @@
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
       (import "" "waitable-set.poll-cancellable" (func $waitable-set.poll-cancellable (param i32 i32) (result i32)))
       (import "" "thread.yield-cancellable" (func $thread.yield-cancellable (result i32)))
+      (import "" "thread.yield" (func $thread.yield (result i32)))
 
       ;; Test 1: direct cancel delivery through cancellable waitable-set.wait
       (func $wait-cancel (export "wait-cancel") (result i32)
@@ -95,6 +99,36 @@
         (i32.const 0 (; EXIT ;))
       )
 
+      ;; Test 5: a pending cancellation is not delivered to a *non*-cancellable
+      ;; blocking built-in, and survives it to be delivered at the next
+      ;; cancellable one
+      (func $pending-survives-nc-yield (export "pending-survives-nc-yield") (param $futr i32) (result i32)
+        (local $ws i32)
+        (local $ret i32)
+        (local $event_code i32)
+        (local.set $ws (call $waitable-set.new))
+        ;; read future - blocks (caller hasn't written yet)
+        (local.set $ret (call $future.read (local.get $futr) (i32.const 0)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+        (call $waitable.join (local.get $futr) (local.get $ws))
+        ;; wait WITHOUT cancellable - cancel will be deferred as PENDING_CANCEL
+        (local.set $event_code (call $waitable-set.wait (local.get $ws) (i32.const 0)))
+        (if (i32.ne (i32.const 4 (; FUTURE_READ ;)) (local.get $event_code))
+          (then unreachable))
+        ;; yield WITHOUT cancellable - must not report the pending cancel, and
+        ;; must leave it pending
+        (local.set $ret (call $thread.yield))
+        (if (i32.ne (i32.const 0 (; NOT CANCELLED ;)) (local.get $ret))
+          (then unreachable))
+        ;; yield WITH cancellable - delivers the still-pending cancel
+        (local.set $ret (call $thread.yield-cancellable))
+        (if (i32.ne (i32.const 1 (; CANCELLED ;)) (local.get $ret))
+          (then unreachable))
+        (call $task.cancel)
+        (i32.const 0 (; EXIT ;))
+      )
+
       ;; callback that should never be called
       (func (export "unreachable-cb") (param i32 i32 i32) (result i32)
         unreachable
@@ -109,6 +143,7 @@
     (canon waitable-set.wait (memory (core memory $memory "mem")) (core func $waitable-set.wait))
     (canon waitable-set.poll cancellable (memory (core memory $memory "mem")) (core func $waitable-set.poll-cancellable))
     (canon thread.yield cancellable (core func $thread.yield-cancellable))
+    (canon thread.yield (core func $thread.yield))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.cancel" (func $task.cancel))
@@ -119,6 +154,7 @@
       (export "waitable-set.wait" (func $waitable-set.wait))
       (export "waitable-set.poll-cancellable" (func $waitable-set.poll-cancellable))
       (export "thread.yield-cancellable" (func $thread.yield-cancellable))
+      (export "thread.yield" (func $thread.yield))
     ))))
     (func (export "wait-cancel") async (result u32) (canon lift
       (core func $cm "wait-cancel")
@@ -136,6 +172,10 @@
       (core func $cm "yield-cancel-pending")
       async (callback (core func $cm "unreachable-cb"))
     ))
+    (func (export "pending-survives-nc-yield") async (param "fut" $FT) (result u32) (canon lift
+      (core func $cm "pending-survives-nc-yield")
+      async (callback (core func $cm "unreachable-cb"))
+    ))
   )
 
   (component $D
@@ -144,6 +184,7 @@
     (import "yield-cancel" (func $yield-cancel async (result u32)))
     (import "poll-cancel-pending" (func $poll-cancel-pending async (param "fut" $FT) (result u32)))
     (import "yield-cancel-pending" (func $yield-cancel-pending async (param "fut" $FT) (result u32)))
+    (import "pending-survives-nc-yield" (func $pending-survives-nc-yield async (param "fut" $FT) (result u32)))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))
@@ -160,6 +201,7 @@
       (import "" "yield-cancel" (func $yield-cancel (param i32) (result i32)))
       (import "" "poll-cancel-pending" (func $poll-cancel-pending (param i32 i32) (result i32)))
       (import "" "yield-cancel-pending" (func $yield-cancel-pending (param i32 i32) (result i32)))
+      (import "" "pending-survives-nc-yield" (func $pending-survives-nc-yield (param i32 i32) (result i32)))
 
       (func $run (export "run") (result i32)
         (local $ret i32) (local $ret64 i64)
@@ -278,6 +320,43 @@
           (then unreachable))
         (call $subtask.drop (local.get $subtask))
 
+        ;; ==========================================
+        ;; Test 5: pending cancel survives a non-cancellable yield
+        ;; ==========================================
+
+        ;; create future for pending-survives-nc-yield to read
+        (local.set $ret64 (call $future.new))
+        (local.set $futr (i32.wrap_i64 (local.get $ret64)))
+        (local.set $futw (i32.wrap_i64 (i64.shr_u (local.get $ret64) (i64.const 32))))
+
+        ;; call pending-survives-nc-yield; it should block in non-cancellable wait
+        (local.set $ret (call $pending-survives-nc-yield (local.get $futr) (local.get $retp)))
+        (if (i32.ne (i32.const 1 (; STARTED ;)) (i32.and (local.get $ret) (i32.const 0xf)))
+          (then unreachable))
+        (local.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))
+
+        ;; cancel; blocks because C's wait is not cancellable
+        (local.set $ret (call $subtask.cancel (local.get $subtask)))
+        (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; write to future; unblocks C's non-cancellable wait
+        (local.set $ret (call $future.write (local.get $futw) (i32.const 0)))
+        (if (i32.ne (i32.const 0 (; COMPLETED ;)) (local.get $ret))
+          (then unreachable))
+
+        ;; wait for subtask to complete
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $subtask) (local.get $ws))
+        (local.set $event_code (call $waitable-set.wait (local.get $ws) (local.get $retp2)))
+        (if (i32.ne (i32.const 1 (; SUBTASK ;)) (local.get $event_code))
+          (then unreachable))
+        (if (i32.ne (local.get $subtask) (i32.load (local.get $retp2)))
+          (then unreachable))
+        (if (i32.ne (i32.const 4 (; CANCELLED_BEFORE_RETURNED ;)) (i32.load offset=4 (local.get $retp2)))
+          (then unreachable))
+        (call $subtask.drop (local.get $subtask))
+
         ;; all tests passed
         (i32.const 42)
       )
@@ -293,6 +372,7 @@
     (canon lower (func $yield-cancel) async (memory (core memory $memory "mem")) (core func $yield-cancel'))
     (canon lower (func $poll-cancel-pending) async (memory (core memory $memory "mem")) (core func $poll-cancel-pending'))
     (canon lower (func $yield-cancel-pending) async (memory (core memory $memory "mem")) (core func $yield-cancel-pending'))
+    (canon lower (func $pending-survives-nc-yield) async (memory (core memory $memory "mem")) (core func $pending-survives-nc-yield'))
     (core instance $dm (instantiate $DM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "subtask.cancel" (func $subtask.cancel))
@@ -306,6 +386,7 @@
       (export "yield-cancel" (func $yield-cancel'))
       (export "poll-cancel-pending" (func $poll-cancel-pending'))
       (export "yield-cancel-pending" (func $yield-cancel-pending'))
+      (export "pending-survives-nc-yield" (func $pending-survives-nc-yield'))
     ))))
     (func (export "run") async (result u32) (canon lift (core func $dm "run")))
   )
@@ -316,6 +397,7 @@
     (with "yield-cancel" (func $c "yield-cancel"))
     (with "poll-cancel-pending" (func $c "poll-cancel-pending"))
     (with "yield-cancel-pending" (func $c "yield-cancel-pending"))
+    (with "pending-survives-nc-yield" (func $c "pending-survives-nc-yield"))
   ))
   (func (export "run") (alias export $d "run"))
 )


### PR DESCRIPTION
This PR adds some cancellation WAST tests (that currently pass on Wasmtime).  This actually exercises a corner case of the spec that the spec Python definition gets wrong, so this PR fixes that too.  In particular, if a `callback` task is waiting by returning the `WAIT` code, and a cancellation is requested, but the callback can't run eagerly (b/c some other async task is on the stack), and a pending cancellation request is set on the task, the `WAIT`-ing `callback` task should resume as soon as the other thread gets off the stack; before this PR the `WAIT`ing task would just keep waiting (maybe forever).