### PR TITLE
Allow trailing comma in `use-names-list`

### DIFF
--- a/design/mvp/WIT.md
+++ b/design/mvp/WIT.md
@@ -1613,8 +1613,6 @@ use-names-item ::= id
                  | id 'as' id
 ```
 
-Note: Here `use-names-list?` means at least one `use-name-list` term.
-
 ## Items: type
 
 There are a number of methods of defining types in a `wit` package, and all of


### PR DESCRIPTION
Fixes #713

Allow trailing comma in use-names-list to be consistent with other constructs (e.g. `include-names-list`, `record-fields`)

```wit
use types.{
  foo,
  bar as baz,
  quux,
};
```

This was an easy-to-miss sidenote, and was essentially an exception to the grammar as written. If trailing commas are meant to be explicitly forbidden, it could more easily be written as one of the following:

```ebnf
use-names-list ::= use-names-item
                 | use-names-item ',' use-names-list

use-names-list ::= use-names-item (',' use-names-item)*
```

Related: #586